### PR TITLE
Fix Connect volume requests

### DIFF
--- a/internal/spotify/connect_commands.go
+++ b/internal/spotify/connect_commands.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 )
 
@@ -83,7 +84,8 @@ func (c *ConnectClient) volume(ctx context.Context, volume int) error {
 		if fromID == "" || state.activeDeviceID == "" {
 			return errors.New("missing device id")
 		}
-		return c.sendConnectCommand(ctx, fmt.Sprintf("%s/connect/volume/from/%s/to/%s", connectStateBase, fromID, state.activeDeviceID), map[string]any{
+		url := fmt.Sprintf("%s/connect/volume/from/%s/to/%s", connectStateBase, fromID, state.activeDeviceID)
+		return c.sendConnectRequest(ctx, http.MethodPut, url, map[string]any{
 			"volume": int(float64(volume) / 100 * 65535),
 		})
 	})

--- a/internal/spotify/connect_playback_test.go
+++ b/internal/spotify/connect_playback_test.go
@@ -32,6 +32,11 @@ func TestConnectPlaybackCommands(t *testing.T) {
 		switch {
 		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/devices/hobs_"):
 			return jsonResponse(http.StatusOK, statePayload), nil
+		case strings.Contains(req.URL.Path, "/connect/volume/"):
+			if req.Method != http.MethodPut {
+				return textResponse(http.StatusMethodNotAllowed, "method not allowed"), nil
+			}
+			return textResponse(http.StatusOK, "ok"), nil
 		case req.Method == http.MethodPost:
 			return textResponse(http.StatusOK, "ok"), nil
 		default:

--- a/internal/spotify/connect_transport.go
+++ b/internal/spotify/connect_transport.go
@@ -207,11 +207,15 @@ func (c *ConnectClient) sendPlayerCommand(ctx context.Context, state connectStat
 }
 
 func (c *ConnectClient) sendConnectCommand(ctx context.Context, url string, payload map[string]any) error {
+	return c.sendConnectRequest(ctx, http.MethodPost, url, payload)
+}
+
+func (c *ConnectClient) sendConnectRequest(ctx context.Context, method, url string, payload map[string]any) error {
 	auth, err := c.session.auth(ctx)
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, encodeJSON(payload))
+	req, err := http.NewRequestWithContext(ctx, method, url, encodeJSON(payload))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Connect volume changes were failing with 405 Method Not Allowed. The `/connect/volume/from/.../to/...` endpoint uses PUT, while the generic Connect command helper always posted.

This keeps the existing POST helper for player commands and adds a method-aware helper so volume can use PUT without changing play/pause/skip/etc.

Tested with:

```sh
go test ./internal/spotify
```