### PR TITLE
fix(connect): hydrate status metadata + improve device UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Connect: hydrate `status` item and device metadata via Web API best-effort (helps devices/sessions that return sparse connect-state payloads).
+- Connect: bound hydration calls with short timeouts to keep `status --json` responsive under automation.
+- Devices: add `device show` and `device clear`, add `device set --save`, and improve device selector matching (exact/partial name or id).
+
 ## 0.2.0 - 2026-01-07
 
 - Add `applescript` engine for direct Spotify.app control on macOS (thanks @adam91holt)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Commands:
 - `queue add|show`
 - `library tracks|albums|artists|playlists`
 - `playlist create|add|remove|tracks`
-- `device list|set`
+- `device list|set|show|clear`
 
 Full spec: `docs/spec.md`.
 
@@ -106,6 +106,7 @@ Defaults: Chrome + Default profile. Cookies are stored under your config directo
 
 - `connect` uses Spotify's internal connect-state endpoints for playback control.
 - Search/info prefer the internal GraphQL API and fall back to web search if hashes can’t be resolved.
+- `status` does best-effort metadata hydration via Web API (track/device names) with short timeouts to avoid hangs.
 
 ## Web engine notes
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -105,7 +105,9 @@ spogo [global flags] <command> [args]
 ### devices
 
 - `spogo device list`
-- `spogo device set <name|id>`
+- `spogo device set <name|id> [--save]`
+- `spogo device show`
+- `spogo device clear`
 
 ## Output contract
 
@@ -117,7 +119,7 @@ spogo [global flags] <command> [args]
 ## Engines
 
 - `auto`: connect first; fall back to web for unsupported features or rate limits.
-- `connect`: internal connect-state endpoints for playback; GraphQL for search/info.
+- `connect`: internal connect-state endpoints for playback; GraphQL for search/info; `status` may hydrate missing track/device metadata via Web API best-effort.
 - `web`: Web API endpoints; search/info/playback auto-fallback to connect when rate limited.
 
 ## Exit codes

--- a/internal/cli/device.go
+++ b/internal/cli/device.go
@@ -2,22 +2,33 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/steipete/spogo/internal/app"
+	"github.com/steipete/spogo/internal/config"
+	"github.com/steipete/spogo/internal/spotify"
 )
 
 type DeviceCmd struct {
-	List DeviceListCmd `kong:"cmd,help='List devices.'"`
-	Set  DeviceSetCmd  `kong:"cmd,help='Set active device.'"`
+	List  DeviceListCmd  `kong:"cmd,help='List devices.'"`
+	Set   DeviceSetCmd   `kong:"cmd,help='Set active device.'"`
+	Show  DeviceShowCmd  `kong:"cmd,help='Show active device and configured target.'"`
+	Clear DeviceClearCmd `kong:"cmd,help='Clear saved device for current profile.'"`
 }
 
 type DeviceListCmd struct{}
 
 type DeviceSetCmd struct {
-	Device string `arg:"" required:"" help:"Device name or id."`
+	Device string `arg:"" required:"" help:"Device name or id (supports unique partial match)."`
+	Save   bool   `help:"Persist device selection in the current profile config."`
 }
+
+type DeviceShowCmd struct{}
+
+type DeviceClearCmd struct{}
 
 func (cmd *DeviceListCmd) Run(ctx *app.Context) error {
 	client, err := ctx.Spotify()
@@ -28,6 +39,12 @@ func (cmd *DeviceListCmd) Run(ctx *app.Context) error {
 	if err != nil {
 		return err
 	}
+	sort.SliceStable(devices, func(i, j int) bool {
+		if devices[i].Active == devices[j].Active {
+			return strings.ToLower(devices[i].Name) < strings.ToLower(devices[j].Name)
+		}
+		return devices[i].Active
+	})
 	plain := make([]string, 0, len(devices))
 	human := make([]string, 0, len(devices))
 	for _, device := range devices {
@@ -50,17 +67,97 @@ func (cmd *DeviceSetCmd) Run(ctx *app.Context) error {
 	if err != nil {
 		return err
 	}
-	id := cmd.Device
-	for _, device := range devices {
-		if strings.EqualFold(device.ID, cmd.Device) || strings.EqualFold(device.Name, cmd.Device) {
-			id = device.ID
-			break
-		}
+	id, err := spotify.ResolveDeviceID(devices, cmd.Device)
+	if err != nil {
+		return err
 	}
 	if err := client.Transfer(context.Background(), id); err != nil {
 		return err
 	}
+	if cmd.Save {
+		if ctx.Config == nil {
+			return errors.New("config not loaded")
+		}
+		profile := ctx.Profile
+		profile.Device = id
+		ctx.Profile = profile
+		ctx.Config.SetProfile(ctx.ProfileKey, profile)
+		if err := config.Save(ctx.ConfigPath, ctx.Config); err != nil {
+			return err
+		}
+	}
 	return ctx.Output.Emit(map[string]any{"status": "ok", "device": id}, []string{"ok"}, []string{fmt.Sprintf("Switched to %s", id)})
+}
+
+func (cmd *DeviceShowCmd) Run(ctx *app.Context) error {
+	client, err := ctx.Spotify()
+	if err != nil {
+		return err
+	}
+	devices, err := client.Devices(context.Background())
+	if err != nil {
+		return err
+	}
+
+	var active spotify.Device
+	for _, d := range devices {
+		if d.Active {
+			active = d
+			break
+		}
+	}
+
+	selector := strings.TrimSpace(ctx.Profile.Device)
+	targetID := ""
+	var target spotify.Device
+	if selector != "" {
+		id, rerr := spotify.ResolveDeviceID(devices, selector)
+		if rerr != nil {
+			return rerr
+		}
+		targetID = id
+		for _, d := range devices {
+			if d.ID == targetID {
+				target = d
+				break
+			}
+		}
+	}
+
+	payload := map[string]any{
+		"status": "ok",
+		"active": active,
+		"target": target,
+	}
+	plain := []string{fmt.Sprintf("%s\t%s\t%s\t%s", active.ID, active.Name, targetID, target.Name)}
+
+	activeLabel := "(none)"
+	if strings.TrimSpace(active.ID) != "" || strings.TrimSpace(active.Name) != "" {
+		activeLabel = fmt.Sprintf("%s (%s)", active.Name, active.ID)
+	}
+	targetLabel := "(none)"
+	if selector != "" {
+		targetLabel = fmt.Sprintf("%s (%s)", target.Name, targetID)
+	}
+	human := []string{
+		fmt.Sprintf("Active: %s", activeLabel),
+		fmt.Sprintf("Target: %s", targetLabel),
+	}
+	return ctx.Output.Emit(payload, plain, human)
+}
+
+func (cmd *DeviceClearCmd) Run(ctx *app.Context) error {
+	if ctx.Config == nil {
+		return errors.New("config not loaded")
+	}
+	profile := ctx.Profile
+	profile.Device = ""
+	ctx.Profile = profile
+	ctx.Config.SetProfile(ctx.ProfileKey, profile)
+	if err := config.Save(ctx.ConfigPath, ctx.Config); err != nil {
+		return err
+	}
+	return ctx.Output.Emit(map[string]string{"status": "ok"}, []string{"ok"}, []string{"Cleared saved device"})
 }
 
 func activeMarker(active bool) string {

--- a/internal/cli/device_test.go
+++ b/internal/cli/device_test.go
@@ -3,8 +3,11 @@ package cli
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/steipete/spogo/internal/config"
 	"github.com/steipete/spogo/internal/output"
 	"github.com/steipete/spogo/internal/spotify"
 	"github.com/steipete/spogo/internal/testutil"
@@ -32,6 +35,50 @@ func TestDeviceSetCmd(t *testing.T) {
 	}
 	if !called {
 		t.Fatalf("expected transfer")
+	}
+}
+
+func TestDeviceSetCmdSave(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+
+	cfg := config.Default()
+	profileKey := "p1"
+	cfg.SetProfile(profileKey, config.Profile{})
+
+	ctx.Config = cfg
+	ctx.ConfigPath = configPath
+	ctx.ProfileKey = profileKey
+	ctx.Profile = cfg.Profile(profileKey)
+
+	mock := &testutil.SpotifyMock{
+		DevicesFn: func(ctx context.Context) ([]spotify.Device, error) {
+			return []spotify.Device{{ID: "d1", Name: "Desk"}}, nil
+		},
+		TransferFn: func(ctx context.Context, deviceID string) error {
+			if deviceID != "d1" {
+				t.Fatalf("device id %s", deviceID)
+			}
+			return nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := DeviceSetCmd{Device: "Desk", Save: true}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if _, err := os.Stat(configPath); err != nil {
+		t.Fatalf("config not written: %v", err)
+	}
+	loaded, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	got := loaded.Profile(profileKey).Device
+	if got != "d1" {
+		t.Fatalf("expected saved device d1, got %q", got)
 	}
 }
 
@@ -66,6 +113,75 @@ func TestDeviceListCmd(t *testing.T) {
 	}
 	if out.String() == "" {
 		t.Fatalf("expected output")
+	}
+}
+
+func TestDeviceShowCmdNoTarget(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		DevicesFn: func(ctx context.Context) ([]spotify.Device, error) {
+			return []spotify.Device{
+				{ID: "d1", Name: "Desk", Active: true},
+				{ID: "d2", Name: "Phone"},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := DeviceShowCmd{}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out.String() == "" {
+		t.Fatalf("expected output")
+	}
+}
+
+func TestDeviceShowCmdWithTarget(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatPlain)
+	ctx.Profile.Device = "Phone"
+	mock := &testutil.SpotifyMock{
+		DevicesFn: func(ctx context.Context) ([]spotify.Device, error) {
+			return []spotify.Device{
+				{ID: "d1", Name: "Desk", Active: true},
+				{ID: "d2", Name: "Phone"},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := DeviceShowCmd{}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out.String() == "" {
+		t.Fatalf("expected output")
+	}
+}
+
+func TestDeviceClearCmd(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+
+	cfg := config.Default()
+	profileKey := "p1"
+	cfg.SetProfile(profileKey, config.Profile{Device: "d1"})
+
+	ctx.Config = cfg
+	ctx.ConfigPath = configPath
+	ctx.ProfileKey = profileKey
+	ctx.Profile = cfg.Profile(profileKey)
+
+	cmd := DeviceClearCmd{}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	loaded, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	got := loaded.Profile(profileKey).Device
+	if got != "" {
+		t.Fatalf("expected cleared device, got %q", got)
 	}
 }
 

--- a/internal/spotify/connect_mapping.go
+++ b/internal/spotify/connect_mapping.go
@@ -100,6 +100,15 @@ func extractItem(value any, kind string) (Item, bool) {
 		return Item{}, false
 	}
 	uri := getString(m, "uri")
+	if uri == "" {
+		uri = getString(m, "entity_uri")
+	}
+	if uri == "" {
+		uri = getString(m, "track_uri")
+	}
+	if uri == "" {
+		uri = getString(m, "item_uri")
+	}
 	if uri == "" && kind != "" {
 		if id := getString(m, "id"); id != "" {
 			uri = "spotify:" + kind + ":" + id
@@ -119,6 +128,15 @@ func extractItem(value any, kind string) (Item, bool) {
 	name := getString(m, "name")
 	if name == "" {
 		name = getString(m, "title")
+	}
+	if name == "" {
+		// Common connect-state metadata shape: {"metadata":{"title":"..."}}.
+		if meta, ok := m["metadata"].(map[string]any); ok {
+			name = getString(meta, "title")
+			if name == "" {
+				name = getString(meta, "name")
+			}
+		}
 	}
 	if name == "" {
 		name = findFirstName(m)
@@ -231,6 +249,21 @@ func extractArtistNames(value any) []string {
 			if name := getString(m, "artistName"); name != "" {
 				artists = append(artists, name)
 			}
+			// Common connect-state metadata maps.
+			if name := getString(m, "artist_name"); name != "" {
+				artists = append(artists, name)
+			}
+			if name := getString(m, "album_artist_name"); name != "" {
+				artists = append(artists, name)
+			}
+			if meta, ok := m["metadata"].(map[string]any); ok {
+				if name := getString(meta, "artist_name"); name != "" {
+					artists = append(artists, name)
+				}
+				if name := getString(meta, "album_artist_name"); name != "" {
+					artists = append(artists, name)
+				}
+			}
 		}
 	}
 	return dedupeStrings(artists)
@@ -242,6 +275,11 @@ func extractAlbumName(value any) string {
 		if album != "" {
 			return
 		}
+		// Common connect-state metadata maps.
+		if name := getString(m, "album_title"); name != "" {
+			album = name
+			return
+		}
 		if inner, ok := m["album"].(map[string]any); ok {
 			if name := getString(inner, "name"); name != "" {
 				album = name
@@ -249,6 +287,11 @@ func extractAlbumName(value any) string {
 		}
 		if inner, ok := m["albumOfTrack"].(map[string]any); ok {
 			if name := getString(inner, "name"); name != "" {
+				album = name
+			}
+		}
+		if meta, ok := m["metadata"].(map[string]any); ok {
+			if name := getString(meta, "album_title"); name != "" {
 				album = name
 			}
 		}

--- a/internal/spotify/connect_playback.go
+++ b/internal/spotify/connect_playback.go
@@ -28,7 +28,107 @@ func (c *ConnectClient) playback(ctx context.Context) (PlaybackStatus, error) {
 	if err != nil {
 		return PlaybackStatus{}, err
 	}
-	return mapPlaybackStatus(state), nil
+	status := mapPlaybackStatus(state)
+
+	// Connect-state payloads sometimes omit item/device metadata (common for some sessions/devices).
+	// Hydrate missing fields best-effort via Web API playback and/or track info calls.
+	var web *Client
+	if w, werr := c.webClient(); werr == nil {
+		web = w
+	}
+	// Use separate short timeouts for hydration calls so one slow endpoint doesn't starve the others.
+	// These values are intentionally conservative to keep `status --json` snappy under automation.
+	const (
+		webPlaybackTimeout = 900 * time.Millisecond
+		webDevicesTimeout  = 900 * time.Millisecond
+		trackInfoTimeout   = 1500 * time.Millisecond
+	)
+
+	var webDevices []Device
+	webDevicesLoaded := false
+	loadWebDevices := func() []Device {
+		if webDevicesLoaded || web == nil {
+			return webDevices
+		}
+		webDevicesLoaded = true
+		wctx, cancel := hydrationContext(ctx, webDevicesTimeout)
+		defer cancel()
+		if devs, derr := web.Devices(wctx); derr == nil {
+			webDevices = devs
+		}
+		return webDevices
+	}
+
+	if web != nil && ((status.Item != nil && status.Item.Name == "") || status.Device.Name == "" || status.Device.ID == "") {
+		wctx, cancel := hydrationContext(ctx, webPlaybackTimeout)
+		defer cancel()
+		if webStatus, perr := web.Playback(wctx); perr == nil {
+			if (status.Device.Name == "" || status.Device.ID == "") && (webStatus.Device.Name != "" || webStatus.Device.ID != "") {
+				// Prefer Web API device object if it has any useful metadata.
+				if status.Device.ID == "" {
+					status.Device.ID = webStatus.Device.ID
+				}
+				if status.Device.Name == "" {
+					status.Device.Name = webStatus.Device.Name
+				}
+				if status.Device.Type == "" {
+					status.Device.Type = webStatus.Device.Type
+				}
+				if status.Device.Volume == 0 {
+					status.Device.Volume = webStatus.Device.Volume
+				}
+				if !status.Device.Restricted {
+					status.Device.Restricted = webStatus.Device.Restricted
+				}
+				if !status.Device.Active {
+					status.Device.Active = webStatus.Device.Active
+				}
+			}
+			if status.Item != nil && status.Item.Name == "" && webStatus.Item != nil && webStatus.Item.Name != "" {
+				mergeItem(status.Item, webStatus.Item)
+			}
+		}
+	}
+
+	// If we have an id but no name, try to map it via /me/player/devices.
+	if status.Device.Name == "" && status.Device.ID != "" && web != nil {
+		for _, d := range loadWebDevices() {
+			if strings.EqualFold(d.ID, status.Device.ID) && strings.TrimSpace(d.Name) != "" {
+				status.Device = d
+				status.Device.Active = true
+				break
+			}
+		}
+	}
+
+	// Last resort: if connect-state gave us no device info at all, and Web API has exactly one active device,
+	// assume it's the current playback device.
+	if status.Device.ID == "" && status.Device.Name == "" && web != nil {
+		if d, ok := pickPreferredDevice(loadWebDevices()); ok {
+			status.Device = d
+			status.Device.Active = true
+		}
+	}
+
+	// Track hydration: prefer the fast Web API GetTrack call (avoids GraphQL hash resolution on cold start).
+	if status.Item != nil && status.Item.Name == "" && status.Item.ID != "" && (status.Item.Type == "track" || status.Item.Type == "" || strings.HasPrefix(status.Item.URI, "spotify:track:")) {
+		if web != nil {
+			wctx, cancel := hydrationContext(ctx, trackInfoTimeout)
+			defer cancel()
+			if item, ierr := web.GetTrack(wctx, status.Item.ID); ierr == nil && item.Name != "" {
+				mergeItem(status.Item, &item)
+			}
+		}
+		// If still missing, fall back to the connect GraphQL path (may already be warmed/cached).
+		if status.Item.Name == "" {
+			wctx, cancel := hydrationContext(ctx, trackInfoTimeout)
+			defer cancel()
+			if item, ierr := c.trackInfo(wctx, status.Item.ID); ierr == nil && item.Name != "" {
+				mergeItem(status.Item, &item)
+			}
+		}
+	}
+	return status, nil
 }
 
 func (c *ConnectClient) devices(ctx context.Context) ([]Device, error) {
@@ -36,7 +136,26 @@ func (c *ConnectClient) devices(ctx context.Context) ([]Device, error) {
 	if err != nil {
 		return nil, err
 	}
-	return mapDevices(state), nil
+	devices := mapDevices(state)
+	needsHydration := len(devices) == 0
+	if !needsHydration {
+		allBlank := true
+		for _, d := range devices {
+			if strings.TrimSpace(d.Name) != "" {
+				allBlank = false
+				break
+			}
+		}
+		needsHydration = allBlank
+	}
+	if needsHydration {
+		if web, werr := c.webClient(); werr == nil {
+			if webDevices, derr := web.Devices(ctx); derr == nil && len(webDevices) > 0 {
+				return webDevices, nil
+			}
+		}
+	}
+	return devices, nil
 }
 
 func (c *ConnectClient) transfer(ctx context.Context, deviceID string) error {
@@ -64,6 +183,10 @@ func (c *ConnectClient) play(ctx context.Context, uri string) error {
 	if err != nil {
 		return err
 	}
+	state, err = c.ensureTargetDevice(ctx, state)
+	if err != nil {
+		return err
+	}
 	if uri == "" {
 		return c.sendPlayerCommand(ctx, state, "resume", nil)
 	}
@@ -88,11 +211,19 @@ func (c *ConnectClient) pause(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	state, err = c.ensureTargetDevice(ctx, state)
+	if err != nil {
+		return err
+	}
 	return c.sendPlayerCommand(ctx, state, "pause", nil)
 }
 
 func (c *ConnectClient) next(ctx context.Context) error {
 	state, err := c.connectState(ctx)
+	if err != nil {
+		return err
+	}
+	state, err = c.ensureTargetDevice(ctx, state)
 	if err != nil {
 		return err
 	}
@@ -104,6 +235,10 @@ func (c *ConnectClient) previous(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	state, err = c.ensureTargetDevice(ctx, state)
+	if err != nil {
+		return err
+	}
 	return c.sendPlayerCommand(ctx, state, "skip_prev", nil)
 }
 
@@ -112,6 +247,10 @@ func (c *ConnectClient) seek(ctx context.Context, positionMS int) error {
 		positionMS = 0
 	}
 	state, err := c.connectState(ctx)
+	if err != nil {
+		return err
+	}
+	state, err = c.ensureTargetDevice(ctx, state)
 	if err != nil {
 		return err
 	}
@@ -138,6 +277,10 @@ func (c *ConnectClient) volume(ctx context.Context, volume int) error {
 	if err != nil {
 		return err
 	}
+	state, err = c.ensureTargetDevice(ctx, state)
+	if err != nil {
+		return err
+	}
 	fromID := state.originDeviceID
 	if fromID == "" {
 		fromID = state.activeDeviceID
@@ -156,6 +299,10 @@ func (c *ConnectClient) shuffle(ctx context.Context, enabled bool) error {
 	if err != nil {
 		return err
 	}
+	state, err = c.ensureTargetDevice(ctx, state)
+	if err != nil {
+		return err
+	}
 	payload := map[string]any{
 		"command": map[string]any{
 			"endpoint": "set_shuffling_context",
@@ -170,6 +317,10 @@ func (c *ConnectClient) shuffle(ctx context.Context, enabled bool) error {
 
 func (c *ConnectClient) repeat(ctx context.Context, mode string) error {
 	state, err := c.connectState(ctx)
+	if err != nil {
+		return err
+	}
+	state, err = c.ensureTargetDevice(ctx, state)
 	if err != nil {
 		return err
 	}
@@ -201,6 +352,10 @@ func (c *ConnectClient) queueAdd(ctx context.Context, uri string) error {
 	if err != nil {
 		return err
 	}
+	state, err = c.ensureTargetDevice(ctx, state)
+	if err != nil {
+		return err
+	}
 	payload := map[string]any{
 		"command": map[string]any{
 			"endpoint": "add_to_queue",
@@ -229,6 +384,120 @@ type connectState struct {
 	devices        map[string]any
 	activeDeviceID string
 	originDeviceID string
+}
+
+func (c *ConnectClient) ensureTargetDevice(ctx context.Context, state connectState) (connectState, error) {
+	selector := strings.TrimSpace(c.device)
+	if selector == "" {
+		return state, nil
+	}
+	devices := mapDevices(state)
+	targetID, err := ResolveDeviceID(devices, selector)
+	if err != nil {
+		// If connect-state device metadata is incomplete, fall back to Web API device list.
+		if web, werr := c.webClient(); werr == nil {
+			if webDevices, derr := web.Devices(ctx); derr == nil && len(webDevices) > 0 {
+				targetID, err = ResolveDeviceID(webDevices, selector)
+			}
+		}
+	}
+	if err != nil {
+		return state, err
+	}
+	if targetID == "" || targetID == state.activeDeviceID {
+		return state, nil
+	}
+	fromID := state.originDeviceID
+	if fromID == "" {
+		fromID = state.activeDeviceID
+	}
+	if fromID == "" {
+		return state, errors.New("missing origin device id")
+	}
+	if err := c.sendConnectCommand(ctx, fmt.Sprintf("%s/connect/transfer/from/%s/to/%s", connectStateBase, fromID, targetID), map[string]any{
+		"transfer_options": map[string]any{
+			"restore_paused": "resume",
+		},
+		"command_id": randomHex(32),
+	}); err != nil {
+		return state, err
+	}
+	state.activeDeviceID = targetID
+	return state, nil
+}
+
+func mergeItem(dst *Item, src *Item) {
+	if dst == nil || src == nil {
+		return
+	}
+	if dst.ID == "" {
+		dst.ID = src.ID
+	}
+	if dst.URI == "" {
+		dst.URI = src.URI
+	}
+	if dst.Type == "" {
+		dst.Type = src.Type
+	}
+	if dst.URL == "" {
+		dst.URL = src.URL
+	}
+	if dst.Name == "" {
+		dst.Name = src.Name
+	}
+	if len(dst.Artists) == 0 && len(src.Artists) > 0 {
+		dst.Artists = src.Artists
+	}
+	if dst.Album == "" {
+		dst.Album = src.Album
+	}
+	if dst.DurationMS == 0 {
+		dst.DurationMS = src.DurationMS
+	}
+	if !dst.Explicit {
+		dst.Explicit = src.Explicit
+	}
+	if !dst.IsPlayable {
+		dst.IsPlayable = src.IsPlayable
+	}
+}
+
+func pickPreferredDevice(devices []Device) (Device, bool) {
+	if len(devices) == 0 {
+		return Device{}, false
+	}
+	active := make([]Device, 0, 2)
+	for _, d := range devices {
+		if d.Active {
+			active = append(active, d)
+		}
+	}
+	if len(active) == 1 {
+		return active[0], true
+	}
+	// If multiple devices are marked active, prefer the first one with a name.
+	for _, d := range active {
+		if strings.TrimSpace(d.Name) != "" {
+			return d, true
+		}
+	}
+	if len(active) > 0 {
+		return active[0], true
+	}
+	if len(devices) == 1 {
+		return devices[0], true
+	}
+	return Device{}, false
+}
+
+func hydrationContext(ctx context.Context, fallback time.Duration) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		return context.WithTimeout(context.Background(), fallback)
+	}
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, fallback)
 }
 
 func (c *ConnectClient) connectState(ctx context.Context) (connectState, error) {

--- a/internal/spotify/connect_playback_test.go
+++ b/internal/spotify/connect_playback_test.go
@@ -99,6 +99,192 @@ func TestConnectPlaybackCommands(t *testing.T) {
 	}
 }
 
+func TestConnectPlaybackHonorsTargetDeviceSelector(t *testing.T) {
+	statePayload := map[string]any{
+		"devices": map[string]any{
+			"device-1": map[string]any{
+				"name":        "Desk",
+				"device_type": "computer",
+			},
+			"device-2": map[string]any{
+				"name":        "Phone",
+				"device_type": "smartphone",
+			},
+		},
+		"player_state":      map[string]any{"is_paused": false},
+		"active_device_id":  "device-1",
+		"connection_id":     "conn",
+		"last_command_sent": "",
+	}
+	var transferCalls, commandCalls int
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/devices/hobs_"):
+			return jsonResponse(http.StatusOK, statePayload), nil
+		case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/connect/transfer/from/"):
+			transferCalls++
+			return textResponse(http.StatusOK, "ok"), nil
+		case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/player/command/from/"):
+			commandCalls++
+			if !strings.Contains(req.URL.Path, "/to/device-2") {
+				return textResponse(http.StatusBadRequest, "wrong target"), nil
+			}
+			return textResponse(http.StatusOK, "ok"), nil
+		default:
+			return textResponse(http.StatusOK, "ok"), nil
+		}
+	})
+	client := newConnectClientForTests(transport)
+	client.device = "Phone"
+	client.session.connectDeviceID = "device"
+	client.session.connectionID = "conn"
+	client.session.registeredAt = time.Now()
+
+	if err := client.Pause(context.Background()); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	if transferCalls != 1 {
+		t.Fatalf("expected transfer call, got %d", transferCalls)
+	}
+	if commandCalls != 1 {
+		t.Fatalf("expected player command call, got %d", commandCalls)
+	}
+}
+
+type tokenProviderStub struct{}
+
+func (tokenProviderStub) Token(context.Context) (Token, error) {
+	return Token{AccessToken: "token", ExpiresAt: time.Now().Add(time.Hour)}, nil
+}
+
+func TestConnectPlaybackHydratesDeviceNameViaWebDevices(t *testing.T) {
+	statePayload := map[string]any{
+		"devices": map[string]any{
+			"sony-1": map[string]any{},
+		},
+		"player_state": map[string]any{
+			"is_paused": true,
+			"track": map[string]any{
+				"uri": "spotify:track:abc",
+			},
+		},
+		"active_device_id": "sony-1",
+	}
+	var webPlaybackCalls, webDevicesCalls int
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/devices/hobs_"):
+			return jsonResponse(http.StatusOK, statePayload), nil
+		case req.Method == http.MethodGet && req.URL.Host == "api.spotify.com" && req.URL.Path == "/v1/me/player":
+			webPlaybackCalls++
+			// Simulate Web API playback returning a device id but missing name (observed for some sessions).
+			return jsonResponse(http.StatusOK, map[string]any{
+				"is_playing":             false,
+				"progress_ms":            0,
+				"shuffle_state":          false,
+				"repeat_state":           "off",
+				"device":                 map[string]any{"id": "sony-1", "name": "", "type": "tv", "volume_percent": 0, "is_active": true, "is_restricted": false},
+				"item":                   map[string]any{"id": "abc", "name": "Song", "uri": "spotify:track:abc", "album": map[string]any{"name": "Album"}, "artists": []any{map[string]any{"name": "Artist"}}},
+				"currently_playing_type": "track",
+			}), nil
+		case req.Method == http.MethodGet && req.URL.Host == "api.spotify.com" && req.URL.Path == "/v1/me/player/devices":
+			webDevicesCalls++
+			return jsonResponse(http.StatusOK, deviceResponse{
+				Devices: []deviceItem{
+					{ID: "sony-1", Name: "Sony TV", Type: "tv", Volume: 0, Active: true, Restricted: false},
+				},
+			}), nil
+		default:
+			return textResponse(http.StatusNotFound, "missing"), nil
+		}
+	})
+	connectClient := newConnectClientForTests(transport)
+	connectClient.session.connectDeviceID = "device"
+	connectClient.session.connectionID = "conn"
+	connectClient.session.registeredAt = time.Now()
+
+	webClient, err := NewClient(Options{
+		TokenProvider: tokenProviderStub{},
+		HTTPClient:    &http.Client{Transport: transport},
+	})
+	if err != nil {
+		t.Fatalf("web client: %v", err)
+	}
+	connectClient.web = webClient
+
+	status, err := connectClient.Playback(context.Background())
+	if err != nil {
+		t.Fatalf("playback: %v", err)
+	}
+	if webPlaybackCalls == 0 || webDevicesCalls == 0 {
+		t.Fatalf("expected web hydration calls, playback=%d devices=%d", webPlaybackCalls, webDevicesCalls)
+	}
+	if status.Device.ID != "sony-1" || status.Device.Name != "Sony TV" {
+		t.Fatalf("unexpected device: %#v", status.Device)
+	}
+}
+
+func TestConnectPlaybackLastResortDeviceFromSingleActiveWebDevice(t *testing.T) {
+	statePayload := map[string]any{
+		// Device payload is present but barren; no active_device_id and no active flags.
+		"devices": map[string]any{
+			"sony-1": map[string]any{},
+		},
+		"player_state": map[string]any{
+			"is_paused": true,
+			"track": map[string]any{
+				"uri": "spotify:track:abc",
+			},
+		},
+	}
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/devices/hobs_"):
+			return jsonResponse(http.StatusOK, statePayload), nil
+		case req.Method == http.MethodGet && req.URL.Host == "api.spotify.com" && req.URL.Path == "/v1/me/player":
+			// Don't help with device metadata.
+			return jsonResponse(http.StatusOK, map[string]any{
+				"is_playing":    false,
+				"progress_ms":   0,
+				"shuffle_state": false,
+				"repeat_state":  "off",
+				"device":        map[string]any{"id": "", "name": "", "type": "", "volume_percent": 0, "is_active": false, "is_restricted": false},
+				"item":          map[string]any{"id": "abc", "name": "Song", "uri": "spotify:track:abc"},
+			}), nil
+		case req.Method == http.MethodGet && req.URL.Host == "api.spotify.com" && req.URL.Path == "/v1/me/player/devices":
+			return jsonResponse(http.StatusOK, deviceResponse{
+				Devices: []deviceItem{
+					{ID: "web-sony", Name: "Sony TV", Type: "tv", Volume: 0, Active: true, Restricted: false},
+				},
+			}), nil
+		default:
+			return textResponse(http.StatusNotFound, "missing"), nil
+		}
+	})
+	connectClient := newConnectClientForTests(transport)
+	connectClient.session.connectDeviceID = "device"
+	connectClient.session.connectionID = "conn"
+	connectClient.session.registeredAt = time.Now()
+	connectClient.hashes = newHashResolver(&http.Client{Transport: transport}, connectClient.session)
+
+	webClient, err := NewClient(Options{
+		TokenProvider: tokenProviderStub{},
+		HTTPClient:    &http.Client{Transport: transport},
+	})
+	if err != nil {
+		t.Fatalf("web client: %v", err)
+	}
+	connectClient.web = webClient
+
+	status, err := connectClient.Playback(context.Background())
+	if err != nil {
+		t.Fatalf("playback: %v", err)
+	}
+	if status.Device.Name != "Sony TV" || status.Device.ID != "web-sony" {
+		t.Fatalf("unexpected device: %#v", status.Device)
+	}
+}
+
 func TestConnectPlaybackActiveDeviceFromDevices(t *testing.T) {
 	statePayload := map[string]any{
 		"devices": map[string]any{

--- a/internal/spotify/connect_state_map.go
+++ b/internal/spotify/connect_state_map.go
@@ -18,11 +18,31 @@ func mapDevices(state connectState) []Device {
 		if name == "" {
 			name = getString(deviceMap, "device_name")
 		}
+		if name == "" {
+			name = getString(deviceMap, "deviceName")
+		}
+		if name == "" {
+			name = getString(deviceMap, "label")
+		}
+		if name == "" {
+			name = getString(deviceMap, "friendly_name")
+		}
+		devType := getString(deviceMap, "device_type")
+		if devType == "" {
+			devType = getString(deviceMap, "type")
+		}
+		if devType == "" {
+			devType = getString(deviceMap, "deviceType")
+		}
 		device := Device{
 			ID:     id,
 			Name:   name,
-			Type:   getString(deviceMap, "device_type"),
+			Type:   devType,
 			Active: id == state.activeDeviceID,
+		}
+		device.Restricted = getBool(deviceMap, "is_restricted")
+		if !device.Active {
+			device.Active = getBool(deviceMap, "is_active") || getBool(deviceMap, "is_currently_playing") || getBool(deviceMap, "is_active_device")
 		}
 		device.Volume = getInt(deviceMap, "volume")
 		if device.Volume == 0 {
@@ -56,6 +76,11 @@ func mapPlaybackStatus(state connectState) PlaybackStatus {
 	if track := extractPlaybackTrack(player); track.URI != "" {
 		status.Item = &track
 	}
+	// Even if device metadata is missing, preserve the active device id.
+	if state.activeDeviceID != "" {
+		status.Device.ID = state.activeDeviceID
+		status.Device.Active = true
+	}
 	for _, device := range mapDevices(state) {
 		if device.Active {
 			status.Device = device
@@ -75,7 +100,8 @@ func mapQueue(state connectState) Queue {
 	}
 	if next, ok := state.playerState["next_tracks"].([]any); ok {
 		for _, entry := range next {
-			if item, ok := extractItem(entry, "track"); ok {
+			// "next_tracks" can include non-tracks (episodes, ads, etc). Don't hard-filter to track.
+			if item, ok := extractItem(entry, ""); ok {
 				queue.Queue = append(queue.Queue, item)
 			}
 		}
@@ -87,12 +113,30 @@ func extractPlaybackTrack(player map[string]any) Item {
 	if player == nil {
 		return Item{}
 	}
+	// Common connect-state shapes.
 	for _, key := range []string{"track", "item", "current_track"} {
 		if raw, ok := player[key]; ok {
-			if item, ok := extractItem(raw, "track"); ok {
-				return item
+			if item, ok := extractItem(raw, ""); ok {
+				return enrichPlaybackItem(item, player)
 			}
 		}
+	}
+	// Web Playback SDK-style shape.
+	if tw, ok := player["track_window"].(map[string]any); ok {
+		if raw, ok := tw["current_track"]; ok {
+			if item, ok := extractItem(raw, ""); ok {
+				return enrichPlaybackItem(item, player)
+			}
+		}
+	}
+	// Some payloads split metadata away from the track object.
+	if uri := getString(player, "track_uri"); uri != "" && strings.HasPrefix(uri, "spotify:") {
+		item := Item{
+			URI:  uri,
+			ID:   idFromURI(uri),
+			Type: typeFromURI(uri),
+		}
+		return enrichPlaybackItem(item, player)
 	}
 	for _, key := range []string{"context_uri", "context_uri_string"} {
 		if uri, ok := player[key].(string); ok && strings.HasPrefix(uri, "spotify:") {
@@ -105,4 +149,45 @@ func extractPlaybackTrack(player map[string]any) Item {
 		}
 	}
 	return Item{}
+}
+
+func enrichPlaybackItem(item Item, player map[string]any) Item {
+	// If the primary object only contains a URI, try to enrich from adjacent metadata.
+	if player == nil {
+		return item
+	}
+	needsName := item.Name == ""
+	needsArtists := len(item.Artists) == 0
+	needsAlbum := item.Album == ""
+	if !needsName && !needsArtists && !needsAlbum {
+		return item
+	}
+	for _, key := range []string{"track_metadata", "metadata"} {
+		raw, ok := player[key]
+		if !ok {
+			continue
+		}
+		if needsName {
+			if name := findFirstName(raw); name != "" {
+				item.Name = name
+				needsName = false
+			}
+		}
+		if needsArtists {
+			if artists := extractArtistNames(raw); len(artists) > 0 {
+				item.Artists = artists
+				needsArtists = false
+			}
+		}
+		if needsAlbum {
+			if album := extractAlbumName(raw); album != "" {
+				item.Album = album
+				needsAlbum = false
+			}
+		}
+		if !needsName && !needsArtists && !needsAlbum {
+			break
+		}
+	}
+	return item
 }

--- a/internal/spotify/connect_state_map_test.go
+++ b/internal/spotify/connect_state_map_test.go
@@ -40,6 +40,24 @@ func TestMapPlaybackStatusAndDevices(t *testing.T) {
 	}
 }
 
+func TestMapDevicesUsesLabelFallback(t *testing.T) {
+	state := connectState{
+		activeDeviceID: "d1",
+		devices: map[string]any{
+			"d1": map[string]any{
+				"label":       "Sony TV",
+				"device_type": "tv",
+				"is_active":   true,
+			},
+		},
+		playerState: map[string]any{"is_paused": true},
+	}
+	status := mapPlaybackStatus(state)
+	if status.Device.ID != "d1" || status.Device.Name != "Sony TV" || !status.Device.Active {
+		t.Fatalf("unexpected device: %#v", status.Device)
+	}
+}
+
 func TestMapQueue(t *testing.T) {
 	state := connectState{
 		playerState: map[string]any{
@@ -80,6 +98,41 @@ func TestExtractPlaybackTrackCurrent(t *testing.T) {
 	}
 	item := extractPlaybackTrack(player)
 	if item.URI != "spotify:track:xyz" {
+		t.Fatalf("unexpected item: %#v", item)
+	}
+}
+
+func TestExtractPlaybackTrackEnrichesFromTrackMetadata(t *testing.T) {
+	player := map[string]any{
+		"track": map[string]any{
+			"uri": "spotify:track:xyz",
+		},
+		"track_metadata": map[string]any{
+			"title":       "Song",
+			"artist_name": "Artist",
+			"album_title": "Album",
+		},
+	}
+	item := extractPlaybackTrack(player)
+	if item.URI != "spotify:track:xyz" || item.Name != "Song" || item.Album != "Album" {
+		t.Fatalf("unexpected item: %#v", item)
+	}
+	if len(item.Artists) != 1 || item.Artists[0] != "Artist" {
+		t.Fatalf("unexpected artists: %#v", item.Artists)
+	}
+}
+
+func TestExtractPlaybackTrackTrackWindowShape(t *testing.T) {
+	player := map[string]any{
+		"track_window": map[string]any{
+			"current_track": map[string]any{
+				"uri":  "spotify:track:win",
+				"name": "Window Song",
+			},
+		},
+	}
+	item := extractPlaybackTrack(player)
+	if item.URI != "spotify:track:win" || item.Name != "Window Song" {
 		t.Fatalf("unexpected item: %#v", item)
 	}
 }

--- a/internal/spotify/device_select.go
+++ b/internal/spotify/device_select.go
@@ -1,0 +1,86 @@
+package spotify
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ResolveDeviceID resolves a user-supplied selector (name or id) to a concrete device id.
+//
+// Resolution order:
+// - exact id match (case-insensitive)
+// - exact name match (case-insensitive)
+// - unique substring match on name
+// - unique substring match on id
+//
+// If multiple devices match, returns an error describing the ambiguity.
+func ResolveDeviceID(devices []Device, selector string) (string, error) {
+	sel := strings.TrimSpace(selector)
+	if sel == "" {
+		return "", fmt.Errorf("empty device selector")
+	}
+	selFold := strings.ToLower(sel)
+
+	// 1) Exact ID.
+	for _, d := range devices {
+		if strings.EqualFold(d.ID, sel) {
+			return d.ID, nil
+		}
+	}
+	// 2) Exact name.
+	for _, d := range devices {
+		if strings.EqualFold(d.Name, sel) {
+			return d.ID, nil
+		}
+	}
+
+	// 3) Substring name.
+	nameMatches := make([]Device, 0, 4)
+	for _, d := range devices {
+		if d.Name == "" {
+			continue
+		}
+		if strings.Contains(strings.ToLower(d.Name), selFold) {
+			nameMatches = append(nameMatches, d)
+		}
+	}
+	if len(nameMatches) == 1 {
+		return nameMatches[0].ID, nil
+	}
+	if len(nameMatches) > 1 {
+		return "", ambiguousDeviceSelectorError(sel, nameMatches)
+	}
+
+	// 4) Substring id.
+	idMatches := make([]Device, 0, 4)
+	for _, d := range devices {
+		if d.ID == "" {
+			continue
+		}
+		if strings.Contains(strings.ToLower(d.ID), selFold) {
+			idMatches = append(idMatches, d)
+		}
+	}
+	if len(idMatches) == 1 {
+		return idMatches[0].ID, nil
+	}
+	if len(idMatches) > 1 {
+		return "", ambiguousDeviceSelectorError(sel, idMatches)
+	}
+
+	return "", fmt.Errorf("device %q not found", sel)
+}
+
+func ambiguousDeviceSelectorError(selector string, matches []Device) error {
+	labels := make([]string, 0, len(matches))
+	for _, d := range matches {
+		label := d.ID
+		if strings.TrimSpace(d.Name) != "" {
+			label = fmt.Sprintf("%s (%s)", d.Name, d.ID)
+		}
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+	return fmt.Errorf("device %q is ambiguous; matches: %s", selector, strings.Join(labels, ", "))
+}

--- a/internal/spotify/device_select_test.go
+++ b/internal/spotify/device_select_test.go
@@ -1,0 +1,55 @@
+package spotify
+
+import "testing"
+
+func TestResolveDeviceIDExactID(t *testing.T) {
+	devices := []Device{
+		{ID: "d1", Name: "Desk"},
+		{ID: "d2", Name: "Phone"},
+	}
+	got, err := ResolveDeviceID(devices, "d2")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != "d2" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestResolveDeviceIDExactName(t *testing.T) {
+	devices := []Device{
+		{ID: "d1", Name: "Desk"},
+		{ID: "d2", Name: "Phone"},
+	}
+	got, err := ResolveDeviceID(devices, "desk")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != "d1" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestResolveDeviceIDUniqueSubstringName(t *testing.T) {
+	devices := []Device{
+		{ID: "d1", Name: "Desk Mac"},
+		{ID: "d2", Name: "Phone"},
+	}
+	got, err := ResolveDeviceID(devices, "mac")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != "d1" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestResolveDeviceIDAmbiguousSubstringName(t *testing.T) {
+	devices := []Device{
+		{ID: "d1", Name: "Office Desk"},
+		{ID: "d2", Name: "Home Desk"},
+	}
+	if _, err := ResolveDeviceID(devices, "desk"); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/internal/spotify/http_test.go
+++ b/internal/spotify/http_test.go
@@ -16,18 +16,21 @@ func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) 
 func jsonResponse(status int, payload any) *http.Response {
 	data, _ := json.Marshal(payload)
 	return &http.Response{
-		StatusCode: status,
-		Status:     http.StatusText(status),
-		Header:     http.Header{"Content-Type": []string{"application/json"}},
-		Body:       io.NopCloser(bytes.NewReader(data)),
+		StatusCode:    status,
+		Status:        http.StatusText(status),
+		Header:        http.Header{"Content-Type": []string{"application/json"}},
+		ContentLength: int64(len(data)),
+		Body:          io.NopCloser(bytes.NewReader(data)),
 	}
 }
 
 func textResponse(status int, body string) *http.Response {
+	data := []byte(body)
 	return &http.Response{
-		StatusCode: status,
-		Status:     http.StatusText(status),
-		Header:     http.Header{"Content-Type": []string{"text/plain"}},
-		Body:       io.NopCloser(bytes.NewBufferString(body)),
+		StatusCode:    status,
+		Status:        http.StatusText(status),
+		Header:        http.Header{"Content-Type": []string{"text/plain"}},
+		ContentLength: int64(len(data)),
+		Body:          io.NopCloser(bytes.NewReader(data)),
 	}
 }


### PR DESCRIPTION
## Summary

This improves reliability of `spogo status` (especially with the `connect` engine) when Spotify connect-state payloads omit track/device metadata, and upgrades device management ergonomics.

## Problem

Some devices/sessions return sparse connect-state payloads where the currently playing item has a URI/ID but no name/album, and the active device has little to no metadata. This made `status` outputs inconsistent (track/device fields often empty) and could lead to slow/hanging status calls when fallback paths were slow.

## Fix

- Connect playback/status now performs best-effort metadata hydration via Web API:
  - Use Web API `/me/player` to fill missing track/device fields when available.
  - If the track still lacks a name, hydrate via Web API `GetTrack` first (fast), then fall back to the existing connect GraphQL `trackInfo`.
  - If device metadata is missing, hydrate via `/me/player/devices` by ID, and as a last resort pick the single active Web API device.
- Hydration calls are bounded with short per-call timeouts so `status --json` stays responsive under automation.
- Improve connect-state parsing for more playback/device shapes (metadata keys, track_window, etc).

## Device UX

- Add `spogo device show` and `spogo device clear`.
- Add `spogo device set --save` to persist selection to the current profile.
- Add a shared resolver for device selection with exact and unique partial matches (name/id).
- `connect` engine honors `--device`/profile device by auto-transferring before playback commands.

## Tests

- Added unit tests covering connect status hydration paths (track/device), device selection resolver, and CLI device commands.
- Updated test HTTP helpers to include `ContentLength` so Web API JSON decoding behavior matches production client logic.

## Docs

- Document new device subcommands and note `connect` status hydration behavior in README/spec/changelog.
