### PR TITLE
feat: add auth cookie paste fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `auth paste`, wire `--no-input`, and improve cookie diagnostics/cleanup (`#5`, thanks @im-zayan)
 - Add `play --shuffle`, Connect library/playlist support, and context-aware Connect play payloads (`#15`, thanks @StandardGage)
 - Fix Connect track artist extraction for nested artist containers and minimal artist fragments (`#7`, thanks @joelbdavies)
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Env overrides:
 
 Commands:
 
-- `auth status|import|clear`
+- `auth status|import|paste|clear`
 - `search track|album|artist|playlist|show|episode`
 - `track info`, `album info`, `artist info`, `playlist info`, `show info`, `episode info`
 - `play [<id|url>] [--type ...] [--shuffle]`, `pause`, `next`, `prev`, `seek`, `volume`, `shuffle`, `repeat`, `status`
@@ -97,6 +97,24 @@ spogo auth import --browser chrome
 ```
 
 Defaults: Chrome + Default profile. Cookies are stored under your config directory (per profile).
+
+### Manual cookie paste (WSL fallback)
+
+If WSL cookie import/decryption is broken, paste cookies from Chrome DevTools:
+
+1) Developer Tools -> Application tab -> Cookies -> `https://open.spotify.com`
+2) Copy `sp_dc` (required), `sp_key` (optional), `sp_t` (recommended for connect playback)
+3) Run:
+
+```bash
+spogo auth paste
+```
+
+Non-interactive:
+
+```bash
+printf '%s\n%s\n' "sp_dc=..." "sp_t=..." | spogo auth paste --no-input
+```
 
 ## Auto engine notes
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -42,6 +42,11 @@ spogo [global flags] <command> [args]
   - `--browser-profile <name>`
   - `--cookie-path <file>`
   - `--domain <host>` default `spotify.com`
+- `spogo auth paste`
+  - reads cookie values from stdin (prompts when interactive)
+  - `--cookie-path <file>`
+  - `--domain <suffix>` default `spotify.com`
+  - `--path <path>` default `/`
 - `spogo auth clear`
 
 ### search

--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -28,6 +28,7 @@ type Settings struct {
 	Quiet      bool
 	Verbose    bool
 	Debug      bool
+	NoInput    bool
 }
 
 type Context struct {

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -1,11 +1,17 @@
 package cli
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
+	"os"
 	"os/exec"
 	"strings"
 
+	"github.com/mattn/go-isatty"
 	"github.com/steipete/spogo/internal/app"
 	"github.com/steipete/spogo/internal/cookies"
 	"github.com/steipete/spogo/internal/output"
@@ -14,6 +20,7 @@ import (
 type AuthCmd struct {
 	Status AuthStatusCmd `kong:"cmd,help='Show cookie status.'"`
 	Import AuthImportCmd `kong:"cmd,help='Import browser cookies.'"`
+	Paste  AuthPasteCmd  `kong:"cmd,help='Paste cookie values from the browser.'"`
 	Clear  AuthClearCmd  `kong:"cmd,help='Clear stored cookies.'"`
 }
 
@@ -26,11 +33,19 @@ type AuthImportCmd struct {
 	Domain     string `help:"Cookie domain suffix." default:"spotify.com"`
 }
 
+type AuthPasteCmd struct {
+	CookiePath string `help:"Cookie cache file path."`
+	Domain     string `help:"Cookie domain suffix." default:"spotify.com"`
+	Path       string `help:"Cookie path." default:"/"`
+}
+
 type AuthClearCmd struct{}
 
 type authStatusPayload struct {
 	CookieCount int    `json:"cookie_count"`
 	HasSPDC     bool   `json:"has_sp_dc"`
+	HasSPT      bool   `json:"has_sp_t"`
+	HasSPKey    bool   `json:"has_sp_key"`
 	Source      string `json:"source"`
 }
 
@@ -40,23 +55,39 @@ func (cmd *AuthStatusCmd) Run(ctx *app.Context) error {
 		return err
 	}
 	hasSPDC := false
+	hasSPT := false
+	hasSPKey := false
 	for _, cookie := range cookiesList {
-		if cookie.Name == "sp_dc" {
+		switch cookie.Name {
+		case "sp_dc":
 			hasSPDC = true
-			break
+		case "sp_t":
+			hasSPT = true
+		case "sp_key":
+			hasSPKey = true
 		}
 	}
 	payload := authStatusPayload{
 		CookieCount: len(cookiesList),
 		HasSPDC:     hasSPDC,
+		HasSPT:      hasSPT,
+		HasSPKey:    hasSPKey,
 		Source:      sourceLabel,
 	}
-	plain := []string{fmt.Sprintf("%d\t%t\t%s", payload.CookieCount, payload.HasSPDC, payload.Source)}
+	plain := []string{fmt.Sprintf("%d\t%t\t%t\t%t\t%s", payload.CookieCount, payload.HasSPDC, payload.HasSPT, payload.HasSPKey, payload.Source)}
 	human := []string{fmt.Sprintf("Cookies: %d (%s)", payload.CookieCount, payload.Source)}
 	if hasSPDC {
 		human = append(human, "Session cookie: sp_dc")
 	} else {
 		human = append(human, "Session cookie: missing sp_dc")
+	}
+	if hasSPT {
+		human = append(human, "Device cookie: sp_t")
+	} else {
+		human = append(human, "Device cookie: missing sp_t (needed for connect playback)")
+	}
+	if hasSPKey {
+		human = append(human, "Optional cookie: sp_key")
 	}
 	return ctx.Output.Emit(payload, plain, human)
 }
@@ -113,12 +144,92 @@ func (cmd *AuthImportCmd) Run(ctx *app.Context) error {
 	return ctx.Output.Emit(payload, plain, human)
 }
 
+func (cmd *AuthPasteCmd) Run(ctx *app.Context) error {
+	stdinIsTTY := isatty.IsTerminal(os.Stdin.Fd())
+	if ctx.Settings.NoInput && stdinIsTTY {
+		return errors.New("--no-input set; pipe cookie values via stdin")
+	}
+	values, err := readPastedCookies(os.Stdin, ctx.Output, stdinIsTTY && !ctx.Settings.NoInput)
+	if err != nil {
+		return err
+	}
+	if values.spdc == "" {
+		return errors.New("sp_dc required")
+	}
+
+	domain := normalizeCookieDomain(cmd.Domain)
+	path := normalizeCookiePath(cmd.Path)
+
+	cookiesList := []*http.Cookie{{
+		Name:     "sp_dc",
+		Value:    values.spdc,
+		Domain:   domain,
+		Path:     path,
+		Secure:   true,
+		HttpOnly: true,
+	}}
+	if values.spkey != "" {
+		cookiesList = append(cookiesList, &http.Cookie{
+			Name:     "sp_key",
+			Value:    values.spkey,
+			Domain:   domain,
+			Path:     path,
+			Secure:   true,
+			HttpOnly: true,
+		})
+	}
+	if values.spt != "" {
+		cookiesList = append(cookiesList, &http.Cookie{
+			Name:     "sp_t",
+			Value:    values.spt,
+			Domain:   domain,
+			Path:     path,
+			Secure:   true,
+			HttpOnly: true,
+		})
+	} else if strings.EqualFold(strings.TrimSpace(ctx.Profile.Engine), "") || strings.EqualFold(strings.TrimSpace(ctx.Profile.Engine), "connect") || strings.EqualFold(strings.TrimSpace(ctx.Profile.Engine), "auto") {
+		_, _ = fmt.Fprintln(ctx.Output.Err, "warning: missing sp_t; playback may fail (grab sp_t from DevTools)")
+	}
+
+	pathOut := cmd.CookiePath
+	if pathOut == "" {
+		pathOut = ctx.ResolveCookiePath()
+	}
+	if err := cookies.Write(pathOut, cookiesList); err != nil {
+		return err
+	}
+	profileCfg := ctx.Profile
+	profileCfg.CookiePath = pathOut
+	if err := ctx.SaveProfile(profileCfg); err != nil {
+		return err
+	}
+	human := []string{fmt.Sprintf("Saved %d cookies to %s", len(cookiesList), pathOut)}
+	plain := []string{fmt.Sprintf("%d\t%s", len(cookiesList), pathOut)}
+	payload := map[string]any{
+		"cookie_count": len(cookiesList),
+		"path":         pathOut,
+	}
+	return ctx.Output.Emit(payload, plain, human)
+}
+
 func (cmd *AuthClearCmd) Run(ctx *app.Context) error {
-	path := ctx.ResolveCookiePath()
+	path := strings.TrimSpace(ctx.Profile.CookiePath)
+	if path == "" {
+		path = ctx.ResolveCookiePath()
+	}
 	if path == "" {
 		return fmt.Errorf("no cookie path configured")
 	}
-	if err := trashFile(path); err != nil {
+	if _, err := os.Stat(path); err == nil {
+		if err := trashFile(path); err != nil {
+			return err
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	profileCfg := ctx.Profile
+	profileCfg.CookiePath = ""
+	if err := ctx.SaveProfile(profileCfg); err != nil {
 		return err
 	}
 	plain := []string{"ok"}
@@ -147,6 +258,135 @@ func readCookies(ctx *app.Context) ([]*http.Cookie, string, error) {
 		return nil, "", err
 	}
 	return browserCookies, "browser", nil
+}
+
+type pastedCookies struct {
+	spdc  string
+	spkey string
+	spt   string
+}
+
+func readPastedCookies(r io.Reader, out *output.Writer, interactive bool) (pastedCookies, error) {
+	if interactive {
+		return promptPastedCookies(out)
+	}
+	return parsePastedCookies(r)
+}
+
+func promptPastedCookies(out *output.Writer) (pastedCookies, error) {
+	reader := bufio.NewReader(os.Stdin)
+	spdc, err := readPromptCookieValue(reader, out, "sp_dc", true)
+	if err != nil {
+		return pastedCookies{}, err
+	}
+	spkey, err := readPromptCookieValue(reader, out, "sp_key", false)
+	if err != nil {
+		return pastedCookies{}, err
+	}
+	spt, err := readPromptCookieValue(reader, out, "sp_t", false)
+	if err != nil {
+		return pastedCookies{}, err
+	}
+	return pastedCookies{spdc: spdc, spkey: spkey, spt: spt}, nil
+}
+
+func readPromptCookieValue(reader *bufio.Reader, out *output.Writer, name string, required bool) (string, error) {
+	if reader == nil {
+		reader = bufio.NewReader(os.Stdin)
+	}
+	if out != nil {
+		_, _ = fmt.Fprintf(out.Err, "Paste %s value: ", name)
+	}
+	line, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", err
+	}
+	value := normalizePromptCookieValue(line, name)
+	if value == "" && required {
+		return "", fmt.Errorf("%s required", name)
+	}
+	return value, nil
+}
+
+func parsePastedCookies(r io.Reader) (pastedCookies, error) {
+	if r == nil {
+		r = os.Stdin
+	}
+	scanner := bufio.NewScanner(r)
+	values := pastedCookies{}
+	for scanner.Scan() {
+		line := scanner.Text()
+		if value, ok := extractNamedCookieValue(line, "sp_dc"); ok {
+			values.spdc = value
+		}
+		if value, ok := extractNamedCookieValue(line, "sp_key"); ok {
+			values.spkey = value
+		}
+		if value, ok := extractNamedCookieValue(line, "sp_t"); ok {
+			values.spt = value
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return pastedCookies{}, err
+	}
+	return values, nil
+}
+
+func normalizeCookieDomain(domain string) string {
+	trimmed := strings.TrimSpace(domain)
+	if trimmed == "" {
+		trimmed = "spotify.com"
+	}
+	if strings.Contains(trimmed, "://") {
+		if parsed, err := url.Parse(trimmed); err == nil && parsed.Hostname() != "" {
+			trimmed = parsed.Hostname()
+		}
+	}
+	if !strings.HasPrefix(trimmed, ".") {
+		trimmed = "." + trimmed
+	}
+	return trimmed
+}
+
+func normalizeCookiePath(path string) string {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "/"
+	}
+	return trimmed
+}
+
+func normalizePromptCookieValue(value, name string) string {
+	if parsed, ok := extractNamedCookieValue(value, name); ok {
+		return parsed
+	}
+	return trimCookieValue(value)
+}
+
+func extractNamedCookieValue(value, name string) (string, bool) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", false
+	}
+	trimmed = strings.Trim(trimmed, "\"'")
+	for _, part := range strings.Split(trimmed, ";") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key, val, found := strings.Cut(part, "=")
+		if !found {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(key), name) {
+			return trimCookieValue(val), true
+		}
+	}
+	return "", false
+}
+
+func trimCookieValue(value string) string {
+	return strings.Trim(strings.TrimSpace(value), "\"'")
 }
 
 func trashFile(path string) error {

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -1,10 +1,12 @@
 package cli
 
 import (
+	"bufio"
 	"context"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/steipete/spogo/internal/config"
@@ -13,6 +15,25 @@ import (
 	"github.com/steipete/spogo/internal/testutil"
 	"github.com/steipete/sweetcookie"
 )
+
+func withStdin(t *testing.T, contents string, fn func()) {
+	t.Helper()
+	old := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if _, err := w.WriteString(contents); err != nil {
+		_ = r.Close()
+		_ = w.Close()
+		t.Fatalf("write: %v", err)
+	}
+	_ = w.Close()
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = old })
+	fn()
+	_ = r.Close()
+}
 
 func TestAuthStatusCmd(t *testing.T) {
 	ctx, out, _ := testutil.NewTestContext(t, output.FormatPlain)
@@ -98,6 +119,157 @@ func TestAuthImportCmdDefaultPath(t *testing.T) {
 	}
 }
 
+func TestNormalizeCookieDomain(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ".spotify.com"},
+		{"spotify.com", ".spotify.com"},
+		{".spotify.com", ".spotify.com"},
+		{"https://open.spotify.com/", ".open.spotify.com"},
+	}
+	for _, tc := range cases {
+		if got := normalizeCookieDomain(tc.in); got != tc.want {
+			t.Fatalf("normalizeCookieDomain(%q)=%q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeCookieValue(t *testing.T) {
+	if got, ok := extractNamedCookieValue("sp_dc=token; Path=/; Secure", "sp_dc"); !ok || got != "token" {
+		t.Fatalf("expected token, got %q", got)
+	}
+	if got := normalizePromptCookieValue("\"token\"", "sp_dc"); got != "token" {
+		t.Fatalf("expected token, got %q", got)
+	}
+	if got := normalizePromptCookieValue("token", "sp_dc"); got != "token" {
+		t.Fatalf("expected token, got %q", got)
+	}
+}
+
+func TestReadPromptCookieValueEOF(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader("sp_dc=token"))
+	value, err := readPromptCookieValue(reader, nil, "sp_dc", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if value != "token" {
+		t.Fatalf("expected token, got %q", value)
+	}
+}
+
+func TestReadPromptCookieValueRequiredRejectsEmpty(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader("\n"))
+	_, err := readPromptCookieValue(reader, nil, "sp_dc", true)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestParsePastedCookiesAnyOrder(t *testing.T) {
+	values, err := parsePastedCookies(strings.NewReader("sp_t=device\nsp_dc=token\nsp_key=key\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if values.spdc != "token" || values.spkey != "key" || values.spt != "device" {
+		t.Fatalf("unexpected values: %#v", values)
+	}
+}
+
+func TestAuthPasteCmdFromStdin(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	ctx.Config = config.Default()
+	ctx.ConfigPath = filepath.Join(t.TempDir(), "config.toml")
+	ctx.ProfileKey = "default"
+
+	dest := filepath.Join(t.TempDir(), "out.json")
+	withStdin(t, "sp_t=device\nsp_dc=token\nsp_key=key\n", func() {
+		cmd := AuthPasteCmd{
+			CookiePath: dest,
+			Domain:     "spotify.com",
+		}
+		if err := cmd.Run(ctx); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+	cookiesList, err := cookies.Read(dest)
+	if err != nil {
+		t.Fatalf("read cookies: %v", err)
+	}
+	if len(cookiesList) != 3 {
+		t.Fatalf("expected 3 cookies, got %d", len(cookiesList))
+	}
+	if ctx.Profile.CookiePath != dest {
+		t.Fatalf("expected profile cookie path %s, got %s", dest, ctx.Profile.CookiePath)
+	}
+}
+
+func TestAuthPasteCmdWarnsWhenMissingSPT(t *testing.T) {
+	ctx, _, errOut := testutil.NewTestContext(t, output.FormatPlain)
+	ctx.Config = config.Default()
+	ctx.ConfigPath = filepath.Join(t.TempDir(), "config.toml")
+	ctx.ProfileKey = "default"
+	ctx.Profile = config.Profile{Engine: "connect"}
+
+	dest := filepath.Join(t.TempDir(), "out.json")
+	withStdin(t, "sp_dc=token\n", func() {
+		cmd := AuthPasteCmd{CookiePath: dest}
+		if err := cmd.Run(ctx); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+	if !strings.Contains(errOut.String(), "missing sp_t") {
+		t.Fatalf("expected warning in stderr, got %q", errOut.String())
+	}
+}
+
+func TestGlobalsSettingsPassesNoInput(t *testing.T) {
+	settings, err := (Globals{NoInput: true}).Settings()
+	if err != nil {
+		t.Fatalf("settings: %v", err)
+	}
+	if !settings.NoInput {
+		t.Fatalf("expected no_input true")
+	}
+}
+
+func TestGlobalsSettingsRejectsPlainAndJSON(t *testing.T) {
+	_, err := (Globals{JSON: true, Plain: true}).Settings()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestAuthPasteCmdRequiresSPDC(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	withStdin(t, "", func() {
+		cmd := AuthPasteCmd{}
+		if err := cmd.Run(ctx); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+}
+
+func TestAuthPasteCmdNoInputFromStdin(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	ctx.Config = config.Default()
+	ctx.ConfigPath = filepath.Join(t.TempDir(), "config.toml")
+	ctx.ProfileKey = "default"
+	ctx.Settings.NoInput = true
+
+	dest := filepath.Join(t.TempDir(), "out.json")
+	withStdin(t, "sp_dc=token\nsp_t=device\n", func() {
+		cmd := AuthPasteCmd{CookiePath: dest}
+		if err := cmd.Run(ctx); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+	if _, err := cookies.Read(dest); err != nil {
+		t.Fatalf("expected cookies file")
+	}
+}
+
 func TestAuthClearCmdNoPath(t *testing.T) {
 	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
 	cmd := AuthClearCmd{}
@@ -109,9 +281,11 @@ func TestAuthClearCmdNoPath(t *testing.T) {
 func TestAuthClearCmdSuccess(t *testing.T) {
 	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
 	dir := t.TempDir()
+	ctx.Config = config.Default()
 	ctx.ConfigPath = filepath.Join(dir, "config.toml")
 	ctx.ProfileKey = "default"
 	path := filepath.Join(dir, "cookies", "default.json")
+	ctx.Profile.CookiePath = path
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -127,23 +301,14 @@ func TestAuthClearCmdSuccess(t *testing.T) {
 	if err := cmd.Run(ctx); err != nil {
 		t.Fatalf("run: %v", err)
 	}
+	if ctx.Profile.CookiePath != "" {
+		t.Fatalf("expected profile cookie path cleared, got %q", ctx.Profile.CookiePath)
+	}
 }
 
 func TestTrashFileMissing(t *testing.T) {
 	t.Setenv("PATH", "")
 	if err := trashFile("/tmp/missing"); err == nil {
 		t.Fatalf("expected error")
-	}
-}
-
-func TestTrashFileSuccess(t *testing.T) {
-	dir := t.TempDir()
-	script := filepath.Join(dir, "trash")
-	if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	t.Setenv("PATH", dir)
-	if err := trashFile("/tmp/missing"); err != nil {
-		t.Fatalf("expected success")
 	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -79,6 +79,7 @@ func (g Globals) Settings() (app.Settings, error) {
 		Quiet:      g.Quiet,
 		Verbose:    g.Verbose,
 		Debug:      g.Debug,
+		NoInput:    g.NoInput,
 	}, nil
 }
 

--- a/internal/spotify/connect_session.go
+++ b/internal/spotify/connect_session.go
@@ -100,7 +100,7 @@ func (s *connectSession) ensureAppConfigLocked(ctx context.Context) error {
 		}
 	}
 	if deviceID == "" {
-		return errors.New("missing sp_t cookie")
+		return errors.New("missing sp_t cookie (run `spogo auth paste` and include sp_t from DevTools)")
 	}
 	jar, err := cookiejar.New(nil)
 	if err != nil {


### PR DESCRIPTION
- Add `spogo auth paste` to save cookies from DevTools values
- Make `--no-input` effective (disable prompts)
- Improve missing `sp_t` messaging\n- Docs + tests