### PR TITLE
feat: add playlist metadata updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Commands:
 - `play [<id|url>] [--type ...]`, `pause`, `next`, `prev`, `seek`, `volume`, `shuffle`, `repeat`, `status`
 - `queue add|show`
 - `library tracks|albums|artists|playlists`
-- `playlist create|add|remove|tracks`
+- `playlist create|add|prepend|remove|tracks`
 - `device list|set`
 
 Full spec: `docs/spec.md`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -98,7 +98,8 @@ spogo [global flags] <command> [args]
 ### playlists
 
 - `spogo playlist create <name> [--public] [--collab]`
-- `spogo playlist add <playlist> <track...>`
+- `spogo playlist add <playlist> <track-or-album...> [--position N]`
+- `spogo playlist prepend <playlist> <track-or-album...>`
 - `spogo playlist remove <playlist> <track...>`
 - `spogo playlist tracks <playlist> [--limit N]`
 

--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -212,6 +212,15 @@ func (c *Context) cookieSource() (cookies.Source, error) {
 	if c.Profile.CookiePath != "" {
 		return cookies.FileSource{Path: c.Profile.CookiePath}, nil
 	}
+	// Prefer the resolved cookie cache path (created by `spogo auth import` and
+	// used by `spogo auth status`) over browser extraction. This keeps runtime
+	// behavior consistent with auth commands and avoids needing direct browser
+	// cookie access in headless/CI environments.
+	if resolved := c.ResolveCookiePath(); strings.TrimSpace(resolved) != "" {
+		if _, err := os.Stat(resolved); err == nil {
+			return cookies.FileSource{Path: resolved}, nil
+		}
+	}
 	browser := c.Profile.Browser
 	if strings.TrimSpace(browser) == "" {
 		browser = "chrome"

--- a/internal/app/context_test.go
+++ b/internal/app/context_test.go
@@ -301,7 +301,9 @@ func (dummySpotify) PlaylistTracks(context.Context, string, int, int) ([]spotify
 func (dummySpotify) CreatePlaylist(context.Context, string, bool, bool) (spotify.Item, error) {
 	return spotify.Item{}, nil
 }
-func (dummySpotify) AddTracks(context.Context, string, []string) error    { return nil }
+func (dummySpotify) AddTracks(context.Context, string, []string, *int) error {
+	return nil
+}
 func (dummySpotify) RemoveTracks(context.Context, string, []string) error { return nil }
 func (dummySpotify) RecentlyPlayed(context.Context, int) ([]spotify.RecentItem, error) {
 	return nil, nil

--- a/internal/app/context_test.go
+++ b/internal/app/context_test.go
@@ -301,6 +301,9 @@ func (dummySpotify) PlaylistTracks(context.Context, string, int, int) ([]spotify
 func (dummySpotify) CreatePlaylist(context.Context, string, bool, bool) (spotify.Item, error) {
 	return spotify.Item{}, nil
 }
+func (dummySpotify) UpdatePlaylist(context.Context, string, spotify.PlaylistUpdate) (spotify.Item, error) {
+	return spotify.Item{}, nil
+}
 func (dummySpotify) AddTracks(context.Context, string, []string, *int) error {
 	return nil
 }

--- a/internal/app/context_test.go
+++ b/internal/app/context_test.go
@@ -303,3 +303,6 @@ func (dummySpotify) CreatePlaylist(context.Context, string, bool, bool) (spotify
 }
 func (dummySpotify) AddTracks(context.Context, string, []string) error    { return nil }
 func (dummySpotify) RemoveTracks(context.Context, string, []string) error { return nil }
+func (dummySpotify) RecentlyPlayed(context.Context, int) ([]spotify.RecentItem, error) {
+	return nil, nil
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -40,6 +40,7 @@ type CLI struct {
 
 	Queue   QueueCmd   `kong:"cmd,help='Queue operations.'"`
 	Library LibraryCmd `kong:"cmd,help='Library operations.'"`
+	History HistoryCmd `kong:"cmd,help='Recently played tracks.'"`
 	Device  DeviceCmd  `kong:"cmd,help='Playback devices.'"`
 }
 

--- a/internal/cli/history.go
+++ b/internal/cli/history.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/steipete/spogo/internal/app"
+)
+
+type HistoryCmd struct {
+	Limit int `help:"Limit results." default:"20"`
+}
+
+func (cmd *HistoryCmd) Run(ctx *app.Context) error {
+	client, err := ctx.Spotify()
+	if err != nil {
+		return err
+	}
+	limit := cmd.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 50 {
+		limit = 50
+	}
+	items, err := client.RecentlyPlayed(context.Background(), limit)
+	if err != nil {
+		return err
+	}
+
+	var plain, human []string
+	jsonItems := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		playedAt := item.PlayedAt
+		if t, err := time.Parse(time.RFC3339, playedAt); err == nil {
+			playedAt = t.Local().Format("Jan 02 15:04")
+		}
+
+		artists := strings.Join(item.Track.Artists, ", ")
+		plain = append(plain, fmt.Sprintf("%s\t%s\t%s", item.Track.ID, artists, item.Track.Name))
+		human = append(human, fmt.Sprintf("%s  %s — %s", playedAt, artists, item.Track.Name))
+		jsonItems = append(jsonItems, map[string]any{
+			"played_at": item.PlayedAt,
+			"track":     item.Track,
+		})
+	}
+
+	payload := map[string]any{"items": jsonItems}
+	return ctx.Output.Emit(payload, plain, human)
+}

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -20,11 +20,12 @@ type ArtistCmd struct {
 }
 
 type PlaylistCmd struct {
-	Info   InfoPlaylistCmd   `kong:"cmd,help='Playlist info.'"`
-	Create PlaylistCreateCmd `kong:"cmd,help='Create playlist.'"`
-	Add    PlaylistAddCmd    `kong:"cmd,help='Add tracks to playlist.'"`
-	Remove PlaylistRemoveCmd `kong:"cmd,help='Remove tracks from playlist.'"`
-	Tracks PlaylistTracksCmd `kong:"cmd,help='List playlist tracks.'"`
+	Info    InfoPlaylistCmd    `kong:"cmd,help='Playlist info.'"`
+	Create  PlaylistCreateCmd  `kong:"cmd,help='Create playlist.'"`
+	Add     PlaylistAddCmd     `kong:"cmd,help='Add tracks to playlist.'"`
+	Prepend PlaylistPrependCmd `kong:"cmd,help='Prepend tracks or albums to playlist.'"`
+	Remove  PlaylistRemoveCmd  `kong:"cmd,help='Remove tracks from playlist.'"`
+	Tracks  PlaylistTracksCmd  `kong:"cmd,help='List playlist tracks.'"`
 }
 
 type ShowCmd struct {

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -22,6 +22,7 @@ type ArtistCmd struct {
 type PlaylistCmd struct {
 	Info    InfoPlaylistCmd    `kong:"cmd,help='Playlist info.'"`
 	Create  PlaylistCreateCmd  `kong:"cmd,help='Create playlist.'"`
+	Update  PlaylistUpdateCmd  `kong:"cmd,help='Update playlist metadata.'"`
 	Add     PlaylistAddCmd     `kong:"cmd,help='Add tracks to playlist.'"`
 	Prepend PlaylistPrependCmd `kong:"cmd,help='Prepend tracks or albums to playlist.'"`
 	Remove  PlaylistRemoveCmd  `kong:"cmd,help='Remove tracks from playlist.'"`

--- a/internal/cli/playlist.go
+++ b/internal/cli/playlist.go
@@ -165,10 +165,6 @@ func playlistItemURIs(client spotify.API, inputs []string) ([]string, error) {
 			}
 			return nil, fmt.Errorf("invalid playlist item %s", input)
 		case "track":
-			res, err = spotify.ParseTypedID(strings.TrimSpace(input), "track")
-			if err != nil {
-				return nil, err
-			}
 			if res.URI == "" {
 				return nil, fmt.Errorf("invalid track input")
 			}
@@ -198,19 +194,24 @@ func resolveUntypedPlaylistItem(
 	if trackErr == nil && track.URI != "" {
 		return &track, nil, nil
 	}
+	if trackErr == nil {
+		trackErr = fmt.Errorf("track %s has no URI", id)
+	}
 
 	album, albumErr := client.GetAlbum(context.Background(), id)
 	if albumErr == nil && album.URI != "" {
 		return nil, &album, nil
 	}
+	if albumErr == nil {
+		albumErr = fmt.Errorf("album %s has no URI", id)
+	}
 
-	if trackErr != nil {
-		return nil, nil, trackErr
-	}
-	if albumErr != nil {
-		return nil, nil, albumErr
-	}
-	return nil, nil, fmt.Errorf("could not resolve Spotify item %s", id)
+	return nil, nil, fmt.Errorf(
+		"could not resolve Spotify item %s as track (%v) or album (%v)",
+		id,
+		trackErr,
+		albumErr,
+	)
 }
 
 func albumTrackURIs(album spotify.Item, input string) ([]string, error) {
@@ -219,10 +220,13 @@ func albumTrackURIs(album spotify.Item, input string) ([]string, error) {
 	}
 	uris := make([]string, 0, len(album.Tracks))
 	for _, track := range album.Tracks {
-		if track.URI == "" {
-			return nil, fmt.Errorf("album %s returned an invalid track", input)
+		if track.URI == "" || !strings.HasPrefix(track.URI, "spotify:track:") {
+			continue
 		}
 		uris = append(uris, track.URI)
+	}
+	if len(uris) == 0 {
+		return nil, fmt.Errorf("album %s has no playable tracks", input)
 	}
 	return uris, nil
 }

--- a/internal/cli/playlist.go
+++ b/internal/cli/playlist.go
@@ -17,13 +17,13 @@ type PlaylistCreateCmd struct {
 }
 
 type PlaylistUpdateCmd struct {
-	Playlist    string `arg:"" required:"" help:"Playlist ID/URL/URI."`
-	Name        string `help:"New playlist name."`
-	Description string `help:"New playlist description."`
-	Public      bool   `help:"Set playlist public."`
-	Private     bool   `help:"Set playlist private."`
-	Collab      bool   `help:"Set playlist collaborative."`
-	NonCollab   bool   `name:"non-collab" help:"Set playlist non-collaborative."`
+	Playlist    string  `arg:"" required:"" help:"Playlist ID/URL/URI."`
+	Name        string  `help:"New playlist name."`
+	Description *string `help:"New playlist description."`
+	Public      bool    `help:"Set playlist public."`
+	Private     bool    `help:"Set playlist private."`
+	Collab      bool    `help:"Set playlist collaborative."`
+	NonCollab   bool    `name:"non-collab" help:"Set playlist non-collaborative."`
 }
 
 type PlaylistAddCmd struct {
@@ -276,8 +276,8 @@ func (cmd *PlaylistUpdateCmd) updatePayload() (spotify.PlaylistUpdate, error) {
 		name := cmd.Name
 		update.Name = &name
 	}
-	if cmd.Description != "" {
-		description := cmd.Description
+	if cmd.Description != nil {
+		description := *cmd.Description
 		update.Description = &description
 	}
 	if cmd.Public && cmd.Private {

--- a/internal/cli/playlist.go
+++ b/internal/cli/playlist.go
@@ -16,6 +16,16 @@ type PlaylistCreateCmd struct {
 	Collab bool   `help:"Create collaborative playlist."`
 }
 
+type PlaylistUpdateCmd struct {
+	Playlist    string `arg:"" required:"" help:"Playlist ID/URL/URI."`
+	Name        string `help:"New playlist name."`
+	Description string `help:"New playlist description."`
+	Public      bool   `help:"Set playlist public."`
+	Private     bool   `help:"Set playlist private."`
+	Collab      bool   `help:"Set playlist collaborative."`
+	NonCollab   bool   `name:"non-collab" help:"Set playlist non-collaborative."`
+}
+
 type PlaylistAddCmd struct {
 	Playlist string   `arg:"" required:"" help:"Playlist ID/URL/URI."`
 	Items    []string `arg:"" required:"" help:"Track or album IDs/URLs/URIs."`
@@ -49,6 +59,28 @@ func (cmd *PlaylistCreateCmd) Run(ctx *app.Context) error {
 	}
 	plain := []string{itemPlain(item)}
 	human := []string{fmt.Sprintf("Created %s", itemHuman(ctx.Output, item))}
+	return ctx.Output.Emit(item, plain, human)
+}
+
+func (cmd *PlaylistUpdateCmd) Run(ctx *app.Context) error {
+	client, err := ctx.Spotify()
+	if err != nil {
+		return err
+	}
+	playlist, err := spotify.ParseTypedID(cmd.Playlist, "playlist")
+	if err != nil {
+		return err
+	}
+	update, err := cmd.updatePayload()
+	if err != nil {
+		return err
+	}
+	item, err := client.UpdatePlaylist(context.Background(), playlist.ID, update)
+	if err != nil {
+		return err
+	}
+	plain := []string{itemPlain(item)}
+	human := []string{fmt.Sprintf("Updated %s", itemHuman(ctx.Output, item))}
 	return ctx.Output.Emit(item, plain, human)
 }
 
@@ -236,6 +268,44 @@ func validatePosition(position *int) error {
 		return fmt.Errorf("position must be zero or greater")
 	}
 	return nil
+}
+
+func (cmd *PlaylistUpdateCmd) updatePayload() (spotify.PlaylistUpdate, error) {
+	update := spotify.PlaylistUpdate{}
+	if strings.TrimSpace(cmd.Name) != "" {
+		name := cmd.Name
+		update.Name = &name
+	}
+	if cmd.Description != "" {
+		description := cmd.Description
+		update.Description = &description
+	}
+	if cmd.Public && cmd.Private {
+		return spotify.PlaylistUpdate{}, fmt.Errorf("cannot set both public and private")
+	}
+	if cmd.Public {
+		value := true
+		update.Public = &value
+	}
+	if cmd.Private {
+		value := false
+		update.Public = &value
+	}
+	if cmd.Collab && cmd.NonCollab {
+		return spotify.PlaylistUpdate{}, fmt.Errorf("cannot set both collab and non-collab")
+	}
+	if cmd.Collab {
+		value := true
+		update.Collaborative = &value
+	}
+	if cmd.NonCollab {
+		value := false
+		update.Collaborative = &value
+	}
+	if update.Name == nil && update.Description == nil && update.Public == nil && update.Collaborative == nil {
+		return spotify.PlaylistUpdate{}, fmt.Errorf("no playlist updates requested")
+	}
+	return update, nil
 }
 
 func trackURIs(inputs []string) ([]string, error) {

--- a/internal/cli/playlist.go
+++ b/internal/cli/playlist.go
@@ -18,12 +18,18 @@ type PlaylistCreateCmd struct {
 
 type PlaylistAddCmd struct {
 	Playlist string   `arg:"" required:"" help:"Playlist ID/URL/URI."`
-	Tracks   []string `arg:"" required:"" help:"Track IDs/URLs/URIs."`
+	Items    []string `arg:"" required:"" help:"Track or album IDs/URLs/URIs."`
+	Position *int     `help:"Zero-based insertion position. Defaults to append."`
 }
 
 type PlaylistRemoveCmd struct {
 	Playlist string   `arg:"" required:"" help:"Playlist ID/URL/URI."`
 	Tracks   []string `arg:"" required:"" help:"Track IDs/URLs/URIs."`
+}
+
+type PlaylistPrependCmd struct {
+	Playlist string   `arg:"" required:"" help:"Playlist ID/URL/URI."`
+	Items    []string `arg:"" required:"" help:"Track or album IDs/URLs/URIs."`
 }
 
 type PlaylistTracksCmd struct {
@@ -47,24 +53,46 @@ func (cmd *PlaylistCreateCmd) Run(ctx *app.Context) error {
 }
 
 func (cmd *PlaylistAddCmd) Run(ctx *app.Context) error {
+	return runPlaylistAdd(ctx, cmd.Playlist, cmd.Items, cmd.Position)
+}
+
+func (cmd *PlaylistPrependCmd) Run(ctx *app.Context) error {
+	position := 0
+	return runPlaylistAdd(ctx, cmd.Playlist, cmd.Items, &position)
+}
+
+func runPlaylistAdd(
+	ctx *app.Context,
+	playlistInput string,
+	inputs []string,
+	position *int,
+) error {
 	client, err := ctx.Spotify()
 	if err != nil {
 		return err
 	}
-	playlist, err := spotify.ParseTypedID(cmd.Playlist, "playlist")
+	playlist, err := spotify.ParseTypedID(playlistInput, "playlist")
 	if err != nil {
 		return err
 	}
-	uris, err := trackURIs(cmd.Tracks)
+	uris, err := playlistItemURIs(client, inputs)
 	if err != nil {
 		return err
 	}
-	if err := client.AddTracks(context.Background(), playlist.ID, uris); err != nil {
+	if err := validatePosition(position); err != nil {
+		return err
+	}
+	if err := client.AddTracks(context.Background(), playlist.ID, uris, position); err != nil {
 		return err
 	}
 	plain := []string{"ok"}
 	human := []string{fmt.Sprintf("Added %d tracks", len(uris))}
-	return ctx.Output.Emit(map[string]any{"status": "ok", "count": len(uris)}, plain, human)
+	payload := map[string]any{"status": "ok", "count": len(uris)}
+	if position != nil {
+		human = []string{fmt.Sprintf("Added %d tracks at position %d", len(uris), *position)}
+		payload["position"] = *position
+	}
+	return ctx.Output.Emit(payload, plain, human)
 }
 
 func (cmd *PlaylistRemoveCmd) Run(ctx *app.Context) error {
@@ -108,6 +136,102 @@ func (cmd *PlaylistTracksCmd) Run(ctx *app.Context) error {
 	}
 	payload := map[string]any{"total": total, "items": items}
 	return ctx.Output.Emit(payload, plain, human)
+}
+
+func playlistItemURIs(client spotify.API, inputs []string) ([]string, error) {
+	uris := make([]string, 0, len(inputs))
+	for _, input := range inputs {
+		res, err := spotify.ParseResource(strings.TrimSpace(input))
+		if err != nil {
+			return nil, err
+		}
+		switch res.Type {
+		case "":
+			track, album, err := resolveUntypedPlaylistItem(client, res.ID)
+			if err != nil {
+				return nil, err
+			}
+			if track != nil {
+				uris = append(uris, track.URI)
+				continue
+			}
+			if album != nil {
+				albumURIs, err := albumTrackURIs(*album, input)
+				if err != nil {
+					return nil, err
+				}
+				uris = append(uris, albumURIs...)
+				continue
+			}
+			return nil, fmt.Errorf("invalid playlist item %s", input)
+		case "track":
+			res, err = spotify.ParseTypedID(strings.TrimSpace(input), "track")
+			if err != nil {
+				return nil, err
+			}
+			if res.URI == "" {
+				return nil, fmt.Errorf("invalid track input")
+			}
+			uris = append(uris, res.URI)
+		case "album":
+			album, err := client.GetAlbum(context.Background(), res.ID)
+			if err != nil {
+				return nil, err
+			}
+			albumURIs, err := albumTrackURIs(album, input)
+			if err != nil {
+				return nil, err
+			}
+			uris = append(uris, albumURIs...)
+		default:
+			return nil, fmt.Errorf("playlist add supports tracks and albums, got %s", res.Type)
+		}
+	}
+	return uris, nil
+}
+
+func resolveUntypedPlaylistItem(
+	client spotify.API,
+	id string,
+) (*spotify.Item, *spotify.Item, error) {
+	track, trackErr := client.GetTrack(context.Background(), id)
+	if trackErr == nil && track.URI != "" {
+		return &track, nil, nil
+	}
+
+	album, albumErr := client.GetAlbum(context.Background(), id)
+	if albumErr == nil && album.URI != "" {
+		return nil, &album, nil
+	}
+
+	if trackErr != nil {
+		return nil, nil, trackErr
+	}
+	if albumErr != nil {
+		return nil, nil, albumErr
+	}
+	return nil, nil, fmt.Errorf("could not resolve Spotify item %s", id)
+}
+
+func albumTrackURIs(album spotify.Item, input string) ([]string, error) {
+	if len(album.Tracks) == 0 {
+		return nil, fmt.Errorf("album %s has no playable tracks", input)
+	}
+	uris := make([]string, 0, len(album.Tracks))
+	for _, track := range album.Tracks {
+		if track.URI == "" {
+			return nil, fmt.Errorf("album %s returned an invalid track", input)
+		}
+		uris = append(uris, track.URI)
+	}
+	return uris, nil
+}
+
+func validatePosition(position *int) error {
+	if position != nil && *position < 0 {
+		return fmt.Errorf("position must be zero or greater")
+	}
+	return nil
 }
 
 func trackURIs(inputs []string) ([]string, error) {

--- a/internal/cli/playlist_more_test.go
+++ b/internal/cli/playlist_more_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/alecthomas/kong"
 	"github.com/steipete/spogo/internal/output"
 	"github.com/steipete/spogo/internal/spotify"
 	"github.com/steipete/spogo/internal/testutil"
@@ -140,7 +141,7 @@ func TestPlaylistUpdateCmd(t *testing.T) {
 	cmd := PlaylistUpdateCmd{
 		Playlist:    "spotify:playlist:p1",
 		Name:        "Renamed",
-		Description: "New description",
+		Description: func() *string { value := "New description"; return &value }(),
 		Private:     true,
 		Collab:      true,
 	}
@@ -149,6 +150,24 @@ func TestPlaylistUpdateCmd(t *testing.T) {
 	}
 	if out.String() == "" {
 		t.Fatalf("expected output")
+	}
+}
+
+func TestPlaylistUpdateCmdParsesEmptyDescriptionAsExplicitUpdate(t *testing.T) {
+	command := New()
+	parser, err := kong.New(command, kong.Name("spogo"), kong.Vars(VersionVars()))
+	if err != nil {
+		t.Fatalf("parser: %v", err)
+	}
+	if _, err := parser.Parse([]string{"playlist", "update", "spotify:playlist:p1", "--description="}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	update, err := command.Playlist.Update.updatePayload()
+	if err != nil {
+		t.Fatalf("update payload: %v", err)
+	}
+	if update.Description == nil || *update.Description != "" {
+		t.Fatalf("expected explicit empty description update, got %#v", update.Description)
 	}
 }
 

--- a/internal/cli/playlist_more_test.go
+++ b/internal/cli/playlist_more_test.go
@@ -111,6 +111,47 @@ func TestPlaylistCreateCmdError(t *testing.T) {
 	}
 }
 
+func TestPlaylistUpdateCmd(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatPlain)
+	ctx.SetSpotify(&testutil.SpotifyMock{
+		UpdatePlaylistFn: func(
+			ctx context.Context,
+			playlistID string,
+			update spotify.PlaylistUpdate,
+		) (spotify.Item, error) {
+			if playlistID != "p1" {
+				t.Fatalf("playlistID = %s", playlistID)
+			}
+			if update.Name == nil || *update.Name != "Renamed" {
+				t.Fatalf("unexpected name: %#v", update.Name)
+			}
+			if update.Description == nil || *update.Description != "New description" {
+				t.Fatalf("unexpected description: %#v", update.Description)
+			}
+			if update.Public == nil || *update.Public {
+				t.Fatalf("unexpected public: %#v", update.Public)
+			}
+			if update.Collaborative == nil || !*update.Collaborative {
+				t.Fatalf("unexpected collaborative: %#v", update.Collaborative)
+			}
+			return spotify.Item{ID: playlistID, Name: "Renamed", Type: "playlist"}, nil
+		},
+	})
+	cmd := PlaylistUpdateCmd{
+		Playlist:    "spotify:playlist:p1",
+		Name:        "Renamed",
+		Description: "New description",
+		Private:     true,
+		Collab:      true,
+	}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out.String() == "" {
+		t.Fatalf("expected output")
+	}
+}
+
 func TestPlaylistTracksCmdError(t *testing.T) {
 	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
 	ctx.SetSpotify(&testutil.SpotifyMock{

--- a/internal/cli/playlist_more_test.go
+++ b/internal/cli/playlist_more_test.go
@@ -13,17 +13,57 @@ import (
 
 func TestPlaylistAddCmdInvalidPlaylist(t *testing.T) {
 	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
-	ctx.SetSpotify(&testutil.SpotifyMock{AddTracksFn: func(ctx context.Context, playlistID string, uris []string) error { return nil }})
-	cmd := PlaylistAddCmd{Playlist: "spotify:track:t1", Tracks: []string{"spotify:track:t1"}}
+	ctx.SetSpotify(&testutil.SpotifyMock{
+		AddTracksFn: func(
+			ctx context.Context,
+			playlistID string,
+			uris []string,
+			position *int,
+		) error {
+			return nil
+		},
+	})
+	cmd := PlaylistAddCmd{
+		Playlist: "spotify:track:t1",
+		Items:    []string{"spotify:track:t1"},
+	}
 	if err := cmd.Run(ctx); err == nil {
 		t.Fatalf("expected error")
 	}
 }
 
-func TestPlaylistAddCmdInvalidTrack(t *testing.T) {
+func TestPlaylistAddCmdRejectsUnsupportedType(t *testing.T) {
 	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
-	ctx.SetSpotify(&testutil.SpotifyMock{AddTracksFn: func(ctx context.Context, playlistID string, uris []string) error { return nil }})
-	cmd := PlaylistAddCmd{Playlist: "spotify:playlist:p1", Tracks: []string{"spotify:album:a1"}}
+	ctx.SetSpotify(&testutil.SpotifyMock{
+		AddTracksFn: func(
+			ctx context.Context,
+			playlistID string,
+			uris []string,
+			position *int,
+		) error {
+			return nil
+		},
+	})
+	cmd := PlaylistAddCmd{
+		Playlist: "spotify:playlist:p1",
+		Items:    []string{"spotify:artist:a1"},
+	}
+	if err := cmd.Run(ctx); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestPlaylistAddCmdAlbumWithoutTracks(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	ctx.SetSpotify(&testutil.SpotifyMock{
+		GetAlbumFn: func(ctx context.Context, id string) (spotify.Item, error) {
+			return spotify.Item{ID: id, Type: "album", Name: "Album"}, nil
+		},
+	})
+	cmd := PlaylistAddCmd{
+		Playlist: "spotify:playlist:p1",
+		Items:    []string{"spotify:album:a1"},
+	}
 	if err := cmd.Run(ctx); err == nil {
 		t.Fatalf("expected error")
 	}

--- a/internal/cli/playlist_test.go
+++ b/internal/cli/playlist_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/steipete/spogo/internal/output"
@@ -160,6 +161,65 @@ func TestPlaylistPrependCmdBareAlbumID(t *testing.T) {
 	}
 	if err := cmd.Run(ctx); err != nil {
 		t.Fatalf("run: %v", err)
+	}
+}
+
+func TestPlaylistAddCmdSkipsInvalidAlbumTracks(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetAlbumFn: func(ctx context.Context, id string) (spotify.Item, error) {
+			return spotify.Item{
+				ID:   id,
+				Type: "album",
+				Name: "Album",
+				URI:  "spotify:album:" + id,
+				Tracks: []spotify.Item{
+					{ID: "bad", URI: "", Type: "track"},
+					{ID: "local", URI: "spotify:local:artist:album:song", Type: "track"},
+					{ID: "ok", URI: "spotify:track:t1", Type: "track"},
+				},
+			}, nil
+		},
+		AddTracksFn: func(
+			ctx context.Context,
+			playlistID string,
+			uris []string,
+			position *int,
+		) error {
+			if len(uris) != 1 || uris[0] != "spotify:track:t1" {
+				t.Fatalf("uris: %#v", uris)
+			}
+			return nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := PlaylistAddCmd{
+		Playlist: "spotify:playlist:p1",
+		Items:    []string{"spotify:album:a1"},
+	}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+}
+
+func TestResolveUntypedPlaylistItemReturnsCombinedError(t *testing.T) {
+	mock := &testutil.SpotifyMock{
+		GetTrackFn: func(ctx context.Context, id string) (spotify.Item, error) {
+			return spotify.Item{ID: id, Type: "track"}, nil
+		},
+		GetAlbumFn: func(ctx context.Context, id string) (spotify.Item, error) {
+			return spotify.Item{}, errors.New("album lookup failed")
+		},
+	}
+	_, _, err := resolveUntypedPlaylistItem(mock, "x1")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "track x1 has no URI") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "album lookup failed") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/cli/playlist_test.go
+++ b/internal/cli/playlist_test.go
@@ -14,7 +14,12 @@ func TestPlaylistAddCmd(t *testing.T) {
 	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
 	called := false
 	mock := &testutil.SpotifyMock{
-		AddTracksFn: func(ctx context.Context, playlistID string, uris []string) error {
+		AddTracksFn: func(
+			ctx context.Context,
+			playlistID string,
+			uris []string,
+			position *int,
+		) error {
 			called = true
 			if playlistID != "p1" {
 				t.Fatalf("playlist id %s", playlistID)
@@ -22,11 +27,17 @@ func TestPlaylistAddCmd(t *testing.T) {
 			if len(uris) != 1 || uris[0] != "spotify:track:t1" {
 				t.Fatalf("uris: %#v", uris)
 			}
+			if position != nil {
+				t.Fatalf("expected append, got position %d", *position)
+			}
 			return nil
 		},
 	}
 	ctx.SetSpotify(mock)
-	cmd := PlaylistAddCmd{Playlist: "spotify:playlist:p1", Tracks: []string{"spotify:track:t1"}}
+	cmd := PlaylistAddCmd{
+		Playlist: "spotify:playlist:p1",
+		Items:    []string{"spotify:track:t1"},
+	}
 	if err := cmd.Run(ctx); err != nil {
 		t.Fatalf("run: %v", err)
 	}
@@ -38,14 +49,117 @@ func TestPlaylistAddCmd(t *testing.T) {
 func TestPlaylistAddCmdError(t *testing.T) {
 	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
 	mock := &testutil.SpotifyMock{
-		AddTracksFn: func(ctx context.Context, playlistID string, uris []string) error {
+		AddTracksFn: func(
+			ctx context.Context,
+			playlistID string,
+			uris []string,
+			position *int,
+		) error {
 			return errors.New("boom")
 		},
 	}
 	ctx.SetSpotify(mock)
-	cmd := PlaylistAddCmd{Playlist: "spotify:playlist:p1", Tracks: []string{"spotify:track:t1"}}
+	cmd := PlaylistAddCmd{
+		Playlist: "spotify:playlist:p1",
+		Items:    []string{"spotify:track:t1"},
+	}
 	if err := cmd.Run(ctx); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestPlaylistPrependCmdAlbum(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	called := false
+	mock := &testutil.SpotifyMock{
+		GetTrackFn: func(ctx context.Context, id string) (spotify.Item, error) {
+			return spotify.Item{}, errors.New("not a track")
+		},
+		GetAlbumFn: func(ctx context.Context, id string) (spotify.Item, error) {
+			return spotify.Item{
+				ID:   id,
+				Type: "album",
+				Name: "Album",
+				Tracks: []spotify.Item{
+					{ID: "t1", URI: "spotify:track:t1", Type: "track"},
+					{ID: "t2", URI: "spotify:track:t2", Type: "track"},
+				},
+			}, nil
+		},
+		AddTracksFn: func(
+			ctx context.Context,
+			playlistID string,
+			uris []string,
+			position *int,
+		) error {
+			called = true
+			if playlistID != "p1" {
+				t.Fatalf("playlist id %s", playlistID)
+			}
+			if len(uris) != 2 ||
+				uris[0] != "spotify:track:t1" ||
+				uris[1] != "spotify:track:t2" {
+				t.Fatalf("uris: %#v", uris)
+			}
+			if position == nil || *position != 0 {
+				t.Fatalf("expected prepend position 0, got %#v", position)
+			}
+			return nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := PlaylistPrependCmd{
+		Playlist: "spotify:playlist:p1",
+		Items:    []string{"spotify:album:a1"},
+	}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !called {
+		t.Fatalf("expected call")
+	}
+}
+
+func TestPlaylistPrependCmdBareAlbumID(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetTrackFn: func(ctx context.Context, id string) (spotify.Item, error) {
+			return spotify.Item{}, errors.New("not a track")
+		},
+		GetAlbumFn: func(ctx context.Context, id string) (spotify.Item, error) {
+			return spotify.Item{
+				ID:   id,
+				Type: "album",
+				Name: "Album",
+				URI:  "spotify:album:" + id,
+				Tracks: []spotify.Item{
+					{ID: "t1", URI: "spotify:track:t1", Type: "track"},
+					{ID: "t2", URI: "spotify:track:t2", Type: "track"},
+				},
+			}, nil
+		},
+		AddTracksFn: func(
+			ctx context.Context,
+			playlistID string,
+			uris []string,
+			position *int,
+		) error {
+			if len(uris) != 2 {
+				t.Fatalf("uris: %#v", uris)
+			}
+			if position == nil || *position != 0 {
+				t.Fatalf("position: %#v", position)
+			}
+			return nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := PlaylistPrependCmd{
+		Playlist: "spotify:playlist:p1",
+		Items:    []string{"a1"},
+	}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
 	}
 }
 

--- a/internal/spotify/api.go
+++ b/internal/spotify/api.go
@@ -33,4 +33,5 @@ type API interface {
 	CreatePlaylist(ctx context.Context, name string, public, collaborative bool) (Item, error)
 	AddTracks(ctx context.Context, playlistID string, uris []string) error
 	RemoveTracks(ctx context.Context, playlistID string, uris []string) error
+	RecentlyPlayed(ctx context.Context, limit int) ([]RecentItem, error)
 }

--- a/internal/spotify/api.go
+++ b/internal/spotify/api.go
@@ -31,6 +31,7 @@ type API interface {
 	Playlists(ctx context.Context, limit, offset int) ([]Item, int, error)
 	PlaylistTracks(ctx context.Context, id string, limit, offset int) ([]Item, int, error)
 	CreatePlaylist(ctx context.Context, name string, public, collaborative bool) (Item, error)
+	UpdatePlaylist(ctx context.Context, playlistID string, update PlaylistUpdate) (Item, error)
 	AddTracks(ctx context.Context, playlistID string, uris []string, position *int) error
 	RemoveTracks(ctx context.Context, playlistID string, uris []string) error
 	RecentlyPlayed(ctx context.Context, limit int) ([]RecentItem, error)

--- a/internal/spotify/api.go
+++ b/internal/spotify/api.go
@@ -31,7 +31,7 @@ type API interface {
 	Playlists(ctx context.Context, limit, offset int) ([]Item, int, error)
 	PlaylistTracks(ctx context.Context, id string, limit, offset int) ([]Item, int, error)
 	CreatePlaylist(ctx context.Context, name string, public, collaborative bool) (Item, error)
-	AddTracks(ctx context.Context, playlistID string, uris []string) error
+	AddTracks(ctx context.Context, playlistID string, uris []string, position *int) error
 	RemoveTracks(ctx context.Context, playlistID string, uris []string) error
 	RecentlyPlayed(ctx context.Context, limit int) ([]RecentItem, error)
 }

--- a/internal/spotify/applescript.go
+++ b/internal/spotify/applescript.go
@@ -285,9 +285,14 @@ func (c *AppleScriptClient) CreatePlaylist(ctx context.Context, name string, pub
 	return Item{}, ErrUnsupported
 }
 
-func (c *AppleScriptClient) AddTracks(ctx context.Context, playlistID string, uris []string) error {
+func (c *AppleScriptClient) AddTracks(
+	ctx context.Context,
+	playlistID string,
+	uris []string,
+	position *int,
+) error {
 	if c.fallback != nil {
-		return c.fallback.AddTracks(ctx, playlistID, uris)
+		return c.fallback.AddTracks(ctx, playlistID, uris, position)
 	}
 	return ErrUnsupported
 }

--- a/internal/spotify/applescript.go
+++ b/internal/spotify/applescript.go
@@ -285,6 +285,13 @@ func (c *AppleScriptClient) CreatePlaylist(ctx context.Context, name string, pub
 	return Item{}, ErrUnsupported
 }
 
+func (c *AppleScriptClient) UpdatePlaylist(ctx context.Context, playlistID string, update PlaylistUpdate) (Item, error) {
+	if c.fallback != nil {
+		return c.fallback.UpdatePlaylist(ctx, playlistID, update)
+	}
+	return Item{}, ErrUnsupported
+}
+
 func (c *AppleScriptClient) AddTracks(
 	ctx context.Context,
 	playlistID string,

--- a/internal/spotify/applescript.go
+++ b/internal/spotify/applescript.go
@@ -298,3 +298,10 @@ func (c *AppleScriptClient) RemoveTracks(ctx context.Context, playlistID string,
 	}
 	return ErrUnsupported
 }
+
+func (c *AppleScriptClient) RecentlyPlayed(ctx context.Context, limit int) ([]RecentItem, error) {
+	if c.fallback != nil {
+		return c.fallback.RecentlyPlayed(ctx, limit)
+	}
+	return nil, ErrUnsupported
+}

--- a/internal/spotify/auto.go
+++ b/internal/spotify/auto.go
@@ -236,9 +236,14 @@ func (c *autoClient) CreatePlaylist(ctx context.Context, name string, public, co
 	})
 }
 
-func (c *autoClient) AddTracks(ctx context.Context, playlistID string, uris []string) error {
+func (c *autoClient) AddTracks(
+	ctx context.Context,
+	playlistID string,
+	uris []string,
+	position *int,
+) error {
 	return autoVoid(c, func(api API) error {
-		return api.AddTracks(ctx, playlistID, uris)
+		return api.AddTracks(ctx, playlistID, uris, position)
 	})
 }
 

--- a/internal/spotify/auto.go
+++ b/internal/spotify/auto.go
@@ -231,8 +231,17 @@ func (c *autoClient) PlaylistTracks(ctx context.Context, id string, limit, offse
 }
 
 func (c *autoClient) CreatePlaylist(ctx context.Context, name string, public, collaborative bool) (Item, error) {
+	if c.secondary != nil && public {
+		return c.secondary.CreatePlaylist(ctx, name, public, collaborative)
+	}
 	return autoCall(c, func(api API) (Item, error) {
 		return api.CreatePlaylist(ctx, name, public, collaborative)
+	})
+}
+
+func (c *autoClient) UpdatePlaylist(ctx context.Context, playlistID string, update PlaylistUpdate) (Item, error) {
+	return autoCall(c, func(api API) (Item, error) {
+		return api.UpdatePlaylist(ctx, playlistID, update)
 	})
 }
 

--- a/internal/spotify/auto.go
+++ b/internal/spotify/auto.go
@@ -247,3 +247,9 @@ func (c *autoClient) RemoveTracks(ctx context.Context, playlistID string, uris [
 		return api.RemoveTracks(ctx, playlistID, uris)
 	})
 }
+
+func (c *autoClient) RecentlyPlayed(ctx context.Context, limit int) ([]RecentItem, error) {
+	return autoCall(c, func(api API) ([]RecentItem, error) {
+		return api.RecentlyPlayed(ctx, limit)
+	})
+}

--- a/internal/spotify/auto_playlist_test.go
+++ b/internal/spotify/auto_playlist_test.go
@@ -1,0 +1,71 @@
+package spotify_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steipete/spogo/internal/spotify"
+	"github.com/steipete/spogo/internal/testutil"
+)
+
+func TestAutoClientCreatePlaylistUsesConnectClientForCollaborativePlaylists(t *testing.T) {
+	auto := spotify.NewAutoClient(
+		&testutil.SpotifyMock{
+			CreatePlaylistFn: func(
+				ctx context.Context,
+				name string,
+				public bool,
+				collaborative bool,
+			) (spotify.Item, error) {
+				if name != "Shared" || public || !collaborative {
+					t.Fatalf("unexpected args: %q %v %v", name, public, collaborative)
+				}
+				return spotify.Item{ID: "p1", Name: name, Type: "playlist"}, nil
+			},
+		},
+		&testutil.SpotifyMock{
+			CreatePlaylistFn: func(context.Context, string, bool, bool) (spotify.Item, error) {
+				t.Fatalf("expected connect client for collaborative playlist creation")
+				return spotify.Item{}, nil
+			},
+		},
+	)
+
+	item, err := auto.CreatePlaylist(context.Background(), "Shared", false, true)
+	if err != nil {
+		t.Fatalf("create playlist: %v", err)
+	}
+	if item.ID != "p1" {
+		t.Fatalf("unexpected item id: %s", item.ID)
+	}
+}
+
+func TestAutoClientUpdatePlaylistPrefersConnectAndFallsBackOnUnsupported(t *testing.T) {
+	name := "Renamed"
+	auto := spotify.NewAutoClient(
+		&testutil.SpotifyMock{
+			UpdatePlaylistFn: func(context.Context, string, spotify.PlaylistUpdate) (spotify.Item, error) {
+				return spotify.Item{}, spotify.ErrUnsupported
+			},
+		},
+		&testutil.SpotifyMock{
+			UpdatePlaylistFn: func(_ context.Context, playlistID string, update spotify.PlaylistUpdate) (spotify.Item, error) {
+				if playlistID != "p1" {
+					t.Fatalf("unexpected playlist id: %s", playlistID)
+				}
+				if update.Name == nil || *update.Name != name {
+					t.Fatalf("unexpected update: %#v", update)
+				}
+				return spotify.Item{ID: playlistID, Name: name, Type: "playlist"}, nil
+			},
+		},
+	)
+
+	item, err := auto.UpdatePlaylist(context.Background(), "p1", spotify.PlaylistUpdate{Name: &name})
+	if err != nil {
+		t.Fatalf("update playlist: %v", err)
+	}
+	if item.Name != name {
+		t.Fatalf("unexpected item: %#v", item)
+	}
+}

--- a/internal/spotify/auto_test.go
+++ b/internal/spotify/auto_test.go
@@ -195,7 +195,7 @@ func TestAutoPassThrough(t *testing.T) {
 	_, _, _ = client.Playlists(ctx, 1, 0)
 	_, _, _ = client.PlaylistTracks(ctx, "1", 1, 0)
 	_, _ = client.CreatePlaylist(ctx, "name", false, false)
-	_ = client.AddTracks(ctx, "1", []string{"spotify:track:1"})
+	_ = client.AddTracks(ctx, "1", []string{"spotify:track:1"}, nil)
 	_ = client.RemoveTracks(ctx, "1", []string{"spotify:track:1"})
 
 	if len(webCalls) != 0 {

--- a/internal/spotify/client.go
+++ b/internal/spotify/client.go
@@ -395,6 +395,29 @@ func (c *Client) CreatePlaylist(ctx context.Context, name string, public, collab
 	return mapPlaylist(raw), nil
 }
 
+func (c *Client) UpdatePlaylist(ctx context.Context, playlistID string, update PlaylistUpdate) (Item, error) {
+	payload := map[string]any{}
+	if update.Name != nil {
+		payload["name"] = *update.Name
+	}
+	if update.Public != nil {
+		payload["public"] = *update.Public
+	}
+	if update.Collaborative != nil {
+		payload["collaborative"] = *update.Collaborative
+	}
+	if update.Description != nil {
+		payload["description"] = *update.Description
+	}
+	if len(payload) == 0 {
+		return c.GetPlaylist(ctx, playlistID)
+	}
+	if err := c.put(ctx, "/playlists/"+playlistID, payload); err != nil {
+		return Item{}, err
+	}
+	return c.GetPlaylist(ctx, playlistID)
+}
+
 func (c *Client) albumTracks(
 	ctx context.Context,
 	id string,

--- a/internal/spotify/client.go
+++ b/internal/spotify/client.go
@@ -102,7 +102,19 @@ func (c *Client) GetAlbum(ctx context.Context, id string) (Item, error) {
 	if err := c.get(ctx, "/albums/"+id, url.Values{}, &raw); err != nil {
 		return Item{}, err
 	}
-	return mapAlbum(raw), nil
+	item := mapAlbum(raw)
+	totalTracks := raw.Tracks.Total
+	if totalTracks == 0 {
+		totalTracks = raw.TotalTracks
+	}
+	for offset := len(item.Tracks); offset < totalTracks; offset += 50 {
+		page, err := c.albumTracks(ctx, id, 50, offset)
+		if err != nil {
+			return Item{}, err
+		}
+		item.Tracks = append(item.Tracks, page...)
+	}
+	return item, nil
 }
 
 func (c *Client) GetArtist(ctx context.Context, id string) (Item, error) {
@@ -383,9 +395,35 @@ func (c *Client) CreatePlaylist(ctx context.Context, name string, public, collab
 	return mapPlaylist(raw), nil
 }
 
-func (c *Client) AddTracks(ctx context.Context, playlistID string, uris []string) error {
+func (c *Client) albumTracks(ctx context.Context, id string, limit, offset int) ([]Item, error) {
+	params := url.Values{}
+	params.Set("limit", fmt.Sprint(limit))
+	params.Set("offset", fmt.Sprint(offset))
+	var raw albumTracksPage
+	if err := c.get(ctx, "/albums/"+id+"/tracks", params, &raw); err != nil {
+		return nil, err
+	}
+	items := make([]Item, 0, len(raw.Items))
+	for _, track := range raw.Items {
+		if track.ID == "" {
+			continue
+		}
+		items = append(items, mapAlbumTrack(track, ""))
+	}
+	return items, nil
+}
+
+func (c *Client) AddTracks(
+	ctx context.Context,
+	playlistID string,
+	uris []string,
+	position *int,
+) error {
 	payload := map[string]any{
 		"uris": uris,
+	}
+	if position != nil {
+		payload["position"] = *position
 	}
 	return c.postJSON(ctx, "/playlists/"+playlistID+"/tracks", payload, nil)
 }

--- a/internal/spotify/client.go
+++ b/internal/spotify/client.go
@@ -108,7 +108,7 @@ func (c *Client) GetAlbum(ctx context.Context, id string) (Item, error) {
 		totalTracks = raw.TotalTracks
 	}
 	for offset := len(item.Tracks); offset < totalTracks; offset += 50 {
-		page, err := c.albumTracks(ctx, id, 50, offset)
+		page, err := c.albumTracks(ctx, id, item.Name, 50, offset)
 		if err != nil {
 			return Item{}, err
 		}
@@ -395,7 +395,13 @@ func (c *Client) CreatePlaylist(ctx context.Context, name string, public, collab
 	return mapPlaylist(raw), nil
 }
 
-func (c *Client) albumTracks(ctx context.Context, id string, limit, offset int) ([]Item, error) {
+func (c *Client) albumTracks(
+	ctx context.Context,
+	id string,
+	albumName string,
+	limit,
+	offset int,
+) ([]Item, error) {
 	params := url.Values{}
 	params.Set("limit", fmt.Sprint(limit))
 	params.Set("offset", fmt.Sprint(offset))
@@ -408,7 +414,7 @@ func (c *Client) albumTracks(ctx context.Context, id string, limit, offset int) 
 		if track.ID == "" {
 			continue
 		}
-		items = append(items, mapAlbumTrack(track, ""))
+		items = append(items, mapAlbumTrack(track, albumName))
 	}
 	return items, nil
 }

--- a/internal/spotify/client.go
+++ b/internal/spotify/client.go
@@ -409,3 +409,20 @@ func (c *Client) currentUserID(ctx context.Context) (string, error) {
 	}
 	return raw.ID, nil
 }
+
+func (c *Client) RecentlyPlayed(ctx context.Context, limit int) ([]RecentItem, error) {
+	params := url.Values{}
+	params.Set("limit", fmt.Sprint(limit))
+	var raw recentlyPlayedResponse
+	if err := c.get(ctx, "/me/player/recently-played", params, &raw); err != nil {
+		return nil, err
+	}
+	items := make([]RecentItem, 0, len(raw.Items))
+	for _, item := range raw.Items {
+		items = append(items, RecentItem{
+			Track:    mapTrack(item.Track),
+			PlayedAt: item.PlayedAt,
+		})
+	}
+	return items, nil
+}

--- a/internal/spotify/client_more_test.go
+++ b/internal/spotify/client_more_test.go
@@ -26,7 +26,20 @@ func TestClientEndpoints(t *testing.T) {
 		})
 	})
 	mux.HandleFunc("/playlists/p1", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(playlistItem{ID: "p1", URI: "spotify:playlist:p1", Name: "Playlist"})
+		if r.Method == http.MethodPut {
+			body, _ := io.ReadAll(r.Body)
+			if len(body) == 0 {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(playlistItem{ID: "p1", URI: "spotify:playlist:p1", Name: "Playlist", Public: false, Collaborative: true})
 	})
 	mux.HandleFunc("/shows/s1", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(showItem{ID: "s1", URI: "spotify:show:s1", Name: "Show"})
@@ -126,8 +139,15 @@ func TestClientEndpoints(t *testing.T) {
 	if _, err := client.ArtistTopTracks(context.Background(), "ar1", 1); err != nil {
 		t.Fatalf("artist top tracks: %v", err)
 	}
-	if _, err := client.GetPlaylist(context.Background(), "p1"); err != nil {
+	playlist, err := client.GetPlaylist(context.Background(), "p1")
+	if err != nil {
 		t.Fatalf("playlist: %v", err)
+	}
+	if playlist.Public == nil || *playlist.Public {
+		t.Fatalf("expected private playlist metadata, got %#v", playlist.Public)
+	}
+	if playlist.Collaborative == nil || !*playlist.Collaborative {
+		t.Fatalf("expected collaborative playlist metadata, got %#v", playlist.Collaborative)
 	}
 	if _, err := client.GetShow(context.Background(), "s1"); err != nil {
 		t.Fatalf("show: %v", err)
@@ -182,6 +202,18 @@ func TestClientEndpoints(t *testing.T) {
 	}
 	if _, err := client.CreatePlaylist(context.Background(), "Created", true, false); err != nil {
 		t.Fatalf("create playlist: %v", err)
+	}
+	name := "Renamed"
+	description := "New description"
+	public := false
+	collaborative := true
+	if _, err := client.UpdatePlaylist(context.Background(), "p1", PlaylistUpdate{
+		Name:          &name,
+		Description:   &description,
+		Public:        &public,
+		Collaborative: &collaborative,
+	}); err != nil {
+		t.Fatalf("update playlist: %v", err)
 	}
 	if err := client.RemoveTracks(context.Background(), "p1", []string{"spotify:track:t1"}); err != nil {
 		t.Fatalf("remove tracks: %v", err)

--- a/internal/spotify/client_request.go
+++ b/internal/spotify/client_request.go
@@ -28,6 +28,10 @@ func (c *Client) postJSON(ctx context.Context, path string, payload any, dest an
 	return c.send(ctx, http.MethodPost, path, nil, payload, dest)
 }
 
+func (c *Client) patchJSON(ctx context.Context, path string, payload any, dest any) error {
+	return c.send(ctx, http.MethodPatch, path, nil, payload, dest)
+}
+
 func (c *Client) putParams(ctx context.Context, path string, params url.Values) error {
 	return c.send(ctx, http.MethodPut, path, params, nil, nil)
 }

--- a/internal/spotify/client_test.go
+++ b/internal/spotify/client_test.go
@@ -217,6 +217,77 @@ func TestGetAlbumIncludesTracks(t *testing.T) {
 	}
 }
 
+func TestGetAlbumPreservesAlbumNameAcrossPages(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/albums/a1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":            "a1",
+				"uri":           "spotify:album:a1",
+				"name":          "Album",
+				"release_date":  "2024-01-01",
+				"total_tracks":  3,
+				"artists":       []map[string]any{{"name": "Artist"}},
+				"external_urls": map[string]string{"spotify": "https://open.spotify.com/album/a1"},
+				"tracks": map[string]any{
+					"total": 3,
+					"items": []map[string]any{
+						{
+							"id":            "t1",
+							"uri":           "spotify:track:t1",
+							"name":          "Song 1",
+							"duration_ms":   1000,
+							"explicit":      false,
+							"is_playable":   true,
+							"artists":       []map[string]any{{"name": "Artist"}},
+							"external_urls": map[string]string{"spotify": "https://open.spotify.com/track/t1"},
+						},
+					},
+				},
+			})
+		case "/albums/a1/tracks":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{
+					{
+						"id":            "t2",
+						"uri":           "spotify:track:t2",
+						"name":          "Song 2",
+						"duration_ms":   1000,
+						"explicit":      false,
+						"is_playable":   true,
+						"artists":       []map[string]any{{"name": "Artist"}},
+						"external_urls": map[string]string{"spotify": "https://open.spotify.com/track/t2"},
+					},
+					{
+						"id":            "t3",
+						"uri":           "spotify:track:t3",
+						"name":          "Song 3",
+						"duration_ms":   1000,
+						"explicit":      false,
+						"is_playable":   true,
+						"artists":       []map[string]any{{"name": "Artist"}},
+						"external_urls": map[string]string{"spotify": "https://open.spotify.com/track/t3"},
+					},
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	client, closeFn := newTestClient(t, handler)
+	defer closeFn()
+	item, err := client.GetAlbum(context.Background(), "a1")
+	if err != nil {
+		t.Fatalf("get album: %v", err)
+	}
+	if len(item.Tracks) != 3 {
+		t.Fatalf("expected 3 tracks, got %#v", item.Tracks)
+	}
+	if item.Tracks[1].Album != "Album" || item.Tracks[2].Album != "Album" {
+		t.Fatalf("expected album names on paginated tracks: %#v", item.Tracks)
+	}
+}
+
 func TestPlayContextURI(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)

--- a/internal/spotify/client_test.go
+++ b/internal/spotify/client_test.go
@@ -130,8 +130,90 @@ func TestAddTracksPayload(t *testing.T) {
 	})
 	client, closeFn := newTestClient(t, handler)
 	defer closeFn()
-	if err := client.AddTracks(context.Background(), "p1", []string{"spotify:track:t1"}); err != nil {
+	if err := client.AddTracks(
+		context.Background(),
+		"p1",
+		[]string{"spotify:track:t1"},
+		nil,
+	); err != nil {
 		t.Fatalf("add tracks: %v", err)
+	}
+}
+
+func TestAddTracksPayloadWithPosition(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(data), "\"position\":0") {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	})
+	client, closeFn := newTestClient(t, handler)
+	defer closeFn()
+	position := 0
+	if err := client.AddTracks(
+		context.Background(),
+		"p1",
+		[]string{"spotify:track:t1"},
+		&position,
+	); err != nil {
+		t.Fatalf("add tracks: %v", err)
+	}
+}
+
+func TestGetAlbumIncludesTracks(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/albums/a1" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":            "a1",
+			"uri":           "spotify:album:a1",
+			"name":          "Album",
+			"release_date":  "2024-01-01",
+			"total_tracks":  2,
+			"artists":       []map[string]any{{"name": "Artist"}},
+			"external_urls": map[string]string{"spotify": "https://open.spotify.com/album/a1"},
+			"tracks": map[string]any{
+				"total": 2,
+				"items": []map[string]any{
+					{
+						"id":            "t1",
+						"uri":           "spotify:track:t1",
+						"name":          "Song 1",
+						"duration_ms":   1000,
+						"explicit":      false,
+						"is_playable":   true,
+						"artists":       []map[string]any{{"name": "Artist"}},
+						"external_urls": map[string]string{"spotify": "https://open.spotify.com/track/t1"},
+					},
+					{
+						"id":            "t2",
+						"uri":           "spotify:track:t2",
+						"name":          "Song 2",
+						"duration_ms":   1000,
+						"explicit":      false,
+						"is_playable":   true,
+						"artists":       []map[string]any{{"name": "Artist"}},
+						"external_urls": map[string]string{"spotify": "https://open.spotify.com/track/t2"},
+					},
+				},
+			},
+		})
+	})
+	client, closeFn := newTestClient(t, handler)
+	defer closeFn()
+	item, err := client.GetAlbum(context.Background(), "a1")
+	if err != nil {
+		t.Fatalf("get album: %v", err)
+	}
+	if len(item.Tracks) != 2 {
+		t.Fatalf("expected 2 tracks, got %#v", item.Tracks)
+	}
+	if item.Tracks[0].Album != "Album" {
+		t.Fatalf("expected album name on nested tracks: %#v", item.Tracks[0])
 	}
 }
 

--- a/internal/spotify/connect.go
+++ b/internal/spotify/connect.go
@@ -468,11 +468,18 @@ func (c *ConnectClient) playlistInsertPosition(
 		return nil, fmt.Errorf("position must be zero or greater")
 	}
 
-	targetUID, err := c.playlistTrackUIDAtOffset(ctx, playlistID, *position)
+	targetUID, total, err := c.playlistTrackUIDAtOffset(ctx, playlistID, *position)
 	if err != nil {
 		return nil, err
 	}
 	if targetUID == "" {
+		if *position > total {
+			return nil, fmt.Errorf(
+				"position %d is out of range for playlist with %d tracks",
+				*position,
+				total,
+			)
+		}
 		return map[string]any{
 			"moveType": "BOTTOM_OF_PLAYLIST",
 			"fromUid":  nil,
@@ -489,27 +496,28 @@ func (c *ConnectClient) playlistTrackUIDAtOffset(
 	ctx context.Context,
 	playlistID string,
 	offset int,
-) (string, error) {
+) (string, int, error) {
 	payload, err := c.graphQL(ctx, "fetchPlaylistContents", map[string]any{
 		"uri":    "spotify:playlist:" + playlistID,
 		"offset": offset,
 		"limit":  1,
 	})
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 
+	total := extractPlaylistTrackTotal(payload)
 	items := extractPlaylistItems(payload)
 	if len(items) == 0 {
-		return "", nil
+		return "", total, nil
 	}
 
 	itemMap, ok := items[0].(map[string]any)
 	if !ok {
-		return "", nil
+		return "", total, nil
 	}
 	uid, _ := itemMap["uid"].(string)
-	return uid, nil
+	return uid, total, nil
 }
 
 func (c *ConnectClient) RemoveTracks(ctx context.Context, playlistID string, uris []string) error {
@@ -612,6 +620,22 @@ func extractPlaylistItems(payload map[string]any) []any {
 	}
 	items, _ := content["items"].([]any)
 	return items
+}
+
+func extractPlaylistTrackTotal(payload map[string]any) int {
+	data, _ := payload["data"].(map[string]any)
+	if data == nil {
+		return 0
+	}
+	playlistV2, _ := data["playlistV2"].(map[string]any)
+	if playlistV2 == nil {
+		return 0
+	}
+	content, _ := playlistV2["content"].(map[string]any)
+	if content == nil {
+		return 0
+	}
+	return getInt(content, "totalCount")
 }
 
 func extractPlaylistTracksFromPayload(payload map[string]any) ([]Item, int) {

--- a/internal/spotify/connect.go
+++ b/internal/spotify/connect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -33,6 +34,15 @@ type ConnectClient struct {
 	web          *Client
 	searchURL    string
 	searchClient *http.Client
+}
+
+const connectPlaylistBaseURL = "https://spclient.wg.spotify.com/playlist/v2"
+
+type connectPlaylistState struct {
+	Revision      string         `json:"revision"`
+	Length        int            `json:"length"`
+	Attributes    map[string]any `json:"attributes"`
+	OwnerUsername string         `json:"ownerUsername"`
 }
 
 func NewConnectClient(opts ConnectOptions) (*ConnectClient, error) {
@@ -76,6 +86,9 @@ func (c *ConnectClient) GetArtist(ctx context.Context, id string) (Item, error) 
 }
 
 func (c *ConnectClient) GetPlaylist(ctx context.Context, id string) (Item, error) {
+	if item, err := c.playlistDetails(ctx, id); err == nil {
+		return item, nil
+	}
 	return c.playlistInfo(ctx, id)
 }
 
@@ -361,6 +374,9 @@ func (c *ConnectClient) PlaylistTracks(ctx context.Context, id string, limit, of
 }
 
 func (c *ConnectClient) CreatePlaylist(ctx context.Context, name string, public, collaborative bool) (Item, error) {
+	if public {
+		return Item{}, ErrUnsupported
+	}
 	if c.session == nil {
 		return Item{}, errors.New("connect session not initialized")
 	}
@@ -410,12 +426,155 @@ func (c *ConnectClient) CreatePlaylist(ctx context.Context, name string, public,
 	json.NewDecoder(resp.Body).Decode(&result)
 
 	id := strings.TrimPrefix(result.URI, "spotify:playlist:")
-	return Item{
-		ID:   id,
-		URI:  result.URI,
-		Name: name,
-		Type: "playlist",
-		URL:  "https://open.spotify.com/playlist/" + id,
+	if collaborative {
+		trueValue := true
+		if _, err := c.UpdatePlaylist(ctx, id, PlaylistUpdate{Collaborative: &trueValue}); err != nil {
+			return Item{}, err
+		}
+	}
+	return c.playlistDetails(ctx, id)
+}
+
+func (c *ConnectClient) UpdatePlaylist(ctx context.Context, playlistID string, update PlaylistUpdate) (Item, error) {
+	if update.Public != nil {
+		return Item{}, ErrUnsupported
+	}
+	payload, err := buildConnectPlaylistChanges(update)
+	if err != nil {
+		return Item{}, err
+	}
+	if payload == nil {
+		return c.playlistDetails(ctx, playlistID)
+	}
+	if err := c.playlistRequest(ctx, http.MethodPost, "/playlist/"+playlistID+"/changes", payload, nil); err != nil {
+		return Item{}, err
+	}
+	return c.playlistDetails(ctx, playlistID)
+}
+
+func (c *ConnectClient) playlistDetails(ctx context.Context, playlistID string) (Item, error) {
+	var raw connectPlaylistState
+	if err := c.playlistRequest(
+		ctx,
+		http.MethodGet,
+		"/playlist/"+playlistID+"?decorate=revision,length,attributes,timestamp,owner,capabilities",
+		nil,
+		&raw,
+	); err != nil {
+		return Item{}, err
+	}
+	item := Item{
+		ID:          playlistID,
+		URI:         "spotify:playlist:" + playlistID,
+		Name:        getString(raw.Attributes, "name"),
+		Type:        "playlist",
+		URL:         "https://open.spotify.com/playlist/" + playlistID,
+		Owner:       raw.OwnerUsername,
+		TotalTracks: raw.Length,
+		Description: getString(raw.Attributes, "description"),
+	}
+	if value, ok := raw.Attributes["collaborative"].(bool); ok {
+		item.Collaborative = boolPtr(value)
+	}
+	return item, nil
+}
+
+func (c *ConnectClient) playlistRequest(ctx context.Context, method, path string, payload any, dest any) error {
+	auth, err := c.session.auth(ctx)
+	if err != nil {
+		return err
+	}
+	var body *strings.Reader
+	if payload != nil {
+		body = encodeJSON(payload)
+	} else {
+		body = strings.NewReader("")
+	}
+	req, err := http.NewRequestWithContext(ctx, method, connectPlaylistBaseURL+path, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+auth.AccessToken)
+	req.Header.Set("Client-Token", auth.ClientToken)
+	req.Header.Set("spotify-app-version", auth.ClientVersion)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", defaultUserAgent())
+	req.Header.Set("app-platform", "WebPlayer")
+	if c.language != "" {
+		req.Header.Set("Accept-Language", c.language)
+	}
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json;charset=UTF-8")
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return apiErrorFromResponse(resp)
+	}
+	if dest == nil {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(dest); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func buildConnectPlaylistChanges(update PlaylistUpdate) (map[string]any, error) {
+	values := map[string]any{
+		"formatAttributes": []any{},
+		"pictureSize":      []any{},
+	}
+	noValue := []int{}
+	if update.Name != nil {
+		if strings.TrimSpace(*update.Name) == "" {
+			return nil, errors.New("playlist name cannot be empty")
+		}
+		values["name"] = *update.Name
+	}
+	if update.Description != nil {
+		if *update.Description == "" {
+			noValue = append(noValue, 2)
+		} else {
+			values["description"] = *update.Description
+		}
+	}
+	if update.Collaborative != nil {
+		values["collaborative"] = *update.Collaborative
+	}
+	if len(values) == 2 && len(noValue) == 0 {
+		return nil, nil
+	}
+	return map[string]any{
+		"deltas": []map[string]any{
+			{
+				"ops": []map[string]any{
+					{
+						"kind": "UPDATE_LIST_ATTRIBUTES",
+						"updateListAttributes": map[string]any{
+							"newAttributes": map[string]any{
+								"values":  values,
+								"noValue": noValue,
+							},
+						},
+					},
+				},
+				"info": map[string]any{
+					"source": map[string]any{
+						"client": "WEBPLAYER",
+					},
+				},
+			},
+		},
+		"wantResultingRevisions": false,
+		"wantSyncResult":         false,
+		"nonces":                 []any{},
 	}, nil
 }
 

--- a/internal/spotify/connect.go
+++ b/internal/spotify/connect.go
@@ -419,12 +419,16 @@ func (c *ConnectClient) CreatePlaylist(ctx context.Context, name string, public,
 	}, nil
 }
 
-func (c *ConnectClient) AddTracks(ctx context.Context, playlistID string, uris []string) error {
+func (c *ConnectClient) AddTracks(
+	ctx context.Context,
+	playlistID string,
+	uris []string,
+	position *int,
+) error {
 	if len(uris) == 0 {
 		return nil
 	}
 
-	// Ensure URIs are in correct format
 	formattedURIs := make([]string, len(uris))
 	for i, uri := range uris {
 		if !strings.HasPrefix(uri, "spotify:") {
@@ -434,17 +438,78 @@ func (c *ConnectClient) AddTracks(ctx context.Context, playlistID string, uris [
 		}
 	}
 
+	newPosition, err := c.playlistInsertPosition(ctx, playlistID, position)
+	if err != nil {
+		return err
+	}
+
 	variables := map[string]any{
 		"playlistItemUris": formattedURIs,
 		"playlistUri":      "spotify:playlist:" + playlistID,
-		"newPosition": map[string]any{
-			"moveType": "BOTTOM_OF_PLAYLIST",
-			"fromUid":  nil,
-		},
+		"newPosition":      newPosition,
 	}
 
-	_, err := c.graphQL(ctx, "addToPlaylist", variables)
+	_, err = c.graphQL(ctx, "addToPlaylist", variables)
 	return err
+}
+
+func (c *ConnectClient) playlistInsertPosition(
+	ctx context.Context,
+	playlistID string,
+	position *int,
+) (map[string]any, error) {
+	if position == nil {
+		return map[string]any{
+			"moveType": "BOTTOM_OF_PLAYLIST",
+			"fromUid":  nil,
+		}, nil
+	}
+	if *position < 0 {
+		return nil, fmt.Errorf("position must be zero or greater")
+	}
+
+	targetUID, err := c.playlistTrackUIDAtOffset(ctx, playlistID, *position)
+	if err != nil {
+		return nil, err
+	}
+	if targetUID == "" {
+		return map[string]any{
+			"moveType": "BOTTOM_OF_PLAYLIST",
+			"fromUid":  nil,
+		}, nil
+	}
+
+	return map[string]any{
+		"moveType": "BEFORE_UID",
+		"fromUid":  targetUID,
+	}, nil
+}
+
+func (c *ConnectClient) playlistTrackUIDAtOffset(
+	ctx context.Context,
+	playlistID string,
+	offset int,
+) (string, error) {
+	payload, err := c.graphQL(ctx, "fetchPlaylistContents", map[string]any{
+		"uri":    "spotify:playlist:" + playlistID,
+		"offset": offset,
+		"limit":  1,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	items := extractPlaylistItems(payload)
+	if len(items) == 0 {
+		return "", nil
+	}
+
+	itemMap, ok := items[0].(map[string]any)
+	if !ok {
+		return "", nil
+	}
+	uid, _ := itemMap["uid"].(string)
+	return uid, nil
 }
 
 func (c *ConnectClient) RemoveTracks(ctx context.Context, playlistID string, uris []string) error {

--- a/internal/spotify/connect.go
+++ b/internal/spotify/connect.go
@@ -257,14 +257,15 @@ func (c *ConnectClient) RecentlyPlayed(ctx context.Context, limit int) ([]Recent
 		if !ok {
 			continue
 		}
-		playedAt := ""
-		// recents uses a date object in addedAt (no time-of-day).
-		if addedAt, ok := entry["addedAt"].(map[string]any); ok {
-			year := getInt(addedAt, "year")
-			month := getInt(addedAt, "month")
-			day := getInt(addedAt, "day")
-			if year > 0 && month > 0 && day > 0 {
-				playedAt = fmt.Sprintf("%04d-%02d-%02d", year, month, day)
+		playedAt := getString(entry, "playedAt")
+		if playedAt == "" {
+			if addedAt, ok := entry["addedAt"].(map[string]any); ok {
+				year := getInt(addedAt, "year")
+				month := getInt(addedAt, "month")
+				day := getInt(addedAt, "day")
+				if year > 0 && month > 0 && day > 0 {
+					playedAt = time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+				}
 			}
 		}
 		out = append(out, RecentItem{
@@ -377,15 +378,6 @@ func (c *ConnectClient) CreatePlaylist(ctx context.Context, name string, public,
 	if public {
 		return Item{}, ErrUnsupported
 	}
-	if c.session == nil {
-		return Item{}, errors.New("connect session not initialized")
-	}
-	auth, err := c.session.auth(ctx)
-	if err != nil {
-		return Item{}, err
-	}
-
-	createURL := "https://spclient.wg.spotify.com/playlist/v2/playlist"
 	createPayload := map[string]any{
 		"ops": []map[string]any{
 			{
@@ -400,39 +392,23 @@ func (c *ConnectClient) CreatePlaylist(ctx context.Context, name string, public,
 			},
 		},
 	}
-
-	body, _ := json.Marshal(createPayload)
-	req, _ := http.NewRequestWithContext(ctx, "POST", createURL, strings.NewReader(string(body)))
-	req.Header.Set("Authorization", "Bearer "+auth.AccessToken)
-	req.Header.Set("Client-Token", auth.ClientToken)
-	req.Header.Set("spotify-app-version", auth.ClientVersion)
-	req.Header.Set("Content-Type", "application/json;charset=UTF-8")
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("app-platform", "WebPlayer")
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return Item{}, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return Item{}, fmt.Errorf("create playlist failed: %d", resp.StatusCode)
-	}
-
 	var result struct {
 		URI string `json:"uri"`
 	}
-	json.NewDecoder(resp.Body).Decode(&result)
-
-	id := strings.TrimPrefix(result.URI, "spotify:playlist:")
+	if err := c.playlistRequest(ctx, http.MethodPost, "/playlist", createPayload, &result); err != nil {
+		return Item{}, err
+	}
+	playlist, err := ParseTypedID(result.URI, "playlist")
+	if err != nil || playlist.ID == "" {
+		return Item{}, errors.New("missing playlist uri")
+	}
 	if collaborative {
 		trueValue := true
-		if _, err := c.UpdatePlaylist(ctx, id, PlaylistUpdate{Collaborative: &trueValue}); err != nil {
+		if _, err := c.UpdatePlaylist(ctx, playlist.ID, PlaylistUpdate{Collaborative: &trueValue}); err != nil {
 			return Item{}, err
 		}
 	}
-	return c.playlistDetails(ctx, id)
+	return c.playlistDetails(ctx, playlist.ID)
 }
 
 func (c *ConnectClient) UpdatePlaylist(ctx context.Context, playlistID string, update PlaylistUpdate) (Item, error) {
@@ -480,6 +456,9 @@ func (c *ConnectClient) playlistDetails(ctx context.Context, playlistID string) 
 }
 
 func (c *ConnectClient) playlistRequest(ctx context.Context, method, path string, payload any, dest any) error {
+	if c.session == nil {
+		return errors.New("connect session not initialized")
+	}
 	auth, err := c.session.auth(ctx)
 	if err != nil {
 		return err

--- a/internal/spotify/connect.go
+++ b/internal/spotify/connect.go
@@ -2,9 +2,11 @@ package spotify
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -138,41 +140,505 @@ func (c *ConnectClient) Queue(ctx context.Context) (Queue, error) {
 }
 
 func (c *ConnectClient) LibraryTracks(ctx context.Context, limit, offset int) ([]Item, int, error) {
-	return nil, 0, fmt.Errorf("%w: library tracks not supported in connect engine yet", ErrUnsupported)
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	payload, err := c.graphQL(ctx, "fetchLibraryTracks", map[string]any{
+		"offset": offset,
+		"limit":  limit,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	container, ok := getMap(payload, "data", "me", "library", "tracks")
+	if !ok {
+		// Best-effort fallback: extract anything that looks like a track.
+		items := collectItemsByKind(payload, "track")
+		return items, len(items), nil
+	}
+	items := extractItemsFromContainer(container, "track")
+	total := getInt(container, "totalLength")
+	if total == 0 {
+		total = getInt(container, "totalCount")
+	}
+	if total == 0 {
+		total = len(items)
+	}
+	return items, total, nil
 }
 
 func (c *ConnectClient) LibraryAlbums(ctx context.Context, limit, offset int) ([]Item, int, error) {
-	return nil, 0, fmt.Errorf("%w: library albums not supported in connect engine yet", ErrUnsupported)
+	return c.libraryV3List(ctx, "Albums", "album", limit, offset)
 }
 
 func (c *ConnectClient) LibraryModify(ctx context.Context, path string, ids []string, method string) error {
-	return fmt.Errorf("%w: library modify not supported in connect engine yet", ErrUnsupported)
+	kind := ""
+	switch {
+	case strings.Contains(path, "tracks"):
+		kind = "track"
+	case strings.Contains(path, "albums"):
+		kind = "album"
+	default:
+		return fmt.Errorf("%w: unsupported library path %q", ErrUnsupported, path)
+	}
+	return c.libraryModifyByKind(ctx, kind, ids, method)
 }
 
 func (c *ConnectClient) FollowArtists(ctx context.Context, ids []string, method string) error {
-	return fmt.Errorf("%w: follow artists not supported in connect engine yet", ErrUnsupported)
+	return c.libraryModifyByKind(ctx, "artist", ids, method)
 }
 
 func (c *ConnectClient) FollowedArtists(ctx context.Context, limit int, after string) ([]Item, int, string, error) {
-	return nil, 0, "", fmt.Errorf("%w: followed artists not supported in connect engine yet", ErrUnsupported)
+	if after != "" {
+		// The Web API uses `after` cursor pagination. WebPlayer library uses offset pagination.
+		return nil, 0, "", fmt.Errorf("%w: after cursor not supported in connect engine", ErrUnsupported)
+	}
+	items, total, err := c.libraryV3List(ctx, "Artists", "artist", limit, 0)
+	return items, total, "", err
 }
 
 func (c *ConnectClient) Playlists(ctx context.Context, limit, offset int) ([]Item, int, error) {
-	return nil, 0, fmt.Errorf("%w: playlists not supported in connect engine yet", ErrUnsupported)
+	return c.libraryV3List(ctx, "Playlists", "playlist", limit, offset)
+}
+
+func (c *ConnectClient) RecentlyPlayed(ctx context.Context, limit int) ([]RecentItem, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	payload, err := c.graphQL(ctx, "recents", map[string]any{
+		"uris":   []string{"spotify:list:recents:page"},
+		"offset": 0,
+		"limit":  limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	data, _ := payload["data"].(map[string]any)
+	if data == nil {
+		return nil, errors.New("missing data")
+	}
+	lists, _ := data["lists"].([]any)
+	if len(lists) == 0 {
+		return nil, nil
+	}
+	list0, _ := lists[0].(map[string]any)
+	if list0 == nil {
+		return nil, errors.New("invalid lists payload")
+	}
+	itemsContainer, _ := list0["items"].(map[string]any)
+	if itemsContainer == nil {
+		return nil, nil
+	}
+	rawItems, _ := itemsContainer["items"].([]any)
+	out := make([]RecentItem, 0, len(rawItems))
+	for _, raw := range rawItems {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		entity := entry["entity"]
+		item, ok := extractItem(entity, "track")
+		if !ok {
+			continue
+		}
+		playedAt := ""
+		// recents uses a date object in addedAt (no time-of-day).
+		if addedAt, ok := entry["addedAt"].(map[string]any); ok {
+			year := getInt(addedAt, "year")
+			month := getInt(addedAt, "month")
+			day := getInt(addedAt, "day")
+			if year > 0 && month > 0 && day > 0 {
+				playedAt = fmt.Sprintf("%04d-%02d-%02d", year, month, day)
+			}
+		}
+		out = append(out, RecentItem{
+			Track:    item,
+			PlayedAt: playedAt,
+		})
+	}
+	return out, nil
+}
+
+func (c *ConnectClient) libraryModifyByKind(ctx context.Context, kind string, ids []string, method string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	op := ""
+	switch method {
+	case http.MethodPut:
+		op = "addToLibrary"
+	case http.MethodDelete:
+		op = "removeFromLibrary"
+	default:
+		return fmt.Errorf("%w: unsupported library method %q", ErrUnsupported, method)
+	}
+	uris := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if strings.HasPrefix(id, "spotify:") {
+			uris = append(uris, id)
+			continue
+		}
+		uris = append(uris, "spotify:"+kind+":"+id)
+	}
+	if len(uris) == 0 {
+		return nil
+	}
+	_, err := c.graphQL(ctx, op, map[string]any{
+		"libraryItemUris": uris,
+	})
+	return err
+}
+
+func (c *ConnectClient) libraryV3List(ctx context.Context, filterID string, kind string, limit, offset int) ([]Item, int, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	payload, err := c.graphQL(ctx, "libraryV3", map[string]any{
+		"filters":         []string{filterID},
+		"order":           "Recents",
+		"textFilter":      nil,
+		"features":        []string{},
+		"limit":           limit,
+		"offset":          offset,
+		"flatten":         false,
+		"expandedFolders": nil,
+		"folderUri":       nil,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	lib, ok := getMap(payload, "data", "me", "libraryV3")
+	if !ok {
+		return nil, 0, errors.New("missing libraryV3")
+	}
+	rawItems, _ := lib["items"].([]any)
+	out := make([]Item, 0, len(rawItems))
+	for _, raw := range rawItems {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		item, ok := extractItem(entry["item"], kind)
+		if !ok {
+			continue
+		}
+		out = append(out, item)
+	}
+	total := getInt(lib, "totalCount")
+	if total == 0 {
+		total = len(out)
+	}
+	return out, total, nil
 }
 
 func (c *ConnectClient) PlaylistTracks(ctx context.Context, id string, limit, offset int) ([]Item, int, error) {
-	return nil, 0, fmt.Errorf("%w: playlist tracks not supported in connect engine yet", ErrUnsupported)
+	if limit <= 0 {
+		limit = 100
+	}
+
+	variables := map[string]any{
+		"uri":    "spotify:playlist:" + id,
+		"offset": offset,
+		"limit":  limit,
+	}
+
+	payload, err := c.graphQL(ctx, "fetchPlaylistContents", variables)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	items, total := extractPlaylistTracksFromPayload(payload)
+	return items, total, nil
 }
 
 func (c *ConnectClient) CreatePlaylist(ctx context.Context, name string, public, collaborative bool) (Item, error) {
-	return Item{}, fmt.Errorf("%w: create playlist not supported in connect engine yet", ErrUnsupported)
+	if c.session == nil {
+		return Item{}, errors.New("connect session not initialized")
+	}
+	auth, err := c.session.auth(ctx)
+	if err != nil {
+		return Item{}, err
+	}
+
+	createURL := "https://spclient.wg.spotify.com/playlist/v2/playlist"
+	createPayload := map[string]any{
+		"ops": []map[string]any{
+			{
+				"kind": "UPDATE_LIST_ATTRIBUTES",
+				"updateListAttributes": map[string]any{
+					"newAttributes": map[string]any{
+						"values": map[string]any{
+							"name": name,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	body, _ := json.Marshal(createPayload)
+	req, _ := http.NewRequestWithContext(ctx, "POST", createURL, strings.NewReader(string(body)))
+	req.Header.Set("Authorization", "Bearer "+auth.AccessToken)
+	req.Header.Set("Client-Token", auth.ClientToken)
+	req.Header.Set("spotify-app-version", auth.ClientVersion)
+	req.Header.Set("Content-Type", "application/json;charset=UTF-8")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("app-platform", "WebPlayer")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return Item{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return Item{}, fmt.Errorf("create playlist failed: %d", resp.StatusCode)
+	}
+
+	var result struct {
+		URI string `json:"uri"`
+	}
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	id := strings.TrimPrefix(result.URI, "spotify:playlist:")
+	return Item{
+		ID:   id,
+		URI:  result.URI,
+		Name: name,
+		Type: "playlist",
+		URL:  "https://open.spotify.com/playlist/" + id,
+	}, nil
 }
 
 func (c *ConnectClient) AddTracks(ctx context.Context, playlistID string, uris []string) error {
-	return fmt.Errorf("%w: add tracks not supported in connect engine yet", ErrUnsupported)
+	if len(uris) == 0 {
+		return nil
+	}
+
+	// Ensure URIs are in correct format
+	formattedURIs := make([]string, len(uris))
+	for i, uri := range uris {
+		if !strings.HasPrefix(uri, "spotify:") {
+			formattedURIs[i] = "spotify:track:" + uri
+		} else {
+			formattedURIs[i] = uri
+		}
+	}
+
+	variables := map[string]any{
+		"playlistItemUris": formattedURIs,
+		"playlistUri":      "spotify:playlist:" + playlistID,
+		"newPosition": map[string]any{
+			"moveType": "BOTTOM_OF_PLAYLIST",
+			"fromUid":  nil,
+		},
+	}
+
+	_, err := c.graphQL(ctx, "addToPlaylist", variables)
+	return err
 }
 
 func (c *ConnectClient) RemoveTracks(ctx context.Context, playlistID string, uris []string) error {
-	return fmt.Errorf("%w: remove tracks not supported in connect engine yet", ErrUnsupported)
+	if len(uris) == 0 {
+		return nil
+	}
+
+	// Normalize URIs to spotify:track:XXX format
+	normalizedURIs := make(map[string]bool)
+	for _, uri := range uris {
+		if !strings.HasPrefix(uri, "spotify:") {
+			uri = "spotify:track:" + uri
+		}
+		normalizedURIs[uri] = true
+	}
+
+	// Fetch playlist contents to get UIDs for each track
+	uidsToRemove, err := c.getPlaylistTrackUIDs(ctx, playlistID, normalizedURIs)
+	if err != nil {
+		return err
+	}
+
+	if len(uidsToRemove) == 0 {
+		return nil
+	}
+
+	variables := map[string]any{
+		"playlistUri": "spotify:playlist:" + playlistID,
+		"uids":        uidsToRemove,
+	}
+
+	_, err = c.graphQL(ctx, "removeFromPlaylist", variables)
+	return err
+}
+
+func (c *ConnectClient) getPlaylistTrackUIDs(ctx context.Context, playlistID string, targetURIs map[string]bool) ([]string, error) {
+	var uids []string
+	offset := 0
+	limit := 100
+
+	for {
+		variables := map[string]any{
+			"uri":    "spotify:playlist:" + playlistID,
+			"offset": offset,
+			"limit":  limit,
+		}
+
+		payload, err := c.graphQL(ctx, "fetchPlaylistContents", variables)
+		if err != nil {
+			return nil, err
+		}
+
+		items := extractPlaylistItems(payload)
+		if len(items) == 0 {
+			break
+		}
+
+		for _, item := range items {
+			itemMap, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			uid, _ := itemMap["uid"].(string)
+			itemData, _ := itemMap["itemV2"].(map[string]any)
+			if itemData == nil {
+				continue
+			}
+			data, _ := itemData["data"].(map[string]any)
+			if data == nil {
+				continue
+			}
+			trackURI, _ := data["uri"].(string)
+
+			if uid != "" && trackURI != "" && targetURIs[trackURI] {
+				uids = append(uids, uid)
+			}
+		}
+
+		if len(items) < limit {
+			break
+		}
+		offset += limit
+	}
+
+	return uids, nil
+}
+
+func extractPlaylistItems(payload map[string]any) []any {
+	data, _ := payload["data"].(map[string]any)
+	if data == nil {
+		return nil
+	}
+	playlistV2, _ := data["playlistV2"].(map[string]any)
+	if playlistV2 == nil {
+		return nil
+	}
+	content, _ := playlistV2["content"].(map[string]any)
+	if content == nil {
+		return nil
+	}
+	items, _ := content["items"].([]any)
+	return items
+}
+
+func extractPlaylistTracksFromPayload(payload map[string]any) ([]Item, int) {
+	data, _ := payload["data"].(map[string]any)
+	if data == nil {
+		return nil, 0
+	}
+	playlistV2, _ := data["playlistV2"].(map[string]any)
+	if playlistV2 == nil {
+		return nil, 0
+	}
+	content, _ := playlistV2["content"].(map[string]any)
+	if content == nil {
+		return nil, 0
+	}
+
+	total := 0
+	if t, ok := content["totalCount"].(float64); ok {
+		total = int(t)
+	}
+
+	rawItems, _ := content["items"].([]any)
+	items := make([]Item, 0, len(rawItems))
+
+	for _, raw := range rawItems {
+		itemMap, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		itemV2, _ := itemMap["itemV2"].(map[string]any)
+		if itemV2 == nil {
+			continue
+		}
+
+		trackData, _ := itemV2["data"].(map[string]any)
+		if trackData == nil {
+			continue
+		}
+
+		uri, _ := trackData["uri"].(string)
+		if uri == "" || !strings.HasPrefix(uri, "spotify:track:") {
+			continue
+		}
+
+		name, _ := trackData["name"].(string)
+
+		var artists []string
+		if artistsData, ok := trackData["artists"].(map[string]any); ok {
+			if artistItems, ok := artistsData["items"].([]any); ok {
+				for _, a := range artistItems {
+					if artistMap, ok := a.(map[string]any); ok {
+						if profile, ok := artistMap["profile"].(map[string]any); ok {
+							if artistName, ok := profile["name"].(string); ok {
+								artists = append(artists, artistName)
+							}
+						}
+					}
+				}
+			}
+		}
+
+		var album string
+		if albumData, ok := trackData["albumOfTrack"].(map[string]any); ok {
+			if albumName, ok := albumData["name"].(string); ok {
+				album = albumName
+			}
+		}
+
+		var durationMS int
+		if playability, ok := trackData["playability"].(map[string]any); ok {
+			if dur, ok := playability["playable"].(bool); ok && dur {
+				if d, ok := trackData["duration"].(map[string]any); ok {
+					if ms, ok := d["totalMilliseconds"].(float64); ok {
+						durationMS = int(ms)
+					}
+				}
+			}
+		}
+
+		id := strings.TrimPrefix(uri, "spotify:track:")
+		items = append(items, Item{
+			ID:         id,
+			URI:        uri,
+			Name:       name,
+			Type:       "track",
+			URL:        "https://open.spotify.com/track/" + id,
+			Artists:    artists,
+			Album:      album,
+			DurationMS: durationMS,
+		})
+	}
+
+	return items, total
 }

--- a/internal/spotify/connect_client_test.go
+++ b/internal/spotify/connect_client_test.go
@@ -222,3 +222,106 @@ func TestConnectAddTracksPositionOutOfRange(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestConnectUpdatePlaylistUsesChangesEndpoint(t *testing.T) {
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/playlist/v2/playlist/p1/changes":
+			if req.Method != http.MethodPost {
+				return textResponse(http.StatusMethodNotAllowed, "bad method"), nil
+			}
+			var body map[string]any
+			_ = json.NewDecoder(req.Body).Decode(&body)
+			deltas, _ := body["deltas"].([]any)
+			ops, _ := deltas[0].(map[string]any)["ops"].([]any)
+			op := ops[0].(map[string]any)
+			if op["kind"] != "UPDATE_LIST_ATTRIBUTES" {
+				t.Fatalf("unexpected op kind: %#v", op)
+			}
+			newAttrs := op["updateListAttributes"].(map[string]any)["newAttributes"].(map[string]any)
+			values := newAttrs["values"].(map[string]any)
+			if values["name"] != "Renamed" || values["description"] != "desc" || values["collaborative"] != false {
+				t.Fatalf("unexpected values: %#v", values)
+			}
+			return jsonResponse(http.StatusOK, map[string]any{"revision": "rev-2"}), nil
+		case "/playlist/v2/playlist/p1":
+			if req.Method != http.MethodGet {
+				return textResponse(http.StatusMethodNotAllowed, "bad method"), nil
+			}
+			if req.URL.Query().Get("decorate") != "revision,length,attributes,timestamp,owner,capabilities" {
+				t.Fatalf("unexpected query: %s", req.URL.RawQuery)
+			}
+			return jsonResponse(http.StatusOK, map[string]any{
+				"length":        3,
+				"ownerUsername": "me",
+				"attributes": map[string]any{
+					"name":          "Renamed",
+					"description":   "desc",
+					"collaborative": false,
+				},
+			}), nil
+		default:
+			return textResponse(http.StatusNotFound, req.URL.Path), nil
+		}
+	})
+	client := newConnectClientForTests(transport)
+	name := "Renamed"
+	description := "desc"
+	collaborative := false
+	item, err := client.UpdatePlaylist(context.Background(), "p1", PlaylistUpdate{
+		Name:          &name,
+		Description:   &description,
+		Collaborative: &collaborative,
+	})
+	if err != nil {
+		t.Fatalf("update playlist: %v", err)
+	}
+	if item.Name != name || item.Description != description || item.TotalTracks != 3 {
+		t.Fatalf("unexpected item: %#v", item)
+	}
+	if item.Collaborative == nil || *item.Collaborative {
+		t.Fatalf("unexpected collaborative flag: %#v", item.Collaborative)
+	}
+}
+
+func TestConnectCreateCollaborativePlaylistUsesChangesEndpoint(t *testing.T) {
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/playlist/v2/playlist":
+			if req.Method != http.MethodPost {
+				return textResponse(http.StatusMethodNotAllowed, "bad method"), nil
+			}
+			return jsonResponse(http.StatusOK, map[string]any{"uri": "spotify:playlist:p2"}), nil
+		case "/playlist/v2/playlist/p2/changes":
+			var body map[string]any
+			_ = json.NewDecoder(req.Body).Decode(&body)
+			deltas, _ := body["deltas"].([]any)
+			ops, _ := deltas[0].(map[string]any)["ops"].([]any)
+			newAttrs := ops[0].(map[string]any)["updateListAttributes"].(map[string]any)["newAttributes"].(map[string]any)
+			values := newAttrs["values"].(map[string]any)
+			if values["collaborative"] != true {
+				t.Fatalf("unexpected values: %#v", values)
+			}
+			return jsonResponse(http.StatusOK, map[string]any{"revision": "rev-3"}), nil
+		case "/playlist/v2/playlist/p2":
+			return jsonResponse(http.StatusOK, map[string]any{
+				"length":        0,
+				"ownerUsername": "me",
+				"attributes": map[string]any{
+					"name":          "Shared",
+					"collaborative": true,
+				},
+			}), nil
+		default:
+			return textResponse(http.StatusNotFound, req.URL.Path), nil
+		}
+	})
+	client := newConnectClientForTests(transport)
+	item, err := client.CreatePlaylist(context.Background(), "Shared", false, true)
+	if err != nil {
+		t.Fatalf("create playlist: %v", err)
+	}
+	if item.ID != "p2" || item.Collaborative == nil || !*item.Collaborative {
+		t.Fatalf("unexpected item: %#v", item)
+	}
+}

--- a/internal/spotify/connect_client_test.go
+++ b/internal/spotify/connect_client_test.go
@@ -101,10 +101,86 @@ func TestConnectUnsupported(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 	// Empty modifications are treated as no-ops.
-	if err := client.AddTracks(context.Background(), "p1", nil); err != nil {
+	if err := client.AddTracks(context.Background(), "p1", nil, nil); err != nil {
 		t.Fatalf("expected no-op, got error: %v", err)
 	}
 	if err := client.RemoveTracks(context.Background(), "p1", nil); err != nil {
 		t.Fatalf("expected no-op, got error: %v", err)
+	}
+}
+
+func TestConnectAddTracksAppend(t *testing.T) {
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var body struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		_ = json.NewDecoder(req.Body).Decode(&body)
+		if body.OperationName != "addToPlaylist" {
+			return textResponse(http.StatusNotFound, "missing"), nil
+		}
+		position, _ := body.Variables["newPosition"].(map[string]any)
+		if position["moveType"] != "BOTTOM_OF_PLAYLIST" {
+			t.Fatalf("unexpected position: %#v", position)
+		}
+		return jsonResponse(http.StatusOK, map[string]any{"data": map[string]any{}}), nil
+	})
+	client := newConnectClientForTests(transport)
+	client.hashes.hashes["addToPlaylist"] = "hash"
+	if err := client.AddTracks(
+		context.Background(),
+		"p1",
+		[]string{"spotify:track:t1"},
+		nil,
+	); err != nil {
+		t.Fatalf("add tracks: %v", err)
+	}
+}
+
+func TestConnectAddTracksBeforeUID(t *testing.T) {
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var body struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		_ = json.NewDecoder(req.Body).Decode(&body)
+		switch body.OperationName {
+		case "fetchPlaylistContents":
+			payload := map[string]any{
+				"data": map[string]any{
+					"playlistV2": map[string]any{
+						"content": map[string]any{
+							"items": []any{
+								map[string]any{"uid": "uid-1"},
+							},
+						},
+					},
+				},
+			}
+			return jsonResponse(http.StatusOK, payload), nil
+		case "addToPlaylist":
+			position, _ := body.Variables["newPosition"].(map[string]any)
+			if position["moveType"] != "BEFORE_UID" {
+				t.Fatalf("unexpected moveType: %#v", position)
+			}
+			if position["fromUid"] != "uid-1" {
+				t.Fatalf("unexpected target uid: %#v", position)
+			}
+			return jsonResponse(http.StatusOK, map[string]any{"data": map[string]any{}}), nil
+		default:
+			return textResponse(http.StatusNotFound, "missing"), nil
+		}
+	})
+	client := newConnectClientForTests(transport)
+	client.hashes.hashes["fetchPlaylistContents"] = "hash"
+	client.hashes.hashes["addToPlaylist"] = "hash"
+	position := 0
+	if err := client.AddTracks(
+		context.Background(),
+		"p1",
+		[]string{"spotify:track:t1"},
+		&position,
+	); err != nil {
+		t.Fatalf("add tracks: %v", err)
 	}
 }

--- a/internal/spotify/connect_client_test.go
+++ b/internal/spotify/connect_client_test.go
@@ -184,3 +184,41 @@ func TestConnectAddTracksBeforeUID(t *testing.T) {
 		t.Fatalf("add tracks: %v", err)
 	}
 }
+
+func TestConnectAddTracksPositionOutOfRange(t *testing.T) {
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var body struct {
+			OperationName string `json:"operationName"`
+		}
+		_ = json.NewDecoder(req.Body).Decode(&body)
+		if body.OperationName != "fetchPlaylistContents" {
+			return textResponse(http.StatusNotFound, "missing"), nil
+		}
+		payload := map[string]any{
+			"data": map[string]any{
+				"playlistV2": map[string]any{
+					"content": map[string]any{
+						"totalCount": 1,
+						"items":      []any{},
+					},
+				},
+			},
+		}
+		return jsonResponse(http.StatusOK, payload), nil
+	})
+	client := newConnectClientForTests(transport)
+	client.hashes.hashes["fetchPlaylistContents"] = "hash"
+	position := 2
+	err := client.AddTracks(
+		context.Background(),
+		"p1",
+		[]string{"spotify:track:t1"},
+		&position,
+	)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if err.Error() != "position 2 is out of range for playlist with 1 tracks" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/spotify/connect_client_test.go
+++ b/internal/spotify/connect_client_test.go
@@ -2,6 +2,7 @@ package spotify
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 )
@@ -38,7 +39,11 @@ func TestConnectInfoOperations(t *testing.T) {
 		},
 	}
 	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		op := req.URL.Query().Get("operationName")
+		var body struct {
+			OperationName string `json:"operationName"`
+		}
+		_ = json.NewDecoder(req.Body).Decode(&body)
+		op := body.OperationName
 		payload, ok := payloads[op]
 		if !ok {
 			return textResponse(http.StatusNotFound, "missing"), nil
@@ -77,10 +82,10 @@ func TestConnectUnsupported(t *testing.T) {
 	if _, _, err := client.LibraryAlbums(context.Background(), 1, 0); err == nil {
 		t.Fatalf("expected error")
 	}
-	if err := client.LibraryModify(context.Background(), "", nil, ""); err == nil {
+	if err := client.LibraryModify(context.Background(), "/me/tracks", []string{"t1"}, http.MethodPut); err == nil {
 		t.Fatalf("expected error")
 	}
-	if err := client.FollowArtists(context.Background(), nil, ""); err == nil {
+	if err := client.FollowArtists(context.Background(), []string{"a1"}, http.MethodPut); err == nil {
 		t.Fatalf("expected error")
 	}
 	if _, _, _, err := client.FollowedArtists(context.Background(), 1, ""); err == nil {
@@ -95,10 +100,11 @@ func TestConnectUnsupported(t *testing.T) {
 	if _, err := client.CreatePlaylist(context.Background(), "name", false, false); err == nil {
 		t.Fatalf("expected error")
 	}
-	if err := client.AddTracks(context.Background(), "p1", nil); err == nil {
-		t.Fatalf("expected error")
+	// Empty modifications are treated as no-ops.
+	if err := client.AddTracks(context.Background(), "p1", nil); err != nil {
+		t.Fatalf("expected no-op, got error: %v", err)
 	}
-	if err := client.RemoveTracks(context.Background(), "p1", nil); err == nil {
-		t.Fatalf("expected error")
+	if err := client.RemoveTracks(context.Background(), "p1", nil); err != nil {
+		t.Fatalf("expected no-op, got error: %v", err)
 	}
 }

--- a/internal/spotify/connect_client_test.go
+++ b/internal/spotify/connect_client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 )
 
 func TestNewConnectClient(t *testing.T) {
@@ -323,5 +324,68 @@ func TestConnectCreateCollaborativePlaylistUsesChangesEndpoint(t *testing.T) {
 	}
 	if item.ID != "p2" || item.Collaborative == nil || !*item.Collaborative {
 		t.Fatalf("unexpected item: %#v", item)
+	}
+}
+
+func TestConnectCreatePlaylistErrorsOnMissingURI(t *testing.T) {
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/playlist/v2/playlist" {
+			t.Fatalf("unexpected follow-up request: %s", req.URL.Path)
+		}
+		return jsonResponse(http.StatusOK, map[string]any{}), nil
+	})
+	client := newConnectClientForTests(transport)
+	if _, err := client.CreatePlaylist(context.Background(), "Shared", false, false); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestConnectRecentlyPlayedNormalizesDateToRFC3339(t *testing.T) {
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var body struct {
+			OperationName string `json:"operationName"`
+		}
+		_ = json.NewDecoder(req.Body).Decode(&body)
+		if body.OperationName != "recents" {
+			return textResponse(http.StatusNotFound, "missing"), nil
+		}
+		return jsonResponse(http.StatusOK, map[string]any{
+			"data": map[string]any{
+				"lists": []any{
+					map[string]any{
+						"items": map[string]any{
+							"items": []any{
+								map[string]any{
+									"entity": map[string]any{
+										"uri":  "spotify:track:t1",
+										"name": "Song",
+									},
+									"addedAt": map[string]any{
+										"year":  2026,
+										"month": 4,
+										"day":   18,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}), nil
+	})
+	client := newConnectClientForTests(transport)
+	client.hashes.hashes["recents"] = "hash"
+	items, err := client.RecentlyPlayed(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("recently played: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("unexpected items: %#v", items)
+	}
+	if _, err := time.Parse(time.RFC3339, items[0].PlayedAt); err != nil {
+		t.Fatalf("expected RFC3339 timestamp, got %q: %v", items[0].PlayedAt, err)
+	}
+	if items[0].PlayedAt != "2026-04-18T00:00:00Z" {
+		t.Fatalf("unexpected timestamp: %q", items[0].PlayedAt)
 	}
 }

--- a/internal/spotify/connect_hash.go
+++ b/internal/spotify/connect_hash.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/cookiejar"
+	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
@@ -126,13 +128,14 @@ func (h *hashResolver) fetchWebPlayerHTML(ctx context.Context) (string, error) {
 		return "", err
 	}
 	req.Header.Set("User-Agent", defaultUserAgent())
-	resp, err := h.client.Do(req)
+	client := h.clientWithCookies(ctx)
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", apiErrorFromResponse(resp)
+		return "", fmt.Errorf("hash fetch https://open.spotify.com/: %w", apiErrorFromResponse(resp))
 	}
 	body, err := readAll(resp)
 	if err != nil {
@@ -147,19 +150,42 @@ func (h *hashResolver) fetchText(ctx context.Context, url string) (string, error
 		return "", err
 	}
 	req.Header.Set("User-Agent", defaultUserAgent())
-	resp, err := h.client.Do(req)
+	client := h.clientWithCookies(ctx)
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", apiErrorFromResponse(resp)
+		return "", fmt.Errorf("hash fetch %s: %w", url, apiErrorFromResponse(resp))
 	}
 	body, err := readAll(resp)
 	if err != nil {
 		return "", err
 	}
 	return string(body), nil
+}
+
+func (h *hashResolver) clientWithCookies(ctx context.Context) *http.Client {
+	// Hash discovery can require fetching many JS chunks. Doing that without cookies gets
+	// us intermittently blocked (often surfaced as 429). Use the same cookie source that
+	// backs connect auth so requests look like a normal logged-in web player session.
+	if h.session == nil || h.session.source == nil {
+		return h.client
+	}
+	cookiesList, err := h.session.source.Cookies(ctx)
+	if err != nil || len(cookiesList) == 0 {
+		return h.client
+	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return h.client
+	}
+	baseURL, _ := url.Parse("https://open.spotify.com/")
+	jar.SetCookies(baseURL, cookiesList)
+	client := *h.client
+	client.Jar = jar
+	return &client
 }
 
 func pickWebPlayerBundle(html string) (string, error) {

--- a/internal/spotify/connect_mapping.go
+++ b/internal/spotify/connect_mapping.go
@@ -100,8 +100,14 @@ func extractItem(value any, kind string) (Item, bool) {
 		return Item{}, false
 	}
 	uri := getString(m, "uri")
+	if uri == "" {
+		// Many WebPlayer pathfinder payloads use `_uri` (not `uri`).
+		uri = getString(m, "_uri")
+	}
 	if uri == "" && kind != "" {
-		if id := getString(m, "id"); id != "" {
+		// Some payloads include only an id. Only synthesize URIs for real Spotify ids
+		// to avoid false-positives like "Recents", "Playlists", etc.
+		if id := getString(m, "id"); isSpotifyID(id) {
 			uri = "spotify:" + kind + ":" + id
 		}
 	}
@@ -119,6 +125,15 @@ func extractItem(value any, kind string) (Item, bool) {
 	name := getString(m, "name")
 	if name == "" {
 		name = getString(m, "title")
+	}
+	if name == "" {
+		// Many pathfinder wrappers keep the human-readable name under `data.name`.
+		if data, ok := m["data"].(map[string]any); ok {
+			name = getString(data, "name")
+			if name == "" {
+				name = getString(data, "title")
+			}
+		}
 	}
 	if name == "" {
 		name = findFirstName(m)
@@ -222,6 +237,56 @@ func extractArtistNames(value any) []string {
 			for _, entry := range list {
 				if name := findFirstName(entry); name != "" {
 					artists = append(artists, name)
+				}
+			}
+		}
+		// WebPlayer track payloads commonly use:
+		//   artists: { items: [ { profile: { name } } ] }
+		if container, ok := m["artists"].(map[string]any); ok {
+			if items, ok := container["items"].([]any); ok {
+				for _, entry := range items {
+					if em, ok := entry.(map[string]any); ok {
+						if profile, ok := em["profile"].(map[string]any); ok {
+							if name := getString(profile, "name"); name != "" {
+								artists = append(artists, name)
+							}
+						}
+					}
+				}
+			}
+		}
+		// TrackUnion uses `firstArtist` + `otherArtists` containers rather than a flat `artists` field.
+		for _, key := range []string{"firstArtist", "otherArtists"} {
+			if container, ok := m[key].(map[string]any); ok {
+				if items, ok := container["items"].([]any); ok {
+					for _, entry := range items {
+						if em, ok := entry.(map[string]any); ok {
+							if profile, ok := em["profile"].(map[string]any); ok {
+								if name := getString(profile, "name"); name != "" {
+									artists = append(artists, name)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		// Some entity payloads (e.g., recents) provide artists under:
+		//   identityTrait: { contributors: { items: [{ name, uri }] } }
+		if contributors, ok := m["contributors"].(map[string]any); ok {
+			if items, ok := contributors["items"].([]any); ok {
+				for _, entry := range items {
+					em, ok := entry.(map[string]any)
+					if !ok {
+						continue
+					}
+					uri := getString(em, "uri")
+					if uri != "" && !strings.HasPrefix(uri, "spotify:artist:") {
+						continue
+					}
+					if name := getString(em, "name"); name != "" {
+						artists = append(artists, name)
+					}
 				}
 			}
 		}
@@ -355,4 +420,16 @@ func dedupeStrings(values []string) []string {
 		out = append(out, value)
 	}
 	return out
+}
+
+func isSpotifyID(id string) bool {
+	if len(id) != 22 {
+		return false
+	}
+	for _, r := range id {
+		if (r < '0' || r > '9') && (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/spotify/connect_mapping_test.go
+++ b/internal/spotify/connect_mapping_test.go
@@ -32,7 +32,7 @@ func TestSearchPaths(t *testing.T) {
 
 func TestExtractItemFallbacks(t *testing.T) {
 	raw := map[string]any{
-		"id":    "t1",
+		"id":    "79D2D3dKEi4ohriGLxL55t",
 		"title": "Song",
 		"artists": []any{
 			map[string]any{"name": "Artist"},
@@ -51,7 +51,7 @@ func TestExtractItemFallbacks(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected item")
 	}
-	if item.URI != "spotify:track:t1" || item.Name != "Song" {
+	if item.URI != "spotify:track:79D2D3dKEi4ohriGLxL55t" || item.Name != "Song" {
 		t.Fatalf("unexpected item: %#v", item)
 	}
 	if len(item.Artists) != 1 || item.Artists[0] != "Artist" {

--- a/internal/spotify/connect_pathfinder.go
+++ b/internal/spotify/connect_pathfinder.go
@@ -1,18 +1,23 @@
 package spotify
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"net/http"
 	"net/url"
 	"strings"
 )
 
-const pathfinderURL = "https://api-partner.spotify.com/pathfinder/v1/query"
+const pathfinderURL = "https://api-partner.spotify.com/pathfinder/v2/query"
 
 func (c *ConnectClient) graphQL(ctx context.Context, operation string, variables map[string]any) (map[string]any, error) {
+	if c.session == nil {
+		return nil, errors.New("connect session not initialized")
+	}
 	auth, err := c.session.auth(ctx)
 	if err != nil {
 		return nil, err
@@ -21,8 +26,9 @@ func (c *ConnectClient) graphQL(ctx context.Context, operation string, variables
 	if err != nil {
 		return nil, err
 	}
-	params := url.Values{}
-	params.Set("operationName", operation)
+	if os.Getenv("SPOGO_DEBUG_DUMP") != "" {
+		_ = os.WriteFile("/tmp/spogo-hash-"+operation+".txt", []byte(hash+"\n"), 0o600)
+	}
 	if variables == nil {
 		variables = map[string]any{}
 	}
@@ -30,7 +36,7 @@ func (c *ConnectClient) graphQL(ctx context.Context, operation string, variables
 	if err != nil {
 		return nil, err
 	}
-	extensionsJSON, err := json.Marshal(map[string]any{
+	extensions, err := json.Marshal(map[string]any{
 		"persistedQuery": map[string]any{
 			"version":    1,
 			"sha256Hash": hash,
@@ -39,17 +45,28 @@ func (c *ConnectClient) graphQL(ctx context.Context, operation string, variables
 	if err != nil {
 		return nil, err
 	}
-	params.Set("variables", string(variablesJSON))
-	params.Set("extensions", string(extensionsJSON))
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, pathfinderURL+"?"+params.Encode(), nil)
+
+	// Web Player uses POST with a JSON body (not query params) for v2.
+	body, err := json.Marshal(map[string]any{
+		"operationName": operation,
+		"variables":     json.RawMessage(variablesJSON),
+		"extensions":    json.RawMessage(extensions),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, pathfinderURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+auth.AccessToken)
 	req.Header.Set("Client-Token", auth.ClientToken)
-	req.Header.Set("Spotify-App-Version", auth.ClientVersion)
+	req.Header.Set("spotify-app-version", auth.ClientVersion)
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json;charset=UTF-8")
 	req.Header.Set("User-Agent", defaultUserAgent())
+	req.Header.Set("Referer", "https://open.spotify.com/")
 	if c.language != "" {
 		req.Header.Set("Accept-Language", c.language)
 	}
@@ -64,11 +81,21 @@ func (c *ConnectClient) graphQL(ctx context.Context, operation string, variables
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, apiErrorFromResponse(resp)
+		return nil, fmt.Errorf("pathfinder %s: %w", operation, apiErrorFromResponse(resp))
 	}
 	var payload map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		return nil, err
+	}
+	if os.Getenv("SPOGO_DEBUG_DUMP") != "" {
+		switch operation {
+		case "getAlbum", "getTrack", "fetchLibraryTracks", "libraryV3", "fetchEntitiesForRecentlyPlayed", "recents":
+			// Payload is public metadata; dumping it is safe and helps keep the connect extractors aligned
+			// with WebPlayer pathfinder response shapes.
+			if b, err := json.MarshalIndent(payload, "", "  "); err == nil {
+				_ = os.WriteFile("/tmp/spogo-pathfinder-"+operation+".json", b, 0o600)
+			}
+		}
 	}
 	if err := pathfinderError(payload); err != nil {
 		return nil, err
@@ -147,7 +174,17 @@ func (c *ConnectClient) trackInfo(ctx context.Context, id string) (Item, error) 
 }
 
 func (c *ConnectClient) albumInfo(ctx context.Context, id string) (Item, error) {
-	item, err := c.infoByOperation(ctx, "getAlbum", map[string]any{"uri": "spotify:album:" + id}, "album")
+	// WebPlayer getAlbum requires pagination + locale variables; sending only `uri` can yield 500s.
+	locale := c.language
+	if locale == "" {
+		locale = ""
+	}
+	item, err := c.infoByOperation(ctx, "getAlbum", map[string]any{
+		"uri":    "spotify:album:" + id,
+		"locale": locale,
+		"offset": 0,
+		"limit":  50,
+	}, "album")
 	if err == nil {
 		return item, nil
 	}
@@ -155,7 +192,11 @@ func (c *ConnectClient) albumInfo(ctx context.Context, id string) (Item, error) 
 	if ferr != nil {
 		return Item{}, err
 	}
-	return web.GetAlbum(ctx, id)
+	item, werr := web.GetAlbum(ctx, id)
+	if werr == nil {
+		return item, nil
+	}
+	return Item{}, fmt.Errorf("connect album info failed (%v); web fallback failed (%v)", err, werr)
 }
 
 func (c *ConnectClient) artistInfo(ctx context.Context, id string) (Item, error) {
@@ -316,7 +357,7 @@ func (c *ConnectClient) webClient() (*Client, error) {
 	if c.web != nil {
 		return c.web, nil
 	}
-	provider := CookieTokenProvider{Source: c.source, Client: c.client}
+	provider := connectTokenProvider{session: c.session}
 	client, err := NewClient(Options{
 		TokenProvider: provider,
 		HTTPClient:    c.client,

--- a/internal/spotify/connect_pathfinder.go
+++ b/internal/spotify/connect_pathfinder.go
@@ -179,14 +179,23 @@ func (c *ConnectClient) albumInfo(ctx context.Context, id string) (Item, error) 
 	if locale == "" {
 		locale = ""
 	}
-	item, err := c.infoByOperation(ctx, "getAlbum", map[string]any{
+
+	payload, err := c.graphQL(ctx, "getAlbum", map[string]any{
 		"uri":    "spotify:album:" + id,
 		"locale": locale,
 		"offset": 0,
 		"limit":  50,
-	}, "album")
+	})
 	if err == nil {
-		return item, nil
+		if item, ok := extractAlbumFromPathfinder(payload); ok {
+			return item, nil
+		}
+		// Fallback to the generic extractor (may miss tracks/date, but keeps behavior stable
+		// across evolving response shapes).
+		if item, ok := extractItemFromPayload(payload, "album"); ok {
+			return item, nil
+		}
+		return Item{}, errors.New("no album found")
 	}
 	web, ferr := c.webClient()
 	if ferr != nil {
@@ -197,6 +206,149 @@ func (c *ConnectClient) albumInfo(ctx context.Context, id string) (Item, error) 
 		return item, nil
 	}
 	return Item{}, fmt.Errorf("connect album info failed (%v); web fallback failed (%v)", err, werr)
+}
+
+func extractAlbumFromPathfinder(payload map[string]any) (Item, bool) {
+	data, ok := payload["data"].(map[string]any)
+	if !ok {
+		return Item{}, false
+	}
+	album, ok := data["albumUnion"].(map[string]any)
+	if !ok {
+		album, ok = data["album"].(map[string]any)
+		if !ok {
+			return Item{}, false
+		}
+	}
+	uri := getString(album, "uri")
+	if uri == "" || !strings.HasPrefix(uri, "spotify:album:") {
+		return Item{}, false
+	}
+	item := Item{
+		URI:  uri,
+		ID:   idFromURI(uri),
+		Name: getString(album, "name"),
+		Type: "album",
+	}
+	item.URL = fmt.Sprintf("https://open.spotify.com/album/%s", item.ID)
+
+	if artists, ok := album["artists"].(map[string]any); ok {
+		if list, ok := artists["items"].([]any); ok {
+			for _, entry := range list {
+				if m, ok := entry.(map[string]any); ok {
+					if name := extractProfileName(m); name != "" {
+						item.Artists = append(item.Artists, name)
+					}
+				}
+			}
+		}
+	}
+
+	if date, ok := album["date"].(map[string]any); ok {
+		item.ReleaseDate = formatPathfinderDate(date)
+	}
+
+	if tracksV2, ok := album["tracksV2"].(map[string]any); ok {
+		item.TotalTracks = getInt(tracksV2, "totalCount")
+		if item.TotalTracks == 0 {
+			item.TotalTracks = getInt(tracksV2, "totalTracks")
+		}
+		if list, ok := tracksV2["items"].([]any); ok {
+			tracks := make([]Item, 0, len(list))
+			for _, entry := range list {
+				m, ok := entry.(map[string]any)
+				if !ok {
+					continue
+				}
+				track, ok := m["track"].(map[string]any)
+				if !ok {
+					continue
+				}
+				t := mapPathfinderTrack(track)
+				if t.ID != "" {
+					tracks = append(tracks, t)
+				}
+			}
+			item.Tracks = tracks
+			if item.TotalTracks == 0 {
+				item.TotalTracks = len(tracks)
+			}
+		}
+	}
+
+	return item, true
+}
+
+func extractProfileName(value map[string]any) string {
+	if name := getString(value, "name"); name != "" {
+		return name
+	}
+	if profile, ok := value["profile"].(map[string]any); ok {
+		if name := getString(profile, "name"); name != "" {
+			return name
+		}
+	}
+	if data, ok := value["data"].(map[string]any); ok {
+		if name := getString(data, "name"); name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+func formatPathfinderDate(date map[string]any) string {
+	iso := getString(date, "isoString")
+	if iso == "" {
+		return ""
+	}
+	precision := strings.ToUpper(getString(date, "precision"))
+	switch precision {
+	case "YEAR":
+		if len(iso) >= 4 {
+			return iso[:4]
+		}
+	case "MONTH":
+		if len(iso) >= 7 {
+			return iso[:7]
+		}
+	case "DAY":
+		if len(iso) >= 10 {
+			return iso[:10]
+		}
+	}
+	if len(iso) >= 10 {
+		return iso[:10]
+	}
+	return iso
+}
+
+func mapPathfinderTrack(track map[string]any) Item {
+	uri := getString(track, "uri")
+	if uri == "" || !strings.HasPrefix(uri, "spotify:track:") {
+		return Item{}
+	}
+	item := Item{
+		URI:  uri,
+		ID:   idFromURI(uri),
+		Name: getString(track, "name"),
+		Type: "track",
+	}
+	item.URL = fmt.Sprintf("https://open.spotify.com/track/%s", item.ID)
+	if duration, ok := track["duration"].(map[string]any); ok {
+		item.DurationMS = getInt(duration, "totalMilliseconds")
+	}
+	if artists, ok := track["artists"].(map[string]any); ok {
+		if list, ok := artists["items"].([]any); ok {
+			for _, entry := range list {
+				if m, ok := entry.(map[string]any); ok {
+					if name := extractProfileName(m); name != "" {
+						item.Artists = append(item.Artists, name)
+					}
+				}
+			}
+		}
+	}
+	return item
 }
 
 func (c *ConnectClient) artistInfo(ctx context.Context, id string) (Item, error) {

--- a/internal/spotify/connect_pathfinder.go
+++ b/internal/spotify/connect_pathfinder.go
@@ -192,7 +192,10 @@ func (c *ConnectClient) albumInfo(ctx context.Context, id string) (Item, error) 
 				web, ferr := c.webClient()
 				if ferr == nil {
 					webItem, werr := web.GetAlbum(ctx, id)
-					if werr == nil && len(webItem.Tracks) >= len(item.Tracks) {
+					if werr == nil &&
+						(len(webItem.Tracks) > len(item.Tracks) ||
+							(item.TotalTracks > 0 &&
+								len(webItem.Tracks) >= item.TotalTracks)) {
 						return webItem, nil
 					}
 				}

--- a/internal/spotify/connect_pathfinder.go
+++ b/internal/spotify/connect_pathfinder.go
@@ -6,9 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 )
 
@@ -188,6 +188,15 @@ func (c *ConnectClient) albumInfo(ctx context.Context, id string) (Item, error) 
 	})
 	if err == nil {
 		if item, ok := extractAlbumFromPathfinder(payload); ok {
+			if item.TotalTracks > len(item.Tracks) {
+				web, ferr := c.webClient()
+				if ferr == nil {
+					webItem, werr := web.GetAlbum(ctx, id)
+					if werr == nil && len(webItem.Tracks) >= len(item.Tracks) {
+						return webItem, nil
+					}
+				}
+			}
 			return item, nil
 		}
 		// Fallback to the generic extractor (may miss tracks/date, but keeps behavior stable

--- a/internal/spotify/connect_token_provider.go
+++ b/internal/spotify/connect_token_provider.go
@@ -1,0 +1,33 @@
+package spotify
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// connectTokenProvider exposes the already-established connect session access token
+// through the generic TokenProvider interface used by the Web API client.
+//
+// This avoids additional /api/token calls (which can get 429'd) when we already have
+// a valid access token from the connect session.
+type connectTokenProvider struct {
+	session *connectSession
+}
+
+func (p connectTokenProvider) Token(ctx context.Context) (Token, error) {
+	if p.session == nil {
+		return Token{}, errors.New("connect session not initialized")
+	}
+	auth, err := p.session.auth(ctx)
+	if err != nil {
+		return Token{}, err
+	}
+	// The connect session manages the real expiry; we only need a reasonable TTL to
+	// keep the Web API client from refreshing too aggressively.
+	return Token{
+		AccessToken: auth.AccessToken,
+		ExpiresAt:   time.Now().Add(30 * time.Minute),
+	}, nil
+}
+

--- a/internal/spotify/fallback.go
+++ b/internal/spotify/fallback.go
@@ -214,3 +214,7 @@ func (c *fallbackClient) AddTracks(ctx context.Context, playlistID string, uris 
 func (c *fallbackClient) RemoveTracks(ctx context.Context, playlistID string, uris []string) error {
 	return c.web.RemoveTracks(ctx, playlistID, uris)
 }
+
+func (c *fallbackClient) RecentlyPlayed(ctx context.Context, limit int) ([]RecentItem, error) {
+	return c.web.RecentlyPlayed(ctx, limit)
+}

--- a/internal/spotify/fallback.go
+++ b/internal/spotify/fallback.go
@@ -207,8 +207,13 @@ func (c *fallbackClient) CreatePlaylist(ctx context.Context, name string, public
 	return c.web.CreatePlaylist(ctx, name, public, collaborative)
 }
 
-func (c *fallbackClient) AddTracks(ctx context.Context, playlistID string, uris []string) error {
-	return c.web.AddTracks(ctx, playlistID, uris)
+func (c *fallbackClient) AddTracks(
+	ctx context.Context,
+	playlistID string,
+	uris []string,
+	position *int,
+) error {
+	return c.web.AddTracks(ctx, playlistID, uris, position)
 }
 
 func (c *fallbackClient) RemoveTracks(ctx context.Context, playlistID string, uris []string) error {

--- a/internal/spotify/fallback.go
+++ b/internal/spotify/fallback.go
@@ -207,6 +207,10 @@ func (c *fallbackClient) CreatePlaylist(ctx context.Context, name string, public
 	return c.web.CreatePlaylist(ctx, name, public, collaborative)
 }
 
+func (c *fallbackClient) UpdatePlaylist(ctx context.Context, playlistID string, update PlaylistUpdate) (Item, error) {
+	return c.web.UpdatePlaylist(ctx, playlistID, update)
+}
+
 func (c *fallbackClient) AddTracks(
 	ctx context.Context,
 	playlistID string,

--- a/internal/spotify/fallback_test.go
+++ b/internal/spotify/fallback_test.go
@@ -15,6 +15,7 @@ type apiStub struct {
 	libraryModifyFn   func(context.Context, string, []string, string) error
 	followedArtistsFn func(context.Context, int, string) ([]Item, int, string, error)
 	artistTopTracksFn func(context.Context, string, int) ([]Item, error)
+	recentlyPlayedFn  func(context.Context, int) ([]RecentItem, error)
 }
 
 func (a apiStub) Search(ctx context.Context, kind, query string, limit, offset int) (SearchResult, error) {
@@ -194,6 +195,14 @@ func (a apiStub) AddTracks(context.Context, string, []string) error {
 func (a apiStub) RemoveTracks(context.Context, string, []string) error {
 	a.note("RemoveTracks")
 	return nil
+}
+
+func (a apiStub) RecentlyPlayed(ctx context.Context, limit int) ([]RecentItem, error) {
+	a.note("RecentlyPlayed")
+	if a.recentlyPlayedFn != nil {
+		return a.recentlyPlayedFn(ctx, limit)
+	}
+	return nil, nil
 }
 
 func (a apiStub) note(name string) {

--- a/internal/spotify/fallback_test.go
+++ b/internal/spotify/fallback_test.go
@@ -187,7 +187,7 @@ func (a apiStub) CreatePlaylist(context.Context, string, bool, bool) (Item, erro
 	return Item{}, nil
 }
 
-func (a apiStub) AddTracks(context.Context, string, []string) error {
+func (a apiStub) AddTracks(context.Context, string, []string, *int) error {
 	a.note("AddTracks")
 	return nil
 }
@@ -420,7 +420,7 @@ func TestFallbackDelegatesToWeb(t *testing.T) {
 	if _, err := client.CreatePlaylist(ctx, "Name", true, false); err != nil {
 		t.Fatalf("create playlist: %v", err)
 	}
-	if err := client.AddTracks(ctx, "p1", []string{"spotify:track:t1"}); err != nil {
+	if err := client.AddTracks(ctx, "p1", []string{"spotify:track:t1"}, nil); err != nil {
 		t.Fatalf("add tracks: %v", err)
 	}
 	if err := client.RemoveTracks(ctx, "p1", []string{"spotify:track:t1"}); err != nil {

--- a/internal/spotify/fallback_test.go
+++ b/internal/spotify/fallback_test.go
@@ -187,6 +187,11 @@ func (a apiStub) CreatePlaylist(context.Context, string, bool, bool) (Item, erro
 	return Item{}, nil
 }
 
+func (a apiStub) UpdatePlaylist(context.Context, string, PlaylistUpdate) (Item, error) {
+	a.note("UpdatePlaylist")
+	return Item{}, nil
+}
+
 func (a apiStub) AddTracks(context.Context, string, []string, *int) error {
 	a.note("AddTracks")
 	return nil

--- a/internal/spotify/mapper.go
+++ b/internal/spotify/mapper.go
@@ -61,6 +61,10 @@ func mapTrack(t trackItem) Item {
 }
 
 func mapAlbum(a albumItem) Item {
+	tracks := make([]Item, 0, len(a.Tracks.Items))
+	for _, track := range a.Tracks.Items {
+		tracks = append(tracks, mapAlbumTrack(track, a.Name))
+	}
 	return Item{
 		ID:          a.ID,
 		URI:         a.URI,
@@ -70,7 +74,16 @@ func mapAlbum(a albumItem) Item {
 		Artists:     artistNames(a.Artists),
 		ReleaseDate: a.ReleaseDate,
 		TotalTracks: a.TotalTracks,
+		Tracks:      tracks,
 	}
+}
+
+func mapAlbumTrack(t trackItem, albumName string) Item {
+	item := mapTrack(t)
+	if item.Album == "" {
+		item.Album = albumName
+	}
+	return item
 }
 
 func mapArtist(a artistItem) Item {

--- a/internal/spotify/mapper.go
+++ b/internal/spotify/mapper.go
@@ -100,14 +100,16 @@ func mapArtist(a artistItem) Item {
 
 func mapPlaylist(p playlistItem) Item {
 	return Item{
-		ID:          p.ID,
-		URI:         p.URI,
-		Name:        p.Name,
-		Type:        "playlist",
-		URL:         externalURL(p.ExternalURLs),
-		Owner:       p.Owner.DisplayName,
-		TotalTracks: p.Tracks.Total,
-		Description: p.Description,
+		ID:            p.ID,
+		URI:           p.URI,
+		Name:          p.Name,
+		Type:          "playlist",
+		URL:           externalURL(p.ExternalURLs),
+		Owner:         p.Owner.DisplayName,
+		TotalTracks:   p.Tracks.Total,
+		Description:   p.Description,
+		Public:        boolPtr(p.Public),
+		Collaborative: boolPtr(p.Collaborative),
 	}
 }
 
@@ -138,6 +140,11 @@ func mapEpisode(e episodeItem) Item {
 
 func mapDevice(d deviceItem) Device {
 	return Device(d)
+}
+
+func boolPtr(value bool) *bool {
+	v := value
+	return &v
 }
 
 func artistNames(artists []artistRef) []string {

--- a/internal/spotify/models.go
+++ b/internal/spotify/models.go
@@ -27,6 +27,16 @@ type albumItem struct {
 	TotalTracks  int               `json:"total_tracks"`
 	Artists      []artistRef       `json:"artists"`
 	ExternalURLs map[string]string `json:"external_urls"`
+	Tracks       albumTracksPage   `json:"tracks"`
+}
+
+type albumTracksPage struct {
+	Href   string      `json:"href"`
+	Items  []trackItem `json:"items"`
+	Limit  int         `json:"limit"`
+	Offset int         `json:"offset"`
+	Total  int         `json:"total"`
+	Next   string      `json:"next"`
 }
 
 type artistRef struct {

--- a/internal/spotify/models.go
+++ b/internal/spotify/models.go
@@ -65,11 +65,13 @@ type albumRef struct {
 }
 
 type playlistItem struct {
-	ID          string `json:"id"`
-	URI         string `json:"uri"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Owner       struct {
+	ID            string `json:"id"`
+	URI           string `json:"uri"`
+	Name          string `json:"name"`
+	Description   string `json:"description"`
+	Public        bool   `json:"public"`
+	Collaborative bool   `json:"collaborative"`
+	Owner         struct {
 		DisplayName string `json:"display_name"`
 	} `json:"owner"`
 	Tracks struct {

--- a/internal/spotify/models.go
+++ b/internal/spotify/models.go
@@ -159,3 +159,10 @@ type artistsContainer struct {
 type artistTopTracksResponse struct {
 	Tracks []trackItem `json:"tracks"`
 }
+
+type recentlyPlayedResponse struct {
+	Items []struct {
+		Track    trackItem `json:"track"`
+		PlayedAt string    `json:"played_at"`
+	} `json:"items"`
+}

--- a/internal/spotify/types.go
+++ b/internal/spotify/types.go
@@ -20,6 +20,7 @@ type Item struct {
 	IsPlayable    bool     `json:"is_playable,omitempty"`
 	Publisher     string   `json:"publisher,omitempty"`
 	TotalEpisodes int      `json:"total_episodes,omitempty"`
+	Tracks        []Item   `json:"tracks,omitempty"`
 }
 
 type SearchResult struct {

--- a/internal/spotify/types.go
+++ b/internal/spotify/types.go
@@ -14,6 +14,8 @@ type Item struct {
 	TotalTracks   int      `json:"total_tracks,omitempty"`
 	ReleaseDate   string   `json:"release_date,omitempty"`
 	Description   string   `json:"description,omitempty"`
+	Public        *bool    `json:"public,omitempty"`
+	Collaborative *bool    `json:"collaborative,omitempty"`
 	TotalItems    int      `json:"total_items,omitempty"`
 	Followers     int      `json:"followers,omitempty"`
 	Genres        []string `json:"genres,omitempty"`
@@ -21,6 +23,13 @@ type Item struct {
 	Publisher     string   `json:"publisher,omitempty"`
 	TotalEpisodes int      `json:"total_episodes,omitempty"`
 	Tracks        []Item   `json:"tracks,omitempty"`
+}
+
+type PlaylistUpdate struct {
+	Name          *string
+	Public        *bool
+	Collaborative *bool
+	Description   *string
 }
 
 type SearchResult struct {

--- a/internal/spotify/types.go
+++ b/internal/spotify/types.go
@@ -52,3 +52,8 @@ type Queue struct {
 	CurrentlyPlaying *Item  `json:"currently_playing,omitempty"`
 	Queue            []Item `json:"queue"`
 }
+
+type RecentItem struct {
+	Track    Item   `json:"track"`
+	PlayedAt string `json:"played_at"`
+}

--- a/internal/testutil/spotify_mock.go
+++ b/internal/testutil/spotify_mock.go
@@ -41,6 +41,7 @@ type SpotifyMock struct {
 	CreatePlaylistFn  func(context.Context, string, bool, bool) (spotify.Item, error)
 	AddTracksFn       func(context.Context, string, []string) error
 	RemoveTracksFn    func(context.Context, string, []string) error
+	RecentlyPlayedFn  func(context.Context, int) ([]spotify.RecentItem, error)
 }
 
 func (m *SpotifyMock) Search(ctx context.Context, kind, query string, limit, offset int) (spotify.SearchResult, error) {
@@ -258,4 +259,11 @@ func (m *SpotifyMock) RemoveTracks(ctx context.Context, playlistID string, uris 
 		return ErrNotImplemented
 	}
 	return m.RemoveTracksFn(ctx, playlistID, uris)
+}
+
+func (m *SpotifyMock) RecentlyPlayed(ctx context.Context, limit int) ([]spotify.RecentItem, error) {
+	if m.RecentlyPlayedFn == nil {
+		return nil, ErrNotImplemented
+	}
+	return m.RecentlyPlayedFn(ctx, limit)
 }

--- a/internal/testutil/spotify_mock.go
+++ b/internal/testutil/spotify_mock.go
@@ -39,7 +39,7 @@ type SpotifyMock struct {
 	PlaylistsFn       func(context.Context, int, int) ([]spotify.Item, int, error)
 	PlaylistTracksFn  func(context.Context, string, int, int) ([]spotify.Item, int, error)
 	CreatePlaylistFn  func(context.Context, string, bool, bool) (spotify.Item, error)
-	AddTracksFn       func(context.Context, string, []string) error
+	AddTracksFn       func(context.Context, string, []string, *int) error
 	RemoveTracksFn    func(context.Context, string, []string) error
 	RecentlyPlayedFn  func(context.Context, int) ([]spotify.RecentItem, error)
 }
@@ -247,11 +247,16 @@ func (m *SpotifyMock) CreatePlaylist(ctx context.Context, name string, public, c
 	return m.CreatePlaylistFn(ctx, name, public, collaborative)
 }
 
-func (m *SpotifyMock) AddTracks(ctx context.Context, playlistID string, uris []string) error {
+func (m *SpotifyMock) AddTracks(
+	ctx context.Context,
+	playlistID string,
+	uris []string,
+	position *int,
+) error {
 	if m.AddTracksFn == nil {
 		return ErrNotImplemented
 	}
-	return m.AddTracksFn(ctx, playlistID, uris)
+	return m.AddTracksFn(ctx, playlistID, uris, position)
 }
 
 func (m *SpotifyMock) RemoveTracks(ctx context.Context, playlistID string, uris []string) error {

--- a/internal/testutil/spotify_mock.go
+++ b/internal/testutil/spotify_mock.go
@@ -39,6 +39,7 @@ type SpotifyMock struct {
 	PlaylistsFn       func(context.Context, int, int) ([]spotify.Item, int, error)
 	PlaylistTracksFn  func(context.Context, string, int, int) ([]spotify.Item, int, error)
 	CreatePlaylistFn  func(context.Context, string, bool, bool) (spotify.Item, error)
+	UpdatePlaylistFn  func(context.Context, string, spotify.PlaylistUpdate) (spotify.Item, error)
 	AddTracksFn       func(context.Context, string, []string, *int) error
 	RemoveTracksFn    func(context.Context, string, []string) error
 	RecentlyPlayedFn  func(context.Context, int) ([]spotify.RecentItem, error)
@@ -245,6 +246,13 @@ func (m *SpotifyMock) CreatePlaylist(ctx context.Context, name string, public, c
 		return spotify.Item{}, ErrNotImplemented
 	}
 	return m.CreatePlaylistFn(ctx, name, public, collaborative)
+}
+
+func (m *SpotifyMock) UpdatePlaylist(ctx context.Context, playlistID string, update spotify.PlaylistUpdate) (spotify.Item, error) {
+	if m.UpdatePlaylistFn == nil {
+		return spotify.Item{}, ErrNotImplemented
+	}
+	return m.UpdatePlaylistFn(ctx, playlistID, update)
 }
 
 func (m *SpotifyMock) AddTracks(

--- a/internal/testutil/spotify_mock_notimpl_test.go
+++ b/internal/testutil/spotify_mock_notimpl_test.go
@@ -35,6 +35,6 @@ func TestSpotifyMockAllNotImplemented(t *testing.T) {
 	_, _, _ = m.Playlists(context.Background(), 1, 0)
 	_, _, _ = m.PlaylistTracks(context.Background(), "1", 1, 0)
 	_, _ = m.CreatePlaylist(context.Background(), "name", true, false)
-	_ = m.AddTracks(context.Background(), "p", []string{"u"})
+	_ = m.AddTracks(context.Background(), "p", []string{"u"}, nil)
 	_ = m.RemoveTracks(context.Background(), "p", []string{"u"})
 }

--- a/internal/testutil/spotify_mock_notimpl_test.go
+++ b/internal/testutil/spotify_mock_notimpl_test.go
@@ -3,6 +3,8 @@ package testutil
 import (
 	"context"
 	"testing"
+
+	"github.com/steipete/spogo/internal/spotify"
 )
 
 func TestSpotifyMockAllNotImplemented(t *testing.T) {
@@ -35,6 +37,7 @@ func TestSpotifyMockAllNotImplemented(t *testing.T) {
 	_, _, _ = m.Playlists(context.Background(), 1, 0)
 	_, _, _ = m.PlaylistTracks(context.Background(), "1", 1, 0)
 	_, _ = m.CreatePlaylist(context.Background(), "name", true, false)
+	_, _ = m.UpdatePlaylist(context.Background(), "p", spotify.PlaylistUpdate{})
 	_ = m.AddTracks(context.Background(), "p", []string{"u"}, nil)
 	_ = m.RemoveTracks(context.Background(), "p", []string{"u"})
 }

--- a/internal/testutil/spotify_mock_test.go
+++ b/internal/testutil/spotify_mock_test.go
@@ -39,8 +39,11 @@ func TestSpotifyMockAllMethods(t *testing.T) {
 		PlaylistsFn:       func(context.Context, int, int) ([]spotify.Item, int, error) { return nil, 0, nil },
 		PlaylistTracksFn:  func(context.Context, string, int, int) ([]spotify.Item, int, error) { return nil, 0, nil },
 		CreatePlaylistFn:  func(context.Context, string, bool, bool) (spotify.Item, error) { return spotify.Item{}, nil },
-		AddTracksFn:       func(context.Context, string, []string, *int) error { return nil },
-		RemoveTracksFn:    func(context.Context, string, []string) error { return nil },
+		UpdatePlaylistFn: func(context.Context, string, spotify.PlaylistUpdate) (spotify.Item, error) {
+			return spotify.Item{}, nil
+		},
+		AddTracksFn:    func(context.Context, string, []string, *int) error { return nil },
+		RemoveTracksFn: func(context.Context, string, []string) error { return nil },
 	}
 	_, _ = m.Search(context.Background(), "track", "q", 1, 0)
 	_, _ = m.GetTrack(context.Background(), "1")
@@ -70,6 +73,7 @@ func TestSpotifyMockAllMethods(t *testing.T) {
 	_, _, _ = m.Playlists(context.Background(), 1, 0)
 	_, _, _ = m.PlaylistTracks(context.Background(), "1", 1, 0)
 	_, _ = m.CreatePlaylist(context.Background(), "name", true, false)
+	_, _ = m.UpdatePlaylist(context.Background(), "p", spotify.PlaylistUpdate{})
 	_ = m.AddTracks(context.Background(), "p", []string{"u"}, nil)
 	_ = m.RemoveTracks(context.Background(), "p", []string{"u"})
 }

--- a/internal/testutil/spotify_mock_test.go
+++ b/internal/testutil/spotify_mock_test.go
@@ -39,7 +39,7 @@ func TestSpotifyMockAllMethods(t *testing.T) {
 		PlaylistsFn:       func(context.Context, int, int) ([]spotify.Item, int, error) { return nil, 0, nil },
 		PlaylistTracksFn:  func(context.Context, string, int, int) ([]spotify.Item, int, error) { return nil, 0, nil },
 		CreatePlaylistFn:  func(context.Context, string, bool, bool) (spotify.Item, error) { return spotify.Item{}, nil },
-		AddTracksFn:       func(context.Context, string, []string) error { return nil },
+		AddTracksFn:       func(context.Context, string, []string, *int) error { return nil },
 		RemoveTracksFn:    func(context.Context, string, []string) error { return nil },
 	}
 	_, _ = m.Search(context.Background(), "track", "q", 1, 0)
@@ -70,7 +70,7 @@ func TestSpotifyMockAllMethods(t *testing.T) {
 	_, _, _ = m.Playlists(context.Background(), 1, 0)
 	_, _, _ = m.PlaylistTracks(context.Background(), "1", 1, 0)
 	_, _ = m.CreatePlaylist(context.Background(), "name", true, false)
-	_ = m.AddTracks(context.Background(), "p", []string{"u"})
+	_ = m.AddTracks(context.Background(), "p", []string{"u"}, nil)
 	_ = m.RemoveTracks(context.Background(), "p", []string{"u"})
 }
 


### PR DESCRIPTION
## Summary
- add `playlist update` CLI support for renaming and editing playlist metadata
- route playlist metadata writes through the connect playlist changes endpoint
- support collaborative playlist create/update in the connect engine
- make auto mode prefer connect for metadata edits and fall back only when needed
- add regression coverage for connect and auto playlist update behavior

## Testing
- go test ./...
- live smoke test with cookie-backed auth: created a collaborative playlist, renamed it, and toggled collaborative off successfully