### PR TITLE
perf: cache Connect auth and playback routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.0 - Unreleased
 
 - Improve Connect playback latency by caching web auth, client tokens, and the active command route between invocations (`#25`, thanks @kk-spartans)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Improve Connect playback latency by caching web auth, client tokens, and the active command route between invocations (`#25`, thanks @kk-spartans)
+
 ## 0.3.1 - 2026-05-10
 
 - Fix Connect Pathfinder track metadata extraction for explicit ratings, nested durations, and playability (`#26`, thanks @theDimZone)

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ printf '%s\n%s\n' "sp_dc=..." "sp_t=..." | spogo auth paste --no-input
 ## Connect engine notes
 
 - `connect` uses Spotify's internal connect-state endpoints for playback control.
+- Auth/session data and the last active playback route are cached per profile so repeated playback commands avoid a full Connect state refresh when the route is still valid.
 - Search/info prefer the internal GraphQL API and fall back to web search if hashes can’t be resolved.
 
 ## Web engine notes

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -125,7 +125,7 @@ spogo [global flags] <command> [args]
 ## Engines
 
 - `auto`: connect first; fall back to web for unsupported features or rate limits.
-- `connect`: internal connect-state endpoints for playback; GraphQL for search/info.
+- `connect`: internal connect-state endpoints for playback; GraphQL for search/info. Auth/session data and the last active playback route are cached per profile.
 - `web`: Web API endpoints; search/info/playback auto-fallback to connect when rate limited.
 
 ## Exit codes

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,4 +1,4 @@
-# spogo CLI spec (v0.3.1)
+# spogo CLI spec (v0.4.0-unreleased)
 
 One-liner: Spotify power CLI using web cookies; search + playback control.
 Parser: Kong.

--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/steipete/spogo/internal/config"
@@ -65,6 +66,21 @@ func (c *Context) SaveProfile(profile config.Profile) error {
 
 func (c *Context) ResolveCookiePath() string {
 	return config.CookiePath(c.ConfigPath, c.ProfileKey)
+}
+
+func (c *Context) ResolveCachePath() string {
+	return config.CachePath(c.ConfigPath, c.ProfileKey)
+}
+
+func (c *Context) ClearCache() error {
+	path := c.ResolveCachePath()
+	if path == "" {
+		return nil
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
 }
 
 func (c *Context) EnsureTimeout() time.Duration {

--- a/internal/app/context_factory.go
+++ b/internal/app/context_factory.go
@@ -90,11 +90,12 @@ func (c *Context) newAppleScriptClient(source cookies.Source) (spotify.API, erro
 
 func (c *Context) newConnectClient(source cookies.Source) (*spotify.ConnectClient, error) {
 	return spotify.NewConnectClient(spotify.ConnectOptions{
-		Source:   source,
-		Market:   c.Profile.Market,
-		Language: c.Profile.Language,
-		Device:   c.Profile.Device,
-		Timeout:  c.Settings.Timeout,
+		Source:    source,
+		Market:    c.Profile.Market,
+		Language:  c.Profile.Language,
+		Device:    c.Profile.Device,
+		Timeout:   c.Settings.Timeout,
+		CachePath: c.ResolveCachePath(),
 	})
 }
 

--- a/internal/app/context_test.go
+++ b/internal/app/context_test.go
@@ -42,6 +42,27 @@ func TestResolveCookiePath(t *testing.T) {
 	}
 }
 
+func TestClearCache(t *testing.T) {
+	dir := t.TempDir()
+	ctx := &Context{ConfigPath: filepath.Join(dir, "config.toml"), ProfileKey: "default"}
+	path := ctx.ResolveCachePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := ctx.ClearCache(); err != nil {
+		t.Fatalf("clear cache: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected cache removed, err=%v", err)
+	}
+	if err := ctx.ClearCache(); err != nil {
+		t.Fatalf("clear missing cache: %v", err)
+	}
+}
+
 func TestValidateProfile(t *testing.T) {
 	ctx := &Context{Profile: config.Profile{Market: "USA"}}
 	if err := ctx.ValidateProfile(); err == nil {

--- a/internal/cli/auth_import.go
+++ b/internal/cli/auth_import.go
@@ -62,6 +62,9 @@ func saveCookies(ctx *app.Context, path string, cookiesList []*http.Cookie, prof
 	if err := ctx.SaveProfile(profileCfg); err != nil {
 		return err
 	}
+	if err := ctx.ClearCache(); err != nil {
+		return err
+	}
 	human := []string{fmt.Sprintf("Saved %d cookies to %s", len(cookiesList), path)}
 	plain := []string{fmt.Sprintf("%d\t%s", len(cookiesList), path)}
 	payload := map[string]any{"cookie_count": len(cookiesList), "path": path}

--- a/internal/cli/auth_store.go
+++ b/internal/cli/auth_store.go
@@ -29,6 +29,9 @@ func (cmd *AuthClearCmd) Run(ctx *app.Context) error {
 	if err := ctx.SaveProfile(profileCfg); err != nil {
 		return err
 	}
+	if err := ctx.ClearCache(); err != nil {
+		return err
+	}
 	return ctx.Output.Emit(map[string]string{"status": "ok"}, []string{"ok"}, []string{fmt.Sprintf("Moved %s to Trash", path)})
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -10,7 +10,7 @@ import (
 	"github.com/steipete/spogo/internal/output"
 )
 
-const Version = "0.3.1"
+const Version = "0.4.0-unreleased"
 
 func New() *CLI {
 	return &CLI{}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -128,6 +128,17 @@ func CookiePath(configPath, profile string) string {
 	return filepath.Join(base, "cookies", profile+".json")
 }
 
+func CachePath(configPath, profile string) string {
+	if profile == "" {
+		profile = DefaultProfile
+	}
+	if configPath == "" {
+		return ""
+	}
+	base := filepath.Dir(configPath)
+	return filepath.Join(base, "cache", profile+".json")
+}
+
 func (c *Config) normalize() {
 	if c.DefaultProfile == "" {
 		c.DefaultProfile = DefaultProfile

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -71,6 +71,22 @@ func TestCookiePathEmptyConfig(t *testing.T) {
 	}
 }
 
+func TestCachePath(t *testing.T) {
+	path := CachePath("/tmp/spogo/config.toml", "default")
+	if filepath.Base(path) != "default.json" {
+		t.Fatalf("cache path: %s", path)
+	}
+	if filepath.Base(filepath.Dir(path)) != "cache" {
+		t.Fatalf("cache dir: %s", path)
+	}
+}
+
+func TestCachePathEmptyConfig(t *testing.T) {
+	if CachePath("", "default") != "" {
+		t.Fatalf("expected empty")
+	}
+}
+
 func TestLoadInvalid(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bad.toml")

--- a/internal/spotify/connect.go
+++ b/internal/spotify/connect.go
@@ -11,11 +11,12 @@ import (
 )
 
 type ConnectOptions struct {
-	Source   cookies.Source
-	Market   string
-	Language string
-	Device   string
-	Timeout  time.Duration
+	Source    cookies.Source
+	Market    string
+	Language  string
+	Device    string
+	Timeout   time.Duration
+	CachePath string
 }
 
 type ConnectClient struct {
@@ -30,6 +31,13 @@ type ConnectClient struct {
 	web          *Client
 	searchURL    string
 	searchClient *http.Client
+
+	cache *connectCacheStore
+
+	routeMu              sync.RWMutex
+	cachedActiveDeviceID string
+	cachedOriginDeviceID string
+	cachedRouteAt        time.Time
 }
 
 func NewConnectClient(opts ConnectOptions) (*ConnectClient, error) {
@@ -41,9 +49,11 @@ func NewConnectClient(opts ConnectOptions) (*ConnectClient, error) {
 		timeout = 10 * time.Second
 	}
 	httpClient := &http.Client{Timeout: timeout}
+	cache := newConnectCacheStore(opts.CachePath)
 	session := &connectSession{
 		source: opts.Source,
 		client: httpClient,
+		cache:  cache,
 	}
 	return &ConnectClient{
 		source:   opts.Source,
@@ -53,6 +63,7 @@ func NewConnectClient(opts ConnectOptions) (*ConnectClient, error) {
 		client:   httpClient,
 		session:  session,
 		hashes:   newHashResolver(httpClient, session),
+		cache:    cache,
 	}, nil
 }
 

--- a/internal/spotify/connect_cache.go
+++ b/internal/spotify/connect_cache.go
@@ -97,13 +97,6 @@ func unixOrZero(t time.Time) int64 {
 	return t.Unix()
 }
 
-func timeFromUnix(unix int64) time.Time {
-	if unix <= 0 {
-		return time.Time{}
-	}
-	return time.Unix(unix, 0)
-}
-
 func (c *ConnectClient) cacheCommandRoute(state connectState) {
 	if c == nil || state.activeDeviceID == "" {
 		return
@@ -114,40 +107,12 @@ func (c *ConnectClient) cacheCommandRoute(state connectState) {
 	c.cachedOriginDeviceID = state.originDeviceID
 	c.cachedRouteAt = now
 	c.routeMu.Unlock()
-	if c.cache != nil {
-		active := state.activeDeviceID
-		origin := state.originDeviceID
-		_ = c.cache.update(func(cache *connectCache) {
-			cache.ActiveDeviceID = active
-			cache.OriginDeviceID = origin
-			cache.RouteUnix = now.Unix()
-		})
-	}
 }
 
 func (c *ConnectClient) commandRoute() (string, string, bool) {
 	if c == nil {
 		return "", "", false
 	}
-	if from, to, ok := c.memoryCommandRoute(); ok {
-		return from, to, true
-	}
-	if c.cache == nil {
-		return "", "", false
-	}
-	cached, err := c.cache.load()
-	if err != nil {
-		return "", "", false
-	}
-	routeAt := timeFromUnix(cached.RouteUnix)
-	if cached.ActiveDeviceID == "" || routeAt.IsZero() || time.Since(routeAt) > commandRouteTTL {
-		return "", "", false
-	}
-	c.routeMu.Lock()
-	c.cachedActiveDeviceID = cached.ActiveDeviceID
-	c.cachedOriginDeviceID = cached.OriginDeviceID
-	c.cachedRouteAt = routeAt
-	c.routeMu.Unlock()
 	return c.memoryCommandRoute()
 }
 

--- a/internal/spotify/connect_cache.go
+++ b/internal/spotify/connect_cache.go
@@ -97,6 +97,13 @@ func unixOrZero(t time.Time) int64 {
 	return t.Unix()
 }
 
+func timeFromUnix(unix int64) time.Time {
+	if unix <= 0 {
+		return time.Time{}
+	}
+	return time.Unix(unix, 0)
+}
+
 func (c *ConnectClient) cacheCommandRoute(state connectState) {
 	if c == nil || state.activeDeviceID == "" {
 		return
@@ -107,12 +114,40 @@ func (c *ConnectClient) cacheCommandRoute(state connectState) {
 	c.cachedOriginDeviceID = state.originDeviceID
 	c.cachedRouteAt = now
 	c.routeMu.Unlock()
+	if c.cache != nil {
+		active := state.activeDeviceID
+		origin := state.originDeviceID
+		_ = c.cache.update(func(cache *connectCache) {
+			cache.ActiveDeviceID = active
+			cache.OriginDeviceID = origin
+			cache.RouteUnix = now.Unix()
+		})
+	}
 }
 
 func (c *ConnectClient) commandRoute() (string, string, bool) {
 	if c == nil {
 		return "", "", false
 	}
+	if from, to, ok := c.memoryCommandRoute(); ok {
+		return from, to, true
+	}
+	if c.cache == nil {
+		return "", "", false
+	}
+	cached, err := c.cache.load()
+	if err != nil {
+		return "", "", false
+	}
+	routeAt := timeFromUnix(cached.RouteUnix)
+	if cached.ActiveDeviceID == "" || routeAt.IsZero() || time.Since(routeAt) > commandRouteTTL {
+		return "", "", false
+	}
+	c.routeMu.Lock()
+	c.cachedActiveDeviceID = cached.ActiveDeviceID
+	c.cachedOriginDeviceID = cached.OriginDeviceID
+	c.cachedRouteAt = routeAt
+	c.routeMu.Unlock()
 	return c.memoryCommandRoute()
 }
 

--- a/internal/spotify/connect_cache.go
+++ b/internal/spotify/connect_cache.go
@@ -1,0 +1,194 @@
+package spotify
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	connectCacheVersion = 1
+	commandRouteTTL     = 10 * time.Minute
+)
+
+type connectCache struct {
+	Version int `json:"version"`
+
+	AccessToken            string `json:"access_token,omitempty"`
+	AccessTokenExpiresUnix int64  `json:"access_token_expires_unix,omitempty"`
+	Anonymous              bool   `json:"anonymous,omitempty"`
+	ClientID               string `json:"client_id,omitempty"`
+
+	ClientToken            string `json:"client_token,omitempty"`
+	ClientTokenExpiresUnix int64  `json:"client_token_expires_unix,omitempty"`
+	ClientVersion          string `json:"client_version,omitempty"`
+	ConnectVersion         string `json:"connect_version,omitempty"`
+	DeviceID               string `json:"device_id,omitempty"`
+
+	ActiveDeviceID string `json:"active_device_id,omitempty"`
+	OriginDeviceID string `json:"origin_device_id,omitempty"`
+	RouteUnix      int64  `json:"route_unix,omitempty"`
+}
+
+type connectCacheStore struct {
+	path string
+	mu   sync.Mutex
+}
+
+func newConnectCacheStore(path string) *connectCacheStore {
+	if path == "" {
+		return nil
+	}
+	return &connectCacheStore{path: path}
+}
+
+func (s *connectCacheStore) load() (connectCache, error) {
+	if s == nil || s.path == "" {
+		return connectCache{}, os.ErrNotExist
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.loadLocked()
+}
+
+func (s *connectCacheStore) update(fn func(*connectCache)) error {
+	if s == nil || s.path == "" || fn == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cache := connectCache{Version: connectCacheVersion}
+	if loaded, err := s.loadLocked(); err == nil {
+		cache = loaded
+	}
+	fn(&cache)
+	cache.Version = connectCacheVersion
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.path, data, 0o600)
+}
+
+func (s *connectCacheStore) loadLocked() (connectCache, error) {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		return connectCache{}, err
+	}
+	var cache connectCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return connectCache{}, err
+	}
+	if cache.Version != connectCacheVersion {
+		return connectCache{}, os.ErrNotExist
+	}
+	return cache, nil
+}
+
+func unixOrZero(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.Unix()
+}
+
+func timeFromUnix(unix int64) time.Time {
+	if unix <= 0 {
+		return time.Time{}
+	}
+	return time.Unix(unix, 0)
+}
+
+func (c *ConnectClient) cacheCommandRoute(state connectState) {
+	if c == nil || state.activeDeviceID == "" {
+		return
+	}
+	now := time.Now()
+	c.routeMu.Lock()
+	c.cachedActiveDeviceID = state.activeDeviceID
+	c.cachedOriginDeviceID = state.originDeviceID
+	c.cachedRouteAt = now
+	c.routeMu.Unlock()
+	if c.cache != nil {
+		active := state.activeDeviceID
+		origin := state.originDeviceID
+		_ = c.cache.update(func(cache *connectCache) {
+			cache.ActiveDeviceID = active
+			cache.OriginDeviceID = origin
+			cache.RouteUnix = now.Unix()
+		})
+	}
+}
+
+func (c *ConnectClient) commandRoute() (string, string, bool) {
+	if c == nil {
+		return "", "", false
+	}
+	if from, to, ok := c.memoryCommandRoute(); ok {
+		return from, to, true
+	}
+	if c.cache == nil {
+		return "", "", false
+	}
+	cached, err := c.cache.load()
+	if err != nil {
+		return "", "", false
+	}
+	routeAt := timeFromUnix(cached.RouteUnix)
+	if cached.ActiveDeviceID == "" || routeAt.IsZero() || time.Since(routeAt) > commandRouteTTL {
+		return "", "", false
+	}
+	c.routeMu.Lock()
+	c.cachedActiveDeviceID = cached.ActiveDeviceID
+	c.cachedOriginDeviceID = cached.OriginDeviceID
+	c.cachedRouteAt = routeAt
+	c.routeMu.Unlock()
+	return c.memoryCommandRoute()
+}
+
+func (c *ConnectClient) memoryCommandRoute() (string, string, bool) {
+	c.routeMu.RLock()
+	active := c.cachedActiveDeviceID
+	origin := c.cachedOriginDeviceID
+	at := c.cachedRouteAt
+	c.routeMu.RUnlock()
+	if active == "" || at.IsZero() || time.Since(at) > commandRouteTTL {
+		return "", "", false
+	}
+	from := origin
+	if from == "" {
+		c.session.mu.Lock()
+		from = c.session.connectDeviceID
+		c.session.mu.Unlock()
+	}
+	if from == "" {
+		from = active
+	}
+	if from == "" {
+		return "", "", false
+	}
+	return from, active, true
+}
+
+func (c *ConnectClient) invalidateCommandRoute() {
+	if c == nil {
+		return
+	}
+	c.routeMu.Lock()
+	c.cachedActiveDeviceID = ""
+	c.cachedOriginDeviceID = ""
+	c.cachedRouteAt = time.Time{}
+	c.routeMu.Unlock()
+	if c.cache != nil {
+		_ = c.cache.update(func(cache *connectCache) {
+			cache.ActiveDeviceID = ""
+			cache.OriginDeviceID = ""
+			cache.RouteUnix = 0
+		})
+	}
+}

--- a/internal/spotify/connect_commands.go
+++ b/internal/spotify/connect_commands.go
@@ -70,22 +70,22 @@ func (c *ConnectClient) playViaWebAPI(ctx context.Context, uri string) error {
 }
 
 func (c *ConnectClient) pause(ctx context.Context) error {
-	return c.sendStateCommand(ctx, "pause", nil)
+	return c.sendDirectCommand(ctx, "pause", nil)
 }
 
 func (c *ConnectClient) next(ctx context.Context) error {
-	return c.sendStateCommand(ctx, "skip_next", nil)
+	return c.sendDirectCommand(ctx, "skip_next", nil)
 }
 
 func (c *ConnectClient) previous(ctx context.Context) error {
-	return c.sendStateCommand(ctx, "skip_prev", nil)
+	return c.sendDirectCommand(ctx, "skip_prev", nil)
 }
 
 func (c *ConnectClient) seek(ctx context.Context, positionMS int) error {
 	if positionMS < 0 {
 		positionMS = 0
 	}
-	return c.sendStateCommand(ctx, "seek_to", map[string]any{
+	return c.sendDirectCommand(ctx, "seek_to", map[string]any{
 		"command": map[string]any{
 			"endpoint": "seek_to",
 			"value":    positionMS,
@@ -111,7 +111,7 @@ func (c *ConnectClient) volume(ctx context.Context, volume int) error {
 }
 
 func (c *ConnectClient) shuffle(ctx context.Context, enabled bool) error {
-	return c.sendStateCommand(ctx, "set_shuffling_context", map[string]any{
+	return c.sendDirectCommand(ctx, "set_shuffling_context", map[string]any{
 		"command": map[string]any{
 			"endpoint": "set_shuffling_context",
 			"value":    enabled,
@@ -132,11 +132,11 @@ func (c *ConnectClient) repeat(ctx context.Context, mode string) error {
 	repeatingTrack, repeatingContext := repeatFlags(mode)
 	command["repeating_track"] = repeatingTrack
 	command["repeating_context"] = repeatingContext
-	return c.sendStateCommand(ctx, "set_options", map[string]any{"command": command})
+	return c.sendDirectCommand(ctx, "set_options", map[string]any{"command": command})
 }
 
 func (c *ConnectClient) queueAdd(ctx context.Context, uri string) error {
-	return c.sendStateCommand(ctx, "add_to_queue", map[string]any{
+	return c.sendDirectCommand(ctx, "add_to_queue", map[string]any{
 		"command": map[string]any{
 			"endpoint": "add_to_queue",
 			"track": map[string]any{
@@ -159,6 +159,47 @@ func (c *ConnectClient) sendStateCommand(ctx context.Context, endpoint string, p
 	return withConnectStateErr(ctx, c, func(state connectState) error {
 		return c.sendPlayerCommand(ctx, state, endpoint, payload)
 	})
+}
+
+func (c *ConnectClient) sendDirectCommand(ctx context.Context, endpoint string, payload map[string]any) error {
+	if payload == nil {
+		payload = map[string]any{
+			"command": map[string]any{
+				"endpoint": endpoint,
+				"logging_params": map[string]any{
+					"command_id": randomHex(32),
+				},
+			},
+		}
+	}
+	fromID, toID, ok := c.commandRoute()
+	if !ok {
+		return c.sendStateCommand(ctx, endpoint, payload)
+	}
+	url := fmt.Sprintf("%s/player/command/from/%s/to/%s", connectStateBase, fromID, toID)
+	if err := c.sendConnectCommand(ctx, url, payload); err != nil {
+		if !isRouteStaleError(err) {
+			return err
+		}
+		return c.sendStateCommand(ctx, endpoint, payload)
+	}
+	return nil
+}
+
+func isRouteStaleError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.Status {
+	case http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusGone:
+		return true
+	default:
+		return false
+	}
 }
 
 func withConnectState[T any](ctx context.Context, c *ConnectClient, fn func(connectState) (T, error)) (T, error) {

--- a/internal/spotify/connect_playback_test.go
+++ b/internal/spotify/connect_playback_test.go
@@ -144,44 +144,46 @@ func TestConnectPlaybackCachesDirectRoute(t *testing.T) {
 	}
 }
 
-func TestConnectPlaybackPersistsDirectRoute(t *testing.T) {
+func TestConnectPlaybackIgnoresPersistedDirectRoute(t *testing.T) {
 	cachePath := filepath.Join(t.TempDir(), "cache.json")
+	cache := newConnectCacheStore(cachePath)
+	if err := cache.update(func(cached *connectCache) {
+		cached.ActiveDeviceID = "stale-device"
+		cached.OriginDeviceID = "stale-origin"
+		cached.RouteUnix = time.Now().Unix()
+	}); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
 	statePayload := map[string]any{
 		"devices": map[string]any{
-			"device-1": map[string]any{"name": "Desk", "device_type": "computer"},
+			"fresh-device": map[string]any{"name": "Phone", "device_type": "smartphone"},
 		},
 		"player_state": map[string]any{
 			"play_origin": map[string]any{"device_identifier": "origin-device"},
 		},
-		"active_device_id": "device-1",
+		"active_device_id": "fresh-device",
 	}
-	first := newRegisteredConnectClientForTests(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	stateCalls := 0
+	client := newRegisteredConnectClientForTests(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
+		case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/player/command/from/stale-origin/to/stale-device"):
+			t.Fatalf("used stale persisted route")
+			return textResponse(http.StatusInternalServerError, "stale route"), nil
 		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/devices/hobs_"):
+			stateCalls++
 			return jsonResponse(http.StatusOK, statePayload), nil
-		default:
-			return textResponse(http.StatusOK, "ok"), nil
-		}
-	}))
-	attachConnectCacheForTests(first, cachePath)
-	if _, err := first.Playback(context.Background()); err != nil {
-		t.Fatalf("playback: %v", err)
-	}
-
-	second := newConnectClientForTests(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		switch {
-		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/devices/hobs_"):
-			t.Fatalf("unexpected state refresh")
-			return textResponse(http.StatusInternalServerError, "unexpected state refresh"), nil
-		case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/player/command/from/origin-device/to/device-1"):
+		case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/player/command/from/origin-device/to/fresh-device"):
 			return textResponse(http.StatusOK, "ok"), nil
 		default:
 			return textResponse(http.StatusNotFound, "missing"), nil
 		}
 	}))
-	attachConnectCacheForTests(second, cachePath)
-	if err := second.Pause(context.Background()); err != nil {
+	attachConnectCacheForTests(client, cachePath)
+	if err := client.Pause(context.Background()); err != nil {
 		t.Fatalf("pause: %v", err)
+	}
+	if stateCalls != 1 {
+		t.Fatalf("expected one state refresh, got %d", stateCalls)
 	}
 }
 

--- a/internal/spotify/connect_playback_test.go
+++ b/internal/spotify/connect_playback_test.go
@@ -144,46 +144,44 @@ func TestConnectPlaybackCachesDirectRoute(t *testing.T) {
 	}
 }
 
-func TestConnectPlaybackIgnoresPersistedDirectRoute(t *testing.T) {
+func TestConnectPlaybackPersistsDirectRoute(t *testing.T) {
 	cachePath := filepath.Join(t.TempDir(), "cache.json")
-	cache := newConnectCacheStore(cachePath)
-	if err := cache.update(func(cached *connectCache) {
-		cached.ActiveDeviceID = "stale-device"
-		cached.OriginDeviceID = "stale-origin"
-		cached.RouteUnix = time.Now().Unix()
-	}); err != nil {
-		t.Fatalf("seed cache: %v", err)
-	}
 	statePayload := map[string]any{
 		"devices": map[string]any{
-			"fresh-device": map[string]any{"name": "Phone", "device_type": "smartphone"},
+			"device-1": map[string]any{"name": "Desk", "device_type": "computer"},
 		},
 		"player_state": map[string]any{
 			"play_origin": map[string]any{"device_identifier": "origin-device"},
 		},
-		"active_device_id": "fresh-device",
+		"active_device_id": "device-1",
 	}
-	stateCalls := 0
-	client := newRegisteredConnectClientForTests(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	first := newRegisteredConnectClientForTests(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
-		case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/player/command/from/stale-origin/to/stale-device"):
-			t.Fatalf("used stale persisted route")
-			return textResponse(http.StatusInternalServerError, "stale route"), nil
 		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/devices/hobs_"):
-			stateCalls++
 			return jsonResponse(http.StatusOK, statePayload), nil
-		case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/player/command/from/origin-device/to/fresh-device"):
+		default:
+			return textResponse(http.StatusOK, "ok"), nil
+		}
+	}))
+	attachConnectCacheForTests(first, cachePath)
+	if _, err := first.Playback(context.Background()); err != nil {
+		t.Fatalf("playback: %v", err)
+	}
+
+	second := newConnectClientForTests(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/devices/hobs_"):
+			t.Fatalf("unexpected state refresh")
+			return textResponse(http.StatusInternalServerError, "unexpected state refresh"), nil
+		case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/player/command/from/origin-device/to/device-1"):
 			return textResponse(http.StatusOK, "ok"), nil
 		default:
 			return textResponse(http.StatusNotFound, "missing"), nil
 		}
 	}))
-	attachConnectCacheForTests(client, cachePath)
-	if err := client.Pause(context.Background()); err != nil {
+	attachConnectCacheForTests(second, cachePath)
+	if err := second.Pause(context.Background()); err != nil {
 		t.Fatalf("pause: %v", err)
-	}
-	if stateCalls != 1 {
-		t.Fatalf("expected one state refresh, got %d", stateCalls)
 	}
 }
 

--- a/internal/spotify/connect_playback_test.go
+++ b/internal/spotify/connect_playback_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -105,6 +106,121 @@ func TestConnectPlaybackCommands(t *testing.T) {
 	}
 	if err := client.Transfer(context.Background(), "device-1"); err != nil {
 		t.Fatalf("transfer: %v", err)
+	}
+}
+
+func TestConnectPlaybackCachesDirectRoute(t *testing.T) {
+	statePayload := map[string]any{
+		"devices": map[string]any{
+			"device-1": map[string]any{"name": "Desk", "device_type": "computer"},
+		},
+		"player_state": map[string]any{
+			"play_origin": map[string]any{"device_identifier": "origin-device"},
+		},
+		"active_device_id": "device-1",
+	}
+	stateCalls := 0
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/devices/hobs_"):
+			stateCalls++
+			return jsonResponse(http.StatusOK, statePayload), nil
+		case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/player/command/from/origin-device/to/device-1"):
+			return textResponse(http.StatusOK, "ok"), nil
+		default:
+			return textResponse(http.StatusNotFound, "missing"), nil
+		}
+	})
+	client := newRegisteredConnectClientForTests(transport)
+
+	if _, err := client.Playback(context.Background()); err != nil {
+		t.Fatalf("playback: %v", err)
+	}
+	if err := client.Pause(context.Background()); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	if stateCalls != 1 {
+		t.Fatalf("expected one state call, got %d", stateCalls)
+	}
+}
+
+func TestConnectPlaybackPersistsDirectRoute(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "cache.json")
+	statePayload := map[string]any{
+		"devices": map[string]any{
+			"device-1": map[string]any{"name": "Desk", "device_type": "computer"},
+		},
+		"player_state": map[string]any{
+			"play_origin": map[string]any{"device_identifier": "origin-device"},
+		},
+		"active_device_id": "device-1",
+	}
+	first := newRegisteredConnectClientForTests(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/devices/hobs_"):
+			return jsonResponse(http.StatusOK, statePayload), nil
+		default:
+			return textResponse(http.StatusOK, "ok"), nil
+		}
+	}))
+	attachConnectCacheForTests(first, cachePath)
+	if _, err := first.Playback(context.Background()); err != nil {
+		t.Fatalf("playback: %v", err)
+	}
+
+	second := newConnectClientForTests(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/devices/hobs_"):
+			t.Fatalf("unexpected state refresh")
+			return textResponse(http.StatusInternalServerError, "unexpected state refresh"), nil
+		case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/player/command/from/origin-device/to/device-1"):
+			return textResponse(http.StatusOK, "ok"), nil
+		default:
+			return textResponse(http.StatusNotFound, "missing"), nil
+		}
+	}))
+	attachConnectCacheForTests(second, cachePath)
+	if err := second.Pause(context.Background()); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+}
+
+func TestConnectPlaybackStaleRouteFallsBackToState(t *testing.T) {
+	statePayload := map[string]any{
+		"devices": map[string]any{
+			"fresh-device": map[string]any{"name": "Desk", "device_type": "computer"},
+		},
+		"player_state": map[string]any{
+			"play_origin": map[string]any{"device_identifier": "origin-device"},
+		},
+		"active_device_id": "fresh-device",
+	}
+	sawStaleRoute := false
+	sawFreshRoute := false
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/player/command/from/stale-origin/to/stale-device"):
+			sawStaleRoute = true
+			return textResponse(http.StatusGone, "gone"), nil
+		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/devices/hobs_"):
+			return jsonResponse(http.StatusOK, statePayload), nil
+		case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/player/command/from/origin-device/to/fresh-device"):
+			sawFreshRoute = true
+			return textResponse(http.StatusOK, "ok"), nil
+		default:
+			return textResponse(http.StatusNotFound, "missing"), nil
+		}
+	})
+	client := newRegisteredConnectClientForTests(transport)
+	client.cachedActiveDeviceID = "stale-device"
+	client.cachedOriginDeviceID = "stale-origin"
+	client.cachedRouteAt = time.Now()
+
+	if err := client.Pause(context.Background()); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	if !sawStaleRoute || !sawFreshRoute {
+		t.Fatalf("expected stale and fresh routes, stale=%t fresh=%t", sawStaleRoute, sawFreshRoute)
 	}
 }
 

--- a/internal/spotify/connect_session.go
+++ b/internal/spotify/connect_session.go
@@ -131,6 +131,9 @@ func (s *connectSession) saveCacheLocked() {
 		cached.ClientVersion = clientVer
 		cached.ConnectVersion = ""
 		cached.DeviceID = deviceID
+		cached.ActiveDeviceID = ""
+		cached.OriginDeviceID = ""
+		cached.RouteUnix = 0
 	})
 }
 

--- a/internal/spotify/connect_session.go
+++ b/internal/spotify/connect_session.go
@@ -103,9 +103,6 @@ func (s *connectSession) loadCacheLocked() {
 	if cached.ClientVersion != "" {
 		s.clientVer = cached.ClientVersion
 	}
-	if cached.ConnectVersion != "" {
-		s.connectVer = cached.ConnectVersion
-	}
 	if cached.DeviceID != "" {
 		s.deviceID = cached.DeviceID
 	}
@@ -123,7 +120,6 @@ func (s *connectSession) saveCacheLocked() {
 	clientToken := s.clientToken
 	clientTokenT := s.clientTokenT
 	clientVer := s.clientVer
-	connectVer := s.connectVer
 	deviceID := s.deviceID
 	_ = s.cache.update(func(cached *connectCache) {
 		cached.AccessToken = token.AccessToken
@@ -133,7 +129,7 @@ func (s *connectSession) saveCacheLocked() {
 		cached.ClientToken = clientToken
 		cached.ClientTokenExpiresUnix = unixOrZero(clientTokenT)
 		cached.ClientVersion = clientVer
-		cached.ConnectVersion = connectVer
+		cached.ConnectVersion = ""
 		cached.DeviceID = deviceID
 	})
 }
@@ -156,6 +152,7 @@ func (s *connectSession) ensureTokenLocked(ctx context.Context) error {
 }
 
 func (s *connectSession) ensureAppConfigLocked(ctx context.Context) error {
+	s.connectVer = connectClientVersion()
 	if s.clientVer != "" && s.deviceID != "" {
 		return nil
 	}
@@ -219,7 +216,6 @@ func (s *connectSession) ensureAppConfigLocked(ctx context.Context) error {
 		clientVer = clientVer[:idx]
 	}
 	s.clientVer = clientVer
-	s.connectVer = connectClientVersion()
 	s.deviceID = deviceID
 	s.saveCacheLocked()
 	return nil

--- a/internal/spotify/connect_session.go
+++ b/internal/spotify/connect_session.go
@@ -23,8 +23,10 @@ import (
 type connectSession struct {
 	source cookies.Source
 	client *http.Client
+	cache  *connectCacheStore
 
-	mu sync.Mutex
+	mu          sync.Mutex
+	cacheLoaded bool
 
 	token        Token
 	clientToken  string
@@ -50,6 +52,7 @@ type connectAuth struct {
 func (s *connectSession) auth(ctx context.Context) (connectAuth, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.loadCacheLocked()
 	if err := s.ensureTokenLocked(ctx); err != nil {
 		return connectAuth{}, err
 	}
@@ -68,6 +71,73 @@ func (s *connectSession) auth(ctx context.Context) (connectAuth, error) {
 	}, nil
 }
 
+func (s *connectSession) loadCacheLocked() {
+	if s == nil || s.cacheLoaded {
+		return
+	}
+	s.cacheLoaded = true
+	if s.cache == nil {
+		return
+	}
+	cached, err := s.cache.load()
+	if err != nil {
+		return
+	}
+	if cached.AccessToken != "" && cached.AccessTokenExpiresUnix > 0 {
+		s.token = Token{
+			AccessToken: cached.AccessToken,
+			ExpiresAt:   time.Unix(cached.AccessTokenExpiresUnix, 0),
+			Anonymous:   cached.Anonymous,
+			ClientID:    cached.ClientID,
+		}
+	}
+	if cached.ClientID != "" {
+		s.clientID = cached.ClientID
+	}
+	if cached.ClientToken != "" {
+		s.clientToken = cached.ClientToken
+	}
+	if cached.ClientTokenExpiresUnix > 0 {
+		s.clientTokenT = time.Unix(cached.ClientTokenExpiresUnix, 0)
+	}
+	if cached.ClientVersion != "" {
+		s.clientVer = cached.ClientVersion
+	}
+	if cached.ConnectVersion != "" {
+		s.connectVer = cached.ConnectVersion
+	}
+	if cached.DeviceID != "" {
+		s.deviceID = cached.DeviceID
+	}
+}
+
+func (s *connectSession) saveCacheLocked() {
+	if s == nil || s.cache == nil {
+		return
+	}
+	token := s.token
+	clientID := s.clientID
+	if clientID == "" {
+		clientID = token.ClientID
+	}
+	clientToken := s.clientToken
+	clientTokenT := s.clientTokenT
+	clientVer := s.clientVer
+	connectVer := s.connectVer
+	deviceID := s.deviceID
+	_ = s.cache.update(func(cached *connectCache) {
+		cached.AccessToken = token.AccessToken
+		cached.AccessTokenExpiresUnix = unixOrZero(token.ExpiresAt)
+		cached.Anonymous = token.Anonymous
+		cached.ClientID = clientID
+		cached.ClientToken = clientToken
+		cached.ClientTokenExpiresUnix = unixOrZero(clientTokenT)
+		cached.ClientVersion = clientVer
+		cached.ConnectVersion = connectVer
+		cached.DeviceID = deviceID
+	})
+}
+
 func (s *connectSession) ensureTokenLocked(ctx context.Context) error {
 	if s.token.AccessToken != "" && time.Until(s.token.ExpiresAt) > time.Minute {
 		return nil
@@ -81,6 +151,7 @@ func (s *connectSession) ensureTokenLocked(ctx context.Context) error {
 	if token.ClientID != "" {
 		s.clientID = token.ClientID
 	}
+	s.saveCacheLocked()
 	return nil
 }
 
@@ -150,6 +221,7 @@ func (s *connectSession) ensureAppConfigLocked(ctx context.Context) error {
 	s.clientVer = clientVer
 	s.connectVer = connectClientVersion()
 	s.deviceID = deviceID
+	s.saveCacheLocked()
 	return nil
 }
 
@@ -221,6 +293,7 @@ func (s *connectSession) ensureClientTokenLocked(ctx context.Context) error {
 	} else {
 		s.clientTokenT = time.Now().Add(30 * time.Minute)
 	}
+	s.saveCacheLocked()
 	return nil
 }
 

--- a/internal/spotify/connect_session_test.go
+++ b/internal/spotify/connect_session_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -117,6 +118,67 @@ func TestConnectSessionAuthPersistsCache(t *testing.T) {
 	}
 	if auth.AccessToken != "access" || auth.ClientToken != "client-token" || auth.ClientVersion != "1.2.3" || auth.DeviceID != "device" {
 		t.Fatalf("unexpected cached auth: %#v", auth)
+	}
+}
+
+func TestConnectSessionAuthRecomputesConnectVersionOverrideFromCache(t *testing.T) {
+	oldOverride, hadOverride := os.LookupEnv("SPOGO_CONNECT_VERSION")
+	t.Cleanup(func() {
+		if hadOverride {
+			_ = os.Setenv("SPOGO_CONNECT_VERSION", oldOverride)
+			return
+		}
+		_ = os.Unsetenv("SPOGO_CONNECT_VERSION")
+	})
+
+	cache := newConnectCacheStore(filepath.Join(t.TempDir(), "connect.json"))
+	if err := cache.update(func(cached *connectCache) {
+		cached.AccessToken = "access"
+		cached.AccessTokenExpiresUnix = time.Now().Add(time.Hour).Unix()
+		cached.ClientID = "client"
+		cached.ClientToken = "client-token"
+		cached.ClientTokenExpiresUnix = time.Now().Add(time.Hour).Unix()
+		cached.ClientVersion = "1.2.3"
+		cached.ConnectVersion = "cached-version"
+		cached.DeviceID = "device"
+	}); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+	newCachedSession := func() *connectSession {
+		return &connectSession{
+			client: &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				t.Fatalf("unexpected network request: %s", req.URL)
+				return textResponse(http.StatusInternalServerError, "unexpected"), nil
+			})},
+			cache: cache,
+		}
+	}
+
+	_ = os.Setenv("SPOGO_CONNECT_VERSION", "override-one")
+	auth, err := newCachedSession().auth(context.Background())
+	if err != nil {
+		t.Fatalf("cached auth with override: %v", err)
+	}
+	if auth.ConnectVersion != "override-one" {
+		t.Fatalf("expected override-one, got %q", auth.ConnectVersion)
+	}
+
+	_ = os.Setenv("SPOGO_CONNECT_VERSION", "override-two")
+	auth, err = newCachedSession().auth(context.Background())
+	if err != nil {
+		t.Fatalf("cached auth with changed override: %v", err)
+	}
+	if auth.ConnectVersion != "override-two" {
+		t.Fatalf("expected override-two, got %q", auth.ConnectVersion)
+	}
+
+	_ = os.Unsetenv("SPOGO_CONNECT_VERSION")
+	auth, err = newCachedSession().auth(context.Background())
+	if err != nil {
+		t.Fatalf("cached auth without override: %v", err)
+	}
+	if auth.ConnectVersion != connectClientVersion() {
+		t.Fatalf("expected default connect version, got %q", auth.ConnectVersion)
 	}
 }
 

--- a/internal/spotify/connect_session_test.go
+++ b/internal/spotify/connect_session_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -65,6 +66,57 @@ func TestConnectSessionAuth(t *testing.T) {
 	}
 	if auth.DeviceID != "device" {
 		t.Fatalf("unexpected device id: %s", auth.DeviceID)
+	}
+}
+
+func TestConnectSessionAuthPersistsCache(t *testing.T) {
+	restore := SetTotpSecretFetcher(func(ctx context.Context) (int, []byte, error) {
+		return 1, []byte{1, 2, 3, 4}, nil
+	})
+	t.Cleanup(restore)
+
+	cache := newConnectCacheStore(filepath.Join(t.TempDir(), "connect.json"))
+	cookies := []*http.Cookie{
+		{Name: "sp_dc", Value: "token", Domain: ".spotify.com"},
+		{Name: "sp_t", Value: "device", Domain: ".spotify.com"},
+	}
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.URL.Host == "open.spotify.com" && req.URL.Path == "/api/token":
+			return jsonResponse(http.StatusOK, tokenResponse{
+				AccessToken: "access",
+				ExpiresIn:   3600,
+				ClientID:    "client",
+			}), nil
+		case req.URL.Host == "open.spotify.com" && req.URL.Path == "/":
+			raw, _ := json.Marshal(map[string]any{"clientVersion": "1.2.3"})
+			return textResponse(http.StatusOK, fmt.Sprintf(`<script id="appServerConfig" type="text/plain">%s</script>`, base64.StdEncoding.EncodeToString(raw))), nil
+		case req.URL.Host == "clienttoken.spotify.com":
+			return jsonResponse(http.StatusOK, map[string]any{
+				"granted_token": map[string]any{"token": "client-token", "expires_in": 600},
+			}), nil
+		default:
+			return textResponse(http.StatusNotFound, "missing"), nil
+		}
+	})
+	first := &connectSession{source: cookieSourceStub{cookies: cookies}, client: &http.Client{Transport: transport}, cache: cache}
+	if _, err := first.auth(context.Background()); err != nil {
+		t.Fatalf("auth: %v", err)
+	}
+
+	second := &connectSession{
+		client: &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected network request: %s", req.URL)
+			return textResponse(http.StatusInternalServerError, "unexpected"), nil
+		})},
+		cache: cache,
+	}
+	auth, err := second.auth(context.Background())
+	if err != nil {
+		t.Fatalf("cached auth: %v", err)
+	}
+	if auth.AccessToken != "access" || auth.ClientToken != "client-token" || auth.ClientVersion != "1.2.3" || auth.DeviceID != "device" {
+		t.Fatalf("unexpected cached auth: %#v", auth)
 	}
 }
 

--- a/internal/spotify/connect_test_helpers_test.go
+++ b/internal/spotify/connect_test_helpers_test.go
@@ -26,3 +26,9 @@ func newRegisteredConnectClientForTests(transport http.RoundTripper) *ConnectCli
 	client.session.registeredAt = time.Now()
 	return client
 }
+
+func attachConnectCacheForTests(client *ConnectClient, path string) {
+	cache := newConnectCacheStore(path)
+	client.cache = cache
+	client.session.cache = cache
+}

--- a/internal/spotify/connect_transport.go
+++ b/internal/spotify/connect_transport.go
@@ -95,6 +95,7 @@ func (c *ConnectClient) connectState(ctx context.Context) (connectState, error) 
 	if origin := mapPlayOriginID(state.playerState); origin != "" {
 		state.originDeviceID = origin
 	}
+	c.cacheCommandRoute(state)
 	return state, nil
 }
 
@@ -170,10 +171,12 @@ func (c *ConnectClient) registerDevice(ctx context.Context, auth connectAuth, co
 	})
 	resp, err := c.client.Do(req)
 	if err != nil {
+		c.invalidateCommandRoute()
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		c.invalidateCommandRoute()
 		return apiErrorFromResponse(resp)
 	}
 	return nil
@@ -228,10 +231,12 @@ func (c *ConnectClient) sendConnectRequest(ctx context.Context, method, url stri
 	})
 	resp, err := c.client.Do(req)
 	if err != nil {
+		c.invalidateCommandRoute()
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		c.invalidateCommandRoute()
 		return apiErrorFromResponse(resp)
 	}
 	return nil


### PR DESCRIPTION
## Summary

This keeps the CLI synchronous and removes the daemon/client-server layer from the original draft. The performance win now comes from a profile-scoped Connect cache inside the Spotify client.

## How it works

Commands that need full Spotify Connect state, such as `status`, still call `connectState()`. While doing that, spogo stores reusable Connect data in the profile cache:

- web access token + expiry
- Spotify client token + expiry
- client version / device id
- last active playback route: `origin_device_id -> active_device_id`

A later playback command like `spogo pause` can then skip the full Connect state refresh:

1. load the cached auth/session/route data
2. POST the command directly to `connect-state/v1/player/command/from/<origin>/to/<active>`
3. if Spotify reports the route is stale, refresh via `connectState()` and retry once
4. return the real CLI result; no fire-and-forget success

Auth changes invalidate the cache through `auth import`, `auth paste`, and `auth clear`.

## Why this shape

The original daemon design made playback fast by keeping a warm process alive, but it changed CLI semantics and process lifecycle. This rewrite keeps the normal command/exit-code contract while caching the expensive parts that are safe to reuse between invocations.

## E2E proof

Live measured against a real Spotify session with the `Office` device active:

- warm `pause`: PR `360ms ± 19ms`, main `2.096s ± 0.342s` -> about `5.8x` faster
- warm `status`: PR `1.786s`, main `2.053s`
- cold `pause`: PR `2.010s`, main `1.732s`
- cold `status`: PR `1.982s`, main `2.117s`

Behavior check:

- before an active device exists, `pause` exits non-zero with `missing device id`
- after an active route is cached, `pause` uses the warm direct route
- no daemon state or background process involved

## Proof

- `go test ./...`
- `./scripts/lint.sh`
- `./scripts/check-coverage.sh 90` -> `90.1%`