### PR TITLE
fix: restore library tracks via fetchLibraryTracks

### DIFF
--- a/internal/spotify/connect_extract_collections.go
+++ b/internal/spotify/connect_extract_collections.go
@@ -12,6 +12,52 @@ func extractLibraryV3Items(payload map[string]any, kind string) ([]Item, int) {
 	return extractWrappedCollectionItems(lib, "items", "item", "data", "totalCount", kind)
 }
 
+// extractFetchLibraryTracks navigates the fetchLibraryTracks response path
+// data.me.library.tracks.items[i].track.data to extract track items.
+// The track URI lives at items[i].track._uri (not inside .data), so we
+// inject it into the data map before passing it to extractItem.
+func extractFetchLibraryTracks(payload map[string]any) ([]Item, int) {
+	tracks, ok := getMap(payload, "data", "me", "library", "tracks")
+	if !ok {
+		return nil, 0
+	}
+	rawItems, _ := tracks["items"].([]any)
+	items := make([]Item, 0, len(rawItems))
+	seen := map[string]struct{}{}
+	for _, raw := range rawItems {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		wrapper, ok := m["track"].(map[string]any)
+		if !ok {
+			continue
+		}
+		dataM, ok := wrapper["data"].(map[string]any)
+		if !ok {
+			continue
+		}
+		// _uri is on the wrapper, not inside data
+		if uri, ok := wrapper["_uri"].(string); ok && getString(dataM, "uri") == "" {
+			dataM["uri"] = uri
+		}
+		item, ok := extractItem(dataM, "track")
+		if !ok {
+			continue
+		}
+		if _, dup := seen[item.URI]; dup {
+			continue
+		}
+		seen[item.URI] = struct{}{}
+		items = append(items, item)
+	}
+	total := getInt(tracks, "totalCount")
+	if total == 0 {
+		total = len(items)
+	}
+	return items, total
+}
+
 func extractPlaylistContentItems(payload map[string]any, kind string) ([]Item, int) {
 	content, ok := getMap(payload, "data", "playlistV2", "content")
 	if !ok {

--- a/internal/spotify/connect_extract_collections.go
+++ b/internal/spotify/connect_extract_collections.go
@@ -1,5 +1,7 @@
 package spotify
 
+import "fmt"
+
 // extractLibraryV3Items navigates the specific libraryV3 response path
 // data.me.libraryV3.items[i].item.data to extract items of the given kind.
 // Using a targeted path avoids the duplicates and fake sort-category entries
@@ -16,12 +18,19 @@ func extractLibraryV3Items(payload map[string]any, kind string) ([]Item, int) {
 // data.me.library.tracks.items[i].track.data to extract track items.
 // The track URI lives at items[i].track._uri (not inside .data), so we
 // inject it into the data map before passing it to extractItem.
-func extractFetchLibraryTracks(payload map[string]any) ([]Item, int) {
+func extractFetchLibraryTracks(payload map[string]any) ([]Item, int, error) {
 	tracks, ok := getMap(payload, "data", "me", "library", "tracks")
 	if !ok {
-		return nil, 0
+		return nil, 0, fmt.Errorf("fetchLibraryTracks payload missing data.me.library.tracks")
 	}
-	rawItems, _ := tracks["items"].([]any)
+	rawItemsValue, ok := tracks["items"]
+	if !ok {
+		return nil, 0, fmt.Errorf("fetchLibraryTracks payload missing data.me.library.tracks.items")
+	}
+	rawItems, ok := rawItemsValue.([]any)
+	if !ok {
+		return nil, 0, fmt.Errorf("fetchLibraryTracks payload has invalid data.me.library.tracks.items")
+	}
 	items := make([]Item, 0, len(rawItems))
 	seen := map[string]struct{}{}
 	for _, raw := range rawItems {
@@ -55,7 +64,7 @@ func extractFetchLibraryTracks(payload map[string]any) ([]Item, int) {
 	if total == 0 {
 		total = len(items)
 	}
-	return items, total
+	return items, total, nil
 }
 
 func extractPlaylistContentItems(payload map[string]any, kind string) ([]Item, int) {

--- a/internal/spotify/connect_library.go
+++ b/internal/spotify/connect_library.go
@@ -30,8 +30,7 @@ func (c *ConnectClient) libraryTracks(ctx context.Context, limit, offset int) ([
 	if err != nil {
 		return nil, 0, err
 	}
-	items, total := extractFetchLibraryTracks(payload)
-	return items, total, nil
+	return extractFetchLibraryTracks(payload)
 }
 
 func (c *ConnectClient) libraryAlbums(ctx context.Context, limit, offset int) ([]Item, int, error) {

--- a/internal/spotify/connect_library.go
+++ b/internal/spotify/connect_library.go
@@ -21,11 +21,16 @@ func (c *ConnectClient) playlistTracks(ctx context.Context, id string, limit, of
 }
 
 func (c *ConnectClient) libraryTracks(ctx context.Context, limit, offset int) ([]Item, int, error) {
-	payload, err := c.graphQL(ctx, "libraryV3", libraryV3Variables("Songs", normalizeLibraryLimit(limit), offset))
+	vars := map[string]any{
+		"uri":    "spotify:collection:tracks",
+		"offset": offset,
+		"limit":  normalizeLibraryLimit(limit),
+	}
+	payload, err := c.graphQL(ctx, "fetchLibraryTracks", vars)
 	if err != nil {
 		return nil, 0, err
 	}
-	items, total := extractLibraryV3Items(payload, "track")
+	items, total := extractFetchLibraryTracks(payload)
 	return items, total, nil
 }
 

--- a/internal/spotify/connect_mapping_test.go
+++ b/internal/spotify/connect_mapping_test.go
@@ -39,7 +39,10 @@ func TestExtractFetchLibraryTracks(t *testing.T) {
 			},
 		}}}},
 	}
-	items, total := extractFetchLibraryTracks(payload)
+	items, total, err := extractFetchLibraryTracks(payload)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
 	if total != 2 || len(items) != 2 {
 		t.Fatalf("expected 2 items, got %d (total %d)", len(items), total)
 	}
@@ -67,16 +70,19 @@ func TestExtractFetchLibraryTracksDedupes(t *testing.T) {
 			},
 		}}}},
 	}
-	items, _ := extractFetchLibraryTracks(payload)
+	items, _, err := extractFetchLibraryTracks(payload)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
 	if len(items) != 1 {
 		t.Fatalf("expected 1 deduped item, got %d", len(items))
 	}
 }
 
 func TestExtractFetchLibraryTracksMissingPath(t *testing.T) {
-	items, total := extractFetchLibraryTracks(map[string]any{})
-	if len(items) != 0 || total != 0 {
-		t.Fatalf("expected empty result, got %d items (total %d)", len(items), total)
+	items, total, err := extractFetchLibraryTracks(map[string]any{})
+	if err == nil {
+		t.Fatalf("expected error, got %d items (total %d)", len(items), total)
 	}
 }
 
@@ -95,7 +101,10 @@ func TestExtractFetchLibraryTracksSkipsMalformed(t *testing.T) {
 			},
 		}}}},
 	}
-	items, _ := extractFetchLibraryTracks(payload)
+	items, _, err := extractFetchLibraryTracks(payload)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
 	if len(items) != 1 || items[0].ID != "t2" {
 		t.Fatalf("expected 1 valid item, got %#v", items)
 	}

--- a/internal/spotify/connect_mapping_test.go
+++ b/internal/spotify/connect_mapping_test.go
@@ -23,6 +23,84 @@ func TestExtractItem(t *testing.T) {
 	}
 }
 
+func TestExtractFetchLibraryTracks(t *testing.T) {
+	payload := map[string]any{
+		"data": map[string]any{"me": map[string]any{"library": map[string]any{"tracks": map[string]any{
+			"totalCount": 2,
+			"items": []any{
+				map[string]any{"track": map[string]any{
+					"_uri": "spotify:track:t1",
+					"data": map[string]any{"name": "Song One"},
+				}},
+				map[string]any{"track": map[string]any{
+					"_uri": "spotify:track:t2",
+					"data": map[string]any{"name": "Song Two"},
+				}},
+			},
+		}}}},
+	}
+	items, total := extractFetchLibraryTracks(payload)
+	if total != 2 || len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d (total %d)", len(items), total)
+	}
+	if items[0].ID != "t1" || items[0].Name != "Song One" {
+		t.Fatalf("unexpected first item: %#v", items[0])
+	}
+	if items[1].ID != "t2" || items[1].Name != "Song Two" {
+		t.Fatalf("unexpected second item: %#v", items[1])
+	}
+}
+
+func TestExtractFetchLibraryTracksDedupes(t *testing.T) {
+	payload := map[string]any{
+		"data": map[string]any{"me": map[string]any{"library": map[string]any{"tracks": map[string]any{
+			"totalCount": 1,
+			"items": []any{
+				map[string]any{"track": map[string]any{
+					"_uri": "spotify:track:t1",
+					"data": map[string]any{"name": "Song"},
+				}},
+				map[string]any{"track": map[string]any{
+					"_uri": "spotify:track:t1",
+					"data": map[string]any{"name": "Song"},
+				}},
+			},
+		}}}},
+	}
+	items, _ := extractFetchLibraryTracks(payload)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 deduped item, got %d", len(items))
+	}
+}
+
+func TestExtractFetchLibraryTracksMissingPath(t *testing.T) {
+	items, total := extractFetchLibraryTracks(map[string]any{})
+	if len(items) != 0 || total != 0 {
+		t.Fatalf("expected empty result, got %d items (total %d)", len(items), total)
+	}
+}
+
+func TestExtractFetchLibraryTracksSkipsMalformed(t *testing.T) {
+	payload := map[string]any{
+		"data": map[string]any{"me": map[string]any{"library": map[string]any{"tracks": map[string]any{
+			"totalCount": 0,
+			"items": []any{
+				"not a map",
+				map[string]any{"track": "not a map"},
+				map[string]any{"track": map[string]any{"_uri": "spotify:track:t1"}},
+				map[string]any{"track": map[string]any{
+					"_uri": "spotify:track:t2",
+					"data": map[string]any{"name": "Valid"},
+				}},
+			},
+		}}}},
+	}
+	items, _ := extractFetchLibraryTracks(payload)
+	if len(items) != 1 || items[0].ID != "t2" {
+		t.Fatalf("expected 1 valid item, got %#v", items)
+	}
+}
+
 func TestSearchPaths(t *testing.T) {
 	paths := searchPaths("track")
 	if len(paths) == 0 {

--- a/internal/spotify/connect_pathfinder_info_test.go
+++ b/internal/spotify/connect_pathfinder_info_test.go
@@ -28,16 +28,6 @@ func TestConnectLibraryV3Helpers(t *testing.T) {
 						}}}},
 					}}},
 				}), nil
-			case strings.Contains(variables, `"Songs"`):
-				return jsonResponse(http.StatusOK, map[string]any{
-					"data": map[string]any{"me": map[string]any{"libraryV3": map[string]any{
-						"totalCount": 1,
-						"items": []any{map[string]any{"item": map[string]any{"data": map[string]any{
-							"uri":  "spotify:track:t1",
-							"name": "Song",
-						}}}},
-					}}},
-				}), nil
 			case strings.Contains(variables, `"Albums"`):
 				return jsonResponse(http.StatusOK, map[string]any{
 					"data": map[string]any{"me": map[string]any{"libraryV3": map[string]any{
@@ -49,6 +39,18 @@ func TestConnectLibraryV3Helpers(t *testing.T) {
 					}}},
 				}), nil
 			}
+		case "fetchLibraryTracks":
+			return jsonResponse(http.StatusOK, map[string]any{
+				"data": map[string]any{"me": map[string]any{"library": map[string]any{"tracks": map[string]any{
+					"totalCount": 1,
+					"items": []any{map[string]any{"track": map[string]any{
+						"_uri": "spotify:track:t1",
+						"data": map[string]any{
+							"name": "Song",
+						},
+					}}},
+				}}}},
+			}), nil
 		case "fetchPlaylist":
 			return jsonResponse(http.StatusOK, map[string]any{
 				"data": map[string]any{"playlistV2": map[string]any{"content": map[string]any{
@@ -62,7 +64,7 @@ func TestConnectLibraryV3Helpers(t *testing.T) {
 		return textResponse(http.StatusNotFound, "missing"), nil
 	})
 	client := newConnectClientForTests(transport)
-	for _, op := range []string{"libraryV3", "fetchPlaylist"} {
+	for _, op := range []string{"libraryV3", "fetchPlaylist", "fetchLibraryTracks"} {
 		client.hashes.hashes[op] = "hash"
 	}
 

--- a/internal/spotify/connect_pathfinder_info_test.go
+++ b/internal/spotify/connect_pathfinder_info_test.go
@@ -40,6 +40,19 @@ func TestConnectLibraryV3Helpers(t *testing.T) {
 				}), nil
 			}
 		case "fetchLibraryTracks":
+			var vars map[string]any
+			if err := json.Unmarshal([]byte(req.URL.Query().Get("variables")), &vars); err != nil {
+				t.Fatalf("unmarshal fetchLibraryTracks variables: %v", err)
+			}
+			if got := getString(vars, "uri"); got != "spotify:collection:tracks" {
+				t.Fatalf("fetchLibraryTracks uri = %q", got)
+			}
+			if got := getInt(vars, "limit"); got != 10 {
+				t.Fatalf("fetchLibraryTracks limit = %d", got)
+			}
+			if got := getInt(vars, "offset"); got != 0 {
+				t.Fatalf("fetchLibraryTracks offset = %d", got)
+			}
 			return jsonResponse(http.StatusOK, map[string]any{
 				"data": map[string]any{"me": map[string]any{"library": map[string]any{"tracks": map[string]any{
 					"totalCount": 1,
@@ -83,6 +96,52 @@ func TestConnectLibraryV3Helpers(t *testing.T) {
 	albums, total, err := client.libraryAlbums(context.Background(), 10, 0)
 	if err != nil || total != 1 || len(albums) != 1 || albums[0].ID != "a1" {
 		t.Fatalf("library albums: items=%#v total=%d err=%v", albums, total, err)
+	}
+}
+
+func TestConnectLibraryTracksFallsBackWhenFetchLibraryTracksPayloadDrifts(t *testing.T) {
+	webServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/me/tracks":
+			_ = json.NewEncoder(w).Encode(libraryResponse{
+				Items: []struct {
+					Track trackItem `json:"track"`
+					Album albumItem `json:"album"`
+				}{
+					{Track: trackItem{ID: "t1", URI: "spotify:track:t1", Name: "Song"}},
+				},
+				Total: 1,
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(webServer.Close)
+
+	webClient, err := NewClient(Options{
+		TokenProvider: staticTokenProvider{},
+		BaseURL:       webServer.URL,
+		HTTPClient:    webServer.Client(),
+	})
+	if err != nil {
+		t.Fatalf("web client: %v", err)
+	}
+
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Query().Get("operationName") != "fetchLibraryTracks" {
+			return textResponse(http.StatusNotFound, "missing"), nil
+		}
+		return jsonResponse(http.StatusOK, map[string]any{
+			"data": map[string]any{"me": map[string]any{"library": map[string]any{}}},
+		}), nil
+	})
+	client := newConnectClientForTests(transport)
+	client.web = webClient
+	client.hashes.hashes["fetchLibraryTracks"] = "hash"
+
+	items, total, err := client.LibraryTracks(context.Background(), 10, 0)
+	if err != nil || total != 1 || len(items) != 1 || items[0].ID != "t1" {
+		t.Fatalf("library tracks fallback: items=%#v total=%d err=%v", items, total, err)
 	}
 }
 


### PR DESCRIPTION
## Problem

`spogo library tracks list` could return an empty success from the Connect client.

The previous implementation queried `libraryV3` with the `Songs` filter. In current Spotify responses, that request behaves like an invalid liked-songs path: the payload can include `LibraryInvalidFilterIdError` while still decoding to zero items, so the web API fallback never activates.

Liked songs are available through `fetchLibraryTracks` for `spotify:collection:tracks`, but that operation returns a different shape: `data.me.library.tracks.items[].track.data`, with `_uri` on the `track` wrapper rather than inside `data`.

## Changes

- Switch `libraryTracks()` from `libraryV3` to `fetchLibraryTracks` with `spotify:collection:tracks`.
- Add a dedicated extractor for the `fetchLibraryTracks` payload and inject `_uri` into the extracted track data before mapping.
- Treat missing or malformed `fetchLibraryTracks` payloads as errors so `LibraryTracks()` falls back to the web API instead of silently returning an empty result.
- Tighten tests to validate the `fetchLibraryTracks` request variables and cover the fallback path when the response shape drifts.

## Testing

- `go test ./...`
- Manually verified `spogo library tracks list --limit 5`
- Manually verified `spogo library tracks list --limit 3 --json`
