### PR TITLE
fix: fall back to Web API when no active device for play command

### DIFF
--- a/internal/spotify/connect_commands.go
+++ b/internal/spotify/connect_commands.go
@@ -42,10 +42,19 @@ func (c *ConnectClient) transferViaWebAPI(ctx context.Context, deviceID string) 
 
 func (c *ConnectClient) play(ctx context.Context, uri string) error {
 	return withConnectStateErr(ctx, c, func(state connectState) error {
+		if state.activeDeviceID == "" {
+			return c.playViaWebAPI(ctx, uri)
+		}
 		if uri == "" {
 			return c.sendPlayerCommand(ctx, state, "resume", nil)
 		}
 		return c.sendPlayerCommand(ctx, state, "play", playCommandPayload(uri))
+	})
+}
+
+func (c *ConnectClient) playViaWebAPI(ctx context.Context, uri string) error {
+	return withWebFallback(c, func(web *Client) error {
+		return web.Play(ctx, uri)
 	})
 }
 

--- a/internal/spotify/connect_playback_test.go
+++ b/internal/spotify/connect_playback_test.go
@@ -187,6 +187,51 @@ func TestConnectTransferFallsBackToWebAPIWithoutOriginDevice(t *testing.T) {
 	}
 }
 
+func TestConnectPlayFallsBackToWebAPIWithoutActiveDevice(t *testing.T) {
+	statePayload := map[string]any{
+		"devices": map[string]any{
+			"device-1": map[string]any{
+				"name":        "Desk",
+				"device_type": "computer",
+			},
+		},
+		"player_state": map[string]any{
+			"is_paused": true,
+		},
+	}
+	var sawWebPlay bool
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/devices/hobs_"):
+			return jsonResponse(http.StatusOK, statePayload), nil
+		case req.Method == http.MethodPut && req.URL.Path == "/v1/me/player/play":
+			sawWebPlay = true
+			return textResponse(http.StatusNoContent, ""), nil
+		case req.Method == http.MethodPost:
+			t.Fatalf("unexpected connect command: %s", req.URL.Path)
+			return nil, nil
+		default:
+			return textResponse(http.StatusNotFound, "missing"), nil
+		}
+	})
+	client := newRegisteredConnectClientForTests(transport)
+	webClient, err := NewClient(Options{
+		TokenProvider: staticTokenProvider{},
+		HTTPClient:    client.client,
+	})
+	if err != nil {
+		t.Fatalf("new web client: %v", err)
+	}
+	client.web = webClient
+
+	if err := client.Play(context.Background(), "spotify:track:abc"); err != nil {
+		t.Fatalf("play: %v", err)
+	}
+	if !sawWebPlay {
+		t.Fatalf("expected web play fallback")
+	}
+}
+
 func TestSendPlayerCommandMissingDevice(t *testing.T) {
 	client := newConnectClientForTests(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		return textResponse(http.StatusOK, ""), nil


### PR DESCRIPTION
## Summary

- When no Spotify device is actively playing, `spogo play <track> --device <id>` fails with `missing device id` because the Connect engine's `sendPlayerCommand` requires a non-empty `activeDeviceID`
- Mirror the existing `transfer` fallback pattern: if `state.activeDeviceID == ""`, delegate directly to the Web API's `Play` method via `playViaWebAPI`/`withWebFallback`
- The Web API's `PUT /me/player/play` automatically appends `?device_id=<device>` from the `--device` flag (via `client_request.go`), so playback starts on the correct target device

## Test plan

- [ ] Added `TestConnectPlayFallsBackToWebAPIWithoutActiveDevice` — verifies that when the Connect state has no active device, `Play` routes to `PUT /v1/me/player/play` and does not send a Connect command
- [ ] All existing tests pass: `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)