### PR TITLE
fix(spotify): map Pathfinder track metadata

### DIFF
--- a/internal/spotify/connect_extract_items.go
+++ b/internal/spotify/connect_extract_items.go
@@ -77,10 +77,26 @@ func extractItem(value any, kind string) (Item, bool) {
 			item.Album = album
 		}
 	}
-	item.Explicit = getBool(m, "explicit")
+	if _, ok := m["explicit"]; ok {
+		item.Explicit = getBool(m, "explicit")
+		item.ExplicitKnown = true
+	}
+	if rating, ok := m["contentRating"].(map[string]any); ok {
+		label := strings.ToUpper(getString(rating, "label"))
+		if label != "" {
+			item.Explicit = label == "EXPLICIT"
+			item.ExplicitKnown = true
+		}
+	}
 	item.DurationMS = getInt(m, "duration_ms")
 	if item.DurationMS == 0 {
 		item.DurationMS = getInt(m, "durationMs")
+	}
+	if item.DurationMS == 0 {
+		item.DurationMS = getNestedInt(m, "duration", "totalMilliseconds")
+	}
+	if item.DurationMS == 0 {
+		item.DurationMS = getNestedInt(m, "trackDuration", "totalMilliseconds")
 	}
 	item.Owner = extractOwnerName(m)
 	item.TotalTracks = getInt(m, "totalTracks")
@@ -90,6 +106,9 @@ func extractItem(value any, kind string) (Item, bool) {
 	item.ReleaseDate = getString(m, "releaseDate")
 	item.Description = getString(m, "description")
 	item.IsPlayable = getBool(m, "isPlayable")
+	if !item.IsPlayable {
+		item.IsPlayable = getNestedBool(m, "playability", "playable")
+	}
 	item.Publisher = getString(m, "publisher")
 	item.TotalEpisodes = getInt(m, "totalEpisodes")
 	return item, true

--- a/internal/spotify/connect_extract_util.go
+++ b/internal/spotify/connect_extract_util.go
@@ -42,12 +42,26 @@ func getInt(m map[string]any, key string) int {
 	return 0
 }
 
+func getNestedInt(m map[string]any, parent, key string) int {
+	if nested, ok := getMap(m, parent); ok {
+		return getInt(nested, key)
+	}
+	return 0
+}
+
 func getBool(m map[string]any, key string) bool {
 	if m == nil {
 		return false
 	}
 	if value, ok := m[key].(bool); ok {
 		return value
+	}
+	return false
+}
+
+func getNestedBool(m map[string]any, parent, key string) bool {
+	if nested, ok := getMap(m, parent); ok {
+		return getBool(nested, key)
 	}
 	return false
 }

--- a/internal/spotify/connect_mapping_test.go
+++ b/internal/spotify/connect_mapping_test.go
@@ -1,6 +1,9 @@
 package spotify
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestExtractItem(t *testing.T) {
 	raw := map[string]any{
@@ -146,6 +149,97 @@ func TestExtractItemFallbacks(t *testing.T) {
 	}
 	if item.Album != "Album" || item.Owner != "Owner" || item.DurationMS != 1200 {
 		t.Fatalf("unexpected fields: %#v", item)
+	}
+}
+
+func TestExtractItemPathfinderTrackMetadata(t *testing.T) {
+	raw := map[string]any{
+		"id":   "t1",
+		"name": "Song",
+		"contentRating": map[string]any{
+			"label": "EXPLICIT",
+		},
+		"duration": map[string]any{
+			"totalMilliseconds": 321613,
+		},
+		"playability": map[string]any{
+			"playable": true,
+		},
+	}
+	item, ok := extractItem(raw, "track")
+	if !ok {
+		t.Fatalf("expected item")
+	}
+	if !item.Explicit || !item.ExplicitKnown {
+		t.Fatalf("expected explicit metadata: %#v", item)
+	}
+	if item.DurationMS != 321613 {
+		t.Fatalf("unexpected duration: %#v", item)
+	}
+	if !item.IsPlayable {
+		t.Fatalf("expected playable metadata: %#v", item)
+	}
+}
+
+func TestExtractItemPathfinderTrackDurationFallback(t *testing.T) {
+	raw := map[string]any{
+		"id": "t1",
+		"trackDuration": map[string]any{
+			"totalMilliseconds": 1200,
+		},
+	}
+	item, ok := extractItem(raw, "track")
+	if !ok {
+		t.Fatalf("expected item")
+	}
+	if item.DurationMS != 1200 {
+		t.Fatalf("unexpected duration: %#v", item)
+	}
+}
+
+func TestItemJSONIncludesKnownExplicitFalse(t *testing.T) {
+	raw := map[string]any{
+		"id": "t1",
+		"contentRating": map[string]any{
+			"label": "NONE",
+		},
+	}
+	item, ok := extractItem(raw, "track")
+	if !ok {
+		t.Fatalf("expected item")
+	}
+	encoded, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	explicit, ok := fields["explicit"]
+	if !ok {
+		t.Fatalf("expected explicit false in JSON: %s", encoded)
+	}
+	var value bool
+	if err := json.Unmarshal(explicit, &value); err != nil {
+		t.Fatalf("unmarshal explicit: %v", err)
+	}
+	if value {
+		t.Fatalf("expected explicit false in JSON: %s", encoded)
+	}
+}
+
+func TestItemJSONOmitsUnknownExplicitFalse(t *testing.T) {
+	encoded, err := json.Marshal(Item{ID: "p1", URI: "spotify:playlist:p1", Type: "playlist"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := fields["explicit"]; ok {
+		t.Fatalf("unexpected explicit false in JSON: %s", encoded)
 	}
 }
 

--- a/internal/spotify/mapper.go
+++ b/internal/spotify/mapper.go
@@ -189,8 +189,9 @@ func mergeItemMetadata(dst *Item, src Item) {
 	if dst.DurationMS == 0 {
 		dst.DurationMS = src.DurationMS
 	}
-	if !dst.Explicit {
+	if !dst.ExplicitKnown && (src.ExplicitKnown || src.Explicit) {
 		dst.Explicit = src.Explicit
+		dst.ExplicitKnown = src.ExplicitKnown
 	}
 	if !dst.IsPlayable {
 		dst.IsPlayable = src.IsPlayable

--- a/internal/spotify/types.go
+++ b/internal/spotify/types.go
@@ -1,5 +1,7 @@
 package spotify
 
+import "encoding/json"
+
 type Item struct {
 	ID            string   `json:"id"`
 	URI           string   `json:"uri"`
@@ -10,7 +12,8 @@ type Item struct {
 	Album         string   `json:"album,omitempty"`
 	Owner         string   `json:"owner,omitempty"`
 	DurationMS    int      `json:"duration_ms,omitempty"`
-	Explicit      bool     `json:"explicit,omitempty"`
+	Explicit      bool     `json:"-"`
+	ExplicitKnown bool     `json:"-"`
 	TotalTracks   int      `json:"total_tracks,omitempty"`
 	ReleaseDate   string   `json:"release_date,omitempty"`
 	Description   string   `json:"description,omitempty"`
@@ -20,6 +23,21 @@ type Item struct {
 	IsPlayable    bool     `json:"is_playable,omitempty"`
 	Publisher     string   `json:"publisher,omitempty"`
 	TotalEpisodes int      `json:"total_episodes,omitempty"`
+}
+
+func (i Item) MarshalJSON() ([]byte, error) {
+	type itemAlias Item
+	var explicit *bool
+	if i.Explicit || i.ExplicitKnown {
+		explicit = &i.Explicit
+	}
+	return json.Marshal(struct {
+		itemAlias
+		Explicit *bool `json:"explicit,omitempty"`
+	}{
+		itemAlias: itemAlias(i),
+		Explicit:  explicit,
+	})
 }
 
 type SearchResult struct {


### PR DESCRIPTION
I wanted to use spogo for my tool and have noticed that it doesn't show duration in json output. Fixed it with heavy codex assistance.

## Summary

This fixes missing track metadata when playlist, library, and track info results come from Spotify's Pathfinder payloads.

Pathfinder does not always expose track duration as top-level `duration_ms` or `durationMs`. Depending on the endpoint, it can be nested under `duration.totalMilliseconds` or `trackDuration.totalMilliseconds`.

A few other track fields also use Pathfinder-specific shapes:

- explicit metadata comes from `contentRating.label`
- playability comes from `playability.playable`

This PR adds support for those shapes, and keeps `explicit: false` visible in JSON when we know the value is actually present.