### PR TITLE
feat: add user listening history commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - Play artists (starts with top tracks)
 - Queue management
 - Library management (save/remove/follow)
+- User listening reads: top tracks by Spotify affinity and available recent plays
 - Playlist management (create/add/remove/list)
 - Device selection and status
 - Browser cookie import via `sweetcookie`
@@ -83,6 +84,7 @@ Commands:
 - `play [<id|url>] [--type ...] [--shuffle]`, `pause`, `next`, `prev`, `seek`, `volume`, `shuffle`, `repeat`, `status`
 - `queue add|show`
 - `library tracks|albums|artists|playlists`
+- `user top-tracks|history`
 - `playlist create|add|remove|tracks`
 - `device list|set`
 

--- a/cmd/spogo/main.go
+++ b/cmd/spogo/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/steipete/spogo/internal/app"
 	"github.com/steipete/spogo/internal/cli"
+	"github.com/steipete/spogo/internal/output"
 )
 
 var exitFunc = os.Exit
@@ -48,14 +50,21 @@ func run(args []string, out io.Writer, errOut io.Writer) int {
 		_, _ = fmt.Fprintln(errOut, err)
 		return 2
 	}
+	settings.Out = out
+	settings.Err = errOut
 	ctx, err := app.NewContext(settings)
 	if err != nil {
-		_, _ = fmt.Fprintln(errOut, err)
+		if settings.Format == output.FormatJSON {
+			b, _ := json.Marshal(map[string]string{"error": err.Error()})
+			_, _ = fmt.Fprintln(errOut, string(b))
+		} else {
+			_, _ = fmt.Fprintln(errOut, err)
+		}
 		return 1
 	}
 	ctx.SetCommandContext(context.Background())
 	if err := ctx.ValidateProfile(); err != nil {
-		_, _ = fmt.Fprintln(errOut, err)
+		ctx.Output.Errorf("%v", err)
 		return 2
 	}
 	if err := kctx.Run(ctx); err != nil {

--- a/cmd/spogo/main_test.go
+++ b/cmd/spogo/main_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/steipete/spogo/internal/cookies"
@@ -96,6 +98,26 @@ func TestNormalizeArgsMovesNoInput(t *testing.T) {
 	want := []string{"--no-input", "auth", "paste", "--cookie-path", "cookies.json"}
 	if fmt.Sprint(got) != fmt.Sprint(want) {
 		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestRunJSONUserTopTracksDayError(t *testing.T) {
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	code := run([]string{"--json", "user", "top-tracks", "--period", "day"}, out, errOut)
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d; stdout=%q stderr=%q", code, out.String(), errOut.String())
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected empty stdout, got %q", out.String())
+	}
+	stripped := strings.TrimSpace(errOut.String())
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(stripped), &parsed); err != nil {
+		t.Fatalf("stderr is not valid JSON: %v; got %q", err, stripped)
+	}
+	if _, ok := parsed["error"]; !ok {
+		t.Fatalf("stderr JSON missing 'error' key: %q", stripped)
 	}
 }
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -119,6 +119,21 @@ Saved tracks, albums, followed artists, owned/followed playlists. See [Library](
 | `spogo library artists unfollow <id|url...>` | Unfollow artists. |
 | `spogo library playlists list [--limit N]` | List owned/followed playlists. |
 
+## user
+
+Read-only listening data from Spotify's web endpoints.
+
+| Command | Purpose |
+| --- | --- |
+| `spogo user top-tracks [--period all-time|year|6mo|month|week|day] [--limit N] [--offset N]` | Show affinity-ranked top tracks. |
+| `spogo user history [--period all|year|6mo|1mo|1wk|1day] [--limit N] [--after <ms>] [--before <ms>]` | Show recently played tracks available from Spotify. |
+
+Spotify limitations are surfaced rather than hidden:
+
+- Top tracks are Spotify affinity rankings, not play counts.
+- Spotify only supports `long_term`, `medium_term`, and `short_term` top-track windows. `year` maps to `long_term`; `6mo` maps to `medium_term`; `month` and `week` map to `short_term` (roughly 4 weeks); `day` returns an explicit unsupported-period error.
+- Recently played is not a complete historical archive. Spotify returns retained recent plays only, at up to 50 items per page; spogo paginates backward with `before` cursors and stops at a 200-item client cap. Periods and `--after` are local lower-bound filters over the items Spotify returns.
+
 ## playlist
 
 Mutate playlists. See [Library](library.md).

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -102,6 +102,15 @@ spogo [global flags] <command> [args]
 - `spogo library artists unfollow <id|url...>`
 - `spogo library playlists list [--limit N]`
 
+### user
+
+- `spogo user top-tracks [--period all-time|year|6mo|month|week|day] [--limit N] [--offset N]`
+  - returns Spotify affinity-ranked tracks, not play counts
+  - Spotify supports only `long_term`, `medium_term`, `short_term`; `year` maps to `long_term`, `6mo` to `medium_term`, `month` and `week` to `short_term` (~4 weeks), and `day` errors as unsupported
+- `spogo user history [--period all|year|6mo|1mo|1wk|1day] [--limit N] [--after <ms>] [--before <ms>]`
+  - returns retained recent plays available from Spotify, not a complete listening archive
+  - paginates backward with `before` cursors; periods and `--after` are local lower-bound filters; client cap is 200 items
+
 ### playlists
 
 - `spogo playlist create <name> [--public] [--collab]`

--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -26,6 +27,8 @@ type Settings struct {
 	Verbose    bool
 	Debug      bool
 	NoInput    bool
+	Out        io.Writer
+	Err        io.Writer
 }
 
 type Context struct {

--- a/internal/app/context_output.go
+++ b/internal/app/context_output.go
@@ -34,5 +34,7 @@ func newOutputWriter(settings Settings) (*output.Writer, error) {
 		Format: format,
 		Color:  isColorEnabled(format, settings.NoColor),
 		Quiet:  settings.Quiet,
+		Out:    settings.Out,
+		Err:    settings.Err,
 	})
 }

--- a/internal/app/context_test.go
+++ b/internal/app/context_test.go
@@ -417,3 +417,9 @@ func (dummySpotify) CreatePlaylist(context.Context, string, bool, bool) (spotify
 }
 func (dummySpotify) AddTracks(context.Context, string, []string) error    { return nil }
 func (dummySpotify) RemoveTracks(context.Context, string, []string) error { return nil }
+func (dummySpotify) GetUsersTopTracks(context.Context, string, int, int) (spotify.TopTracksResult, error) {
+	return spotify.TopTracksResult{}, nil
+}
+func (dummySpotify) GetRecentlyPlayed(context.Context, int, int64, int64) (spotify.RecentlyPlayedResult, error) {
+	return spotify.RecentlyPlayedResult{}, nil
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -41,6 +41,7 @@ type CLI struct {
 	Queue   QueueCmd   `kong:"cmd,help='Queue operations.'"`
 	Library LibraryCmd `kong:"cmd,help='Library operations.'"`
 	Device  DeviceCmd  `kong:"cmd,help='Playback devices.'"`
+	User    UserCmd    `kong:"cmd,help='User listening data (top tracks, history).'"`
 }
 
 type Globals struct {

--- a/internal/cli/history.go
+++ b/internal/cli/history.go
@@ -1,0 +1,215 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/steipete/spogo/internal/app"
+	"github.com/steipete/spogo/internal/output"
+	"github.com/steipete/spogo/internal/spotify"
+)
+
+const maxHistoryItems = 200
+
+type UserCmd struct {
+	TopTracks UserTopTracksCmd `kong:"cmd,help='Show your top tracks by affinity ranking.'"`
+	History   UserHistoryCmd   `kong:"cmd,help='Show recently played tracks available from Spotify.'"`
+}
+
+type UserTopTracksCmd struct {
+	Period string `help:"Affinity period: all-time/year use Spotify long_term, 6mo uses medium_term, month/week use short_term (~4 weeks), day is unsupported." default:"all-time" enum:"all-time,year,6mo,month,week,day"`
+	Limit  int    `help:"Number of results." default:"20"`
+	Offset int    `help:"Offset results." default:"0"`
+}
+
+type UserHistoryCmd struct {
+	Period string `help:"Local lower-bound filter over Spotify's available recent plays: all, year, 6mo, 1mo, 1wk, 1day." default:"all" enum:"all,year,6mo,1mo,1wk,1day"`
+	Limit  int    `help:"Items per page (max 50)." default:"20"`
+	After  int64  `help:"Client-side lower-bound filter, Unix timestamp (ms). Pagination still walks backward with before cursors."`
+	Before int64  `help:"Return items played before this Unix timestamp (ms)."`
+}
+
+var topTrackPeriods = map[string]string{
+	"all-time": "long_term",
+	"year":     "long_term",
+	"6mo":      "medium_term",
+	"month":    "short_term",
+	"week":     "short_term",
+}
+
+func topTracksTimeRange(period string) string {
+	return topTrackPeriods[period]
+}
+
+func topTracksPeriodNote(period string) string {
+	switch period {
+	case "year":
+		return "Spotify has no calendar-year top-tracks window; year maps to long_term (lifetime affinity)."
+	case "month":
+		return "Spotify short_term is roughly the last 4 weeks; this is an approximation."
+	case "week":
+		return "Spotify has no weekly top-tracks window; week maps to short_term (roughly last 4 weeks)."
+	default:
+		return "Spotify returns affinity-ranked top tracks, not play counts."
+	}
+}
+
+var historyPeriodDurations = map[string]time.Duration{
+	"year": 365 * 24 * time.Hour,
+	"6mo":  180 * 24 * time.Hour,
+	"1mo":  30 * 24 * time.Hour,
+	"1wk":  7 * 24 * time.Hour,
+	"1day": 24 * time.Hour,
+}
+
+func historyAfter(period string) int64 {
+	d, ok := historyPeriodDurations[period]
+	if !ok {
+		return 0
+	}
+	return time.Now().Add(-d).UnixMilli()
+}
+
+func (cmd *UserTopTracksCmd) Run(ctx *app.Context) error {
+	if cmd.Period == "day" {
+		return fmt.Errorf("Spotify does not support daily top tracks; only long_term, medium_term, short_term; use all-time, year, 6mo, month, or week (week maps to short_term, ~4 weeks)")
+	}
+	client, cmdCtx, err := spotifyClient(ctx)
+	if err != nil {
+		return err
+	}
+	timeRange := topTracksTimeRange(cmd.Period)
+	limit := clampLimit(cmd.Limit)
+	res, err := client.GetUsersTopTracks(cmdCtx, timeRange, limit, cmd.Offset)
+	if err != nil {
+		return err
+	}
+	plain, human := renderTopTracks(ctx.Output, res.Items)
+	payload := map[string]any{
+		"total":      res.Total,
+		"limit":      res.Limit,
+		"offset":     res.Offset,
+		"items":      res.Items,
+		"time_range": timeRange,
+		"period":     cmd.Period,
+		"note":       topTracksPeriodNote(cmd.Period),
+		"period_map": topTrackPeriods,
+	}
+	if ctx.Output.Format == output.FormatHuman {
+		header := fmt.Sprintf("Top tracks (%s -> %s): %d (affinity ranking, not play counts)", cmd.Period, timeRange, res.Total)
+		human = append([]string{header, topTracksPeriodNote(cmd.Period)}, human...)
+	}
+	return ctx.Output.Emit(payload, plain, human)
+}
+
+func (cmd *UserHistoryCmd) Run(ctx *app.Context) error {
+	client, cmdCtx, err := spotifyClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	limit := clampLimit(cmd.Limit)
+	after := cmd.After
+	if after == 0 && cmd.Period != "all" {
+		after = historyAfter(cmd.Period)
+	}
+
+	var allItems []spotify.RecentlyPlayedItem
+	var lastCursors *spotify.Cursors
+	before := cmd.Before
+	stopAtLowerBound := false
+
+	for {
+		res, err := client.GetRecentlyPlayed(cmdCtx, limit, 0, before)
+		if err != nil {
+			return err
+		}
+		if res.Cursors != nil {
+			lastCursors = res.Cursors
+		}
+		for _, item := range res.Items {
+			ms, err := parseRFC3339Milli(item.PlayedAt)
+			if err != nil {
+				continue
+			}
+			if cmd.Before > 0 && ms >= cmd.Before {
+				continue
+			}
+			if after > 0 && ms < after {
+				stopAtLowerBound = true
+				continue
+			}
+			allItems = append(allItems, item)
+			if len(allItems) >= maxHistoryItems {
+				break
+			}
+		}
+		if len(res.Items) == 0 || res.Cursors == nil || res.Cursors.Before == "" || len(allItems) >= maxHistoryItems || stopAtLowerBound {
+			break
+		}
+		nextBefore, err := strconv.ParseInt(res.Cursors.Before, 10, 64)
+		if err != nil || nextBefore == before {
+			break
+		}
+		before = nextBefore
+	}
+
+	plain, human := renderRecentlyPlayed(ctx.Output, allItems)
+	payload := map[string]any{
+		"items":                 allItems,
+		"cursors":               lastCursors,
+		"total_fetched":         len(allItems),
+		"max_allowed":           maxHistoryItems,
+		"period":                cmd.Period,
+		"requested_after":       cmd.After,
+		"requested_before":      cmd.Before,
+		"effective_lower_bound": after,
+		"note":                  "Spotify recently-played returns available recent plays only; periods are client-side filters, not complete historical archives.",
+	}
+	if ctx.Output.Format == output.FormatHuman {
+		header := fmt.Sprintf("Recently played available from Spotify: %d", len(allItems))
+		if cmd.Period != "all" {
+			header = fmt.Sprintf("Recently played available within %s: %d", cmd.Period, len(allItems))
+		}
+		human = append([]string{header, "Spotify retention and the 200-item client cap mean this is not a complete listening archive."}, human...)
+	}
+	return ctx.Output.Emit(payload, plain, human)
+}
+
+func parseRFC3339Milli(s string) (int64, error) {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t, err = time.Parse("2006-01-02T15:04:05.000Z", s)
+		if err != nil {
+			return 0, err
+		}
+	}
+	return t.UnixMilli(), nil
+}
+
+func renderTopTracks(w *output.Writer, items []spotify.Item) (plain []string, human []string) {
+	accent := w.Theme.Accent
+	muted := w.Theme.Muted
+	plain = make([]string, 0, len(items))
+	human = make([]string, 0, len(items))
+	for i, item := range items {
+		rank := i + 1
+		plain = append(plain, fmt.Sprintf("%d\ttrack\t%s\t%s\t%s\t%s\t%s", rank, item.ID, item.Name, strings.Join(item.Artists, ", "), item.Album, item.URI))
+		human = append(human, fmt.Sprintf("%d. %s — %s %s", rank, accent(item.Name), strings.Join(item.Artists, ", "), muted("· "+item.Album)))
+	}
+	return plain, human
+}
+
+func renderRecentlyPlayed(w *output.Writer, items []spotify.RecentlyPlayedItem) (plain []string, human []string) {
+	accent := w.Theme.Accent
+	muted := w.Theme.Muted
+	plain = make([]string, 0, len(items))
+	human = make([]string, 0, len(items))
+	for _, item := range items {
+		plain = append(plain, fmt.Sprintf("%s\ttrack\t%s\t%s\t%s\t%s\t%s", item.PlayedAt, item.Track.ID, item.Track.Name, strings.Join(item.Track.Artists, ", "), item.Track.Album, item.Track.URI))
+		human = append(human, fmt.Sprintf("%s — %s %s", accent(item.Track.Name), strings.Join(item.Track.Artists, ", "), muted("· "+item.PlayedAt)))
+	}
+	return plain, human
+}

--- a/internal/cli/history_test.go
+++ b/internal/cli/history_test.go
@@ -1,0 +1,504 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steipete/spogo/internal/output"
+	"github.com/steipete/spogo/internal/spotify"
+	"github.com/steipete/spogo/internal/testutil"
+)
+
+func TestUserTopTracksCmd(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetUsersTopTracksFn: func(ctx context.Context, timeRange string, limit, offset int) (spotify.TopTracksResult, error) {
+			if timeRange != "long_term" {
+				t.Fatalf("unexpected time_range: %s", timeRange)
+			}
+			return spotify.TopTracksResult{
+				Total: 1, Limit: 20, Offset: 0,
+				Items: []spotify.Item{{ID: "t1", Name: "Song", Type: "track", Artists: []string{"A"}, Album: "Album", URI: "spotify:track:t1"}},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserTopTracksCmd{Period: "all-time", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out.String() == "" {
+		t.Fatalf("expected output")
+	}
+}
+
+func TestUserTopTracksCmdYear(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetUsersTopTracksFn: func(ctx context.Context, timeRange string, limit, offset int) (spotify.TopTracksResult, error) {
+			if timeRange != "long_term" {
+				t.Fatalf("expected long_term for year, got %s", timeRange)
+			}
+			return spotify.TopTracksResult{Total: 1, Limit: 20, Offset: 0, Items: []spotify.Item{{ID: "t1", Name: "Song", Type: "track"}}}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserTopTracksCmd{Period: "year", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out.String() == "" {
+		t.Fatalf("expected output")
+	}
+}
+
+func TestUserTopTracksCmd6mo(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetUsersTopTracksFn: func(ctx context.Context, timeRange string, limit, offset int) (spotify.TopTracksResult, error) {
+			if timeRange != "medium_term" {
+				t.Fatalf("expected medium_term, got %s", timeRange)
+			}
+			return spotify.TopTracksResult{Total: 1, Items: []spotify.Item{{ID: "t1", Name: "Song", Type: "track"}}}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserTopTracksCmd{Period: "6mo", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+}
+
+func TestUserTopTracksCmdMonth(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetUsersTopTracksFn: func(ctx context.Context, timeRange string, limit, offset int) (spotify.TopTracksResult, error) {
+			if timeRange != "short_term" {
+				t.Fatalf("expected short_term, got %s", timeRange)
+			}
+			return spotify.TopTracksResult{Total: 1, Items: []spotify.Item{{ID: "t1", Name: "Song", Type: "track"}}}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserTopTracksCmd{Period: "month", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+}
+
+func TestUserTopTracksCmdWeek(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetUsersTopTracksFn: func(ctx context.Context, timeRange string, limit, offset int) (spotify.TopTracksResult, error) {
+			if timeRange != "short_term" {
+				t.Fatalf("expected short_term, got %s", timeRange)
+			}
+			return spotify.TopTracksResult{Total: 1, Items: []spotify.Item{{ID: "t1", Name: "Song", Type: "track"}}}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserTopTracksCmd{Period: "week", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+}
+
+func TestUserTopTracksCmdDayError(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	cmd := UserTopTracksCmd{Period: "day", Limit: 20}
+	if err := cmd.Run(ctx); err == nil {
+		t.Fatalf("expected error for day period")
+	}
+}
+
+func TestUserTopTracksCmdError(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetUsersTopTracksFn: func(ctx context.Context, timeRange string, limit, offset int) (spotify.TopTracksResult, error) {
+			return spotify.TopTracksResult{}, errors.New("boom")
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserTopTracksCmd{Period: "all-time", Limit: 20}
+	if err := cmd.Run(ctx); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestUserTopTracksCmdJSON(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatJSON)
+	mock := &testutil.SpotifyMock{
+		GetUsersTopTracksFn: func(ctx context.Context, timeRange string, limit, offset int) (spotify.TopTracksResult, error) {
+			return spotify.TopTracksResult{
+				Total: 1, Limit: 20, Offset: 0,
+				Items: []spotify.Item{{ID: "t1", Name: "Song", Type: "track", Artists: []string{"A"}, Album: "Album"}},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserTopTracksCmd{Period: "all-time", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(out.String(), `"total": 1`) {
+		t.Fatalf("JSON output missing total: %s", out.String())
+	}
+}
+
+func TestUserHistoryCmd(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "t1", Name: "Song", Type: "track", Artists: []string{"A"}, Album: "Album", URI: "spotify:track:t1"}, PlayedAt: "2024-01-15T10:00:00Z"},
+				},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "all", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out.String() == "" {
+		t.Fatalf("expected output")
+	}
+}
+
+func TestUserHistoryCmdWithPeriod(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			if after != 0 {
+				t.Fatalf("period history should page with before and filter lower bound client-side, got after=%d", after)
+			}
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "t1", Name: "Song", Type: "track"}, PlayedAt: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)},
+				},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "year", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+}
+
+func TestUserHistoryCmdCustomAfter(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	var capturedAfter int64
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			capturedAfter = after
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "t1", Name: "Song", Type: "track"}, PlayedAt: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)},
+				},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "all", Limit: 20, After: 1234567890000}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if capturedAfter != 0 {
+		t.Fatalf("expected API after=0; custom after is a client-side lower bound, got %d", capturedAfter)
+	}
+}
+
+func TestUserHistoryCmdCustomBefore(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	var capturedBefore int64
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			capturedBefore = before
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "t1", Name: "Song", Type: "track"}, PlayedAt: "2024-01-15T10:00:00Z"},
+				},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "all", Limit: 20, Before: 1234567890000}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if capturedBefore != 1234567890000 {
+		t.Fatalf("expected before=1234567890000, got %d", capturedBefore)
+	}
+}
+
+func TestUserHistoryCmdError(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			return spotify.RecentlyPlayedResult{}, errors.New("boom")
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "all", Limit: 20}
+	if err := cmd.Run(ctx); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestUserHistoryCmdJSON(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatJSON)
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "t1", Name: "Song", Type: "track", Artists: []string{"A"}}, PlayedAt: "2024-01-15T10:00:00Z"},
+				},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "all", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(out.String(), `"played_at"`) {
+		t.Fatalf("JSON output missing played_at: %s", out.String())
+	}
+}
+
+func TestUserHistoryCmdPeriodAllNoAfter(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	var capturedAfter int64
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			capturedAfter = after
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "t1", Name: "Song", Type: "track"}, PlayedAt: "2024-01-15T10:00:00Z"},
+				},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "all", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if capturedAfter != 0 {
+		t.Fatalf("expected after=0 for 'all' period, got %d", capturedAfter)
+	}
+}
+
+func TestTopTrackPeriodMapping(t *testing.T) {
+	tests := []struct {
+		period   string
+		expected string
+	}{
+		{"all-time", "long_term"},
+		{"year", "long_term"},
+		{"6mo", "medium_term"},
+		{"month", "short_term"},
+		{"week", "short_term"},
+	}
+	for _, tt := range tests {
+		got := topTracksTimeRange(tt.period)
+		if got != tt.expected {
+			t.Errorf("topTracksTimeRange(%q) = %q, want %q", tt.period, got, tt.expected)
+		}
+	}
+}
+
+func TestHistoryPeriodProducesAfter(t *testing.T) {
+	periods := []string{"year", "6mo", "1mo", "1wk", "1day"}
+	for _, p := range periods {
+		after := historyAfter(p)
+		if after <= 0 {
+			t.Errorf("historyAfter(%q) = %d, expected > 0", p, after)
+		}
+	}
+}
+
+func TestHistoryPeriodAllReturnsZero(t *testing.T) {
+	if after := historyAfter("all"); after != 0 {
+		t.Fatalf("historyAfter(all) = %d, expected 0", after)
+	}
+}
+
+func TestUserHistoryCmdPagination(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatPlain)
+	playedAt1 := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	playedAt2 := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+	callCount := 0
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			if after != 0 {
+				t.Fatalf("pagination should use before cursor, got after=%d", after)
+			}
+			callCount++
+			switch callCount {
+			case 1:
+				if before != 0 {
+					t.Fatalf("expected first page to start from now, got before=%d", before)
+				}
+				return spotify.RecentlyPlayedResult{
+					Limit: limit,
+					Items: []spotify.RecentlyPlayedItem{
+						{Track: spotify.Item{ID: "t1", Name: "Song1", Type: "track"}, PlayedAt: playedAt1},
+					},
+					Cursors: &spotify.Cursors{Before: "1705226400000"},
+					Next:    "https://api.spotify.com/v1/me/player/recently-played?before=1705226400000",
+				}, nil
+			case 2:
+				if before != 1705226400000 {
+					t.Fatalf("expected second page before cursor, got %d", before)
+				}
+				return spotify.RecentlyPlayedResult{
+					Limit: limit,
+					Items: []spotify.RecentlyPlayedItem{
+						{Track: spotify.Item{ID: "t2", Name: "Song2", Type: "track"}, PlayedAt: playedAt2},
+					},
+					Cursors: &spotify.Cursors{Before: "1705140000000"},
+					Next:    "https://api.spotify.com/v1/me/player/recently-played?before=1705140000000",
+				}, nil
+			default:
+				return spotify.RecentlyPlayedResult{Limit: limit}, nil
+			}
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "year", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if callCount != 3 {
+		t.Fatalf("expected 3 API calls for pagination, got %d", callCount)
+	}
+	if out.String() == "" {
+		t.Fatalf("expected output")
+	}
+}
+
+func TestUserHistoryCmdPaginationStopsAtCap(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	playedAt := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	callCount := 0
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			callCount++
+			items := make([]spotify.RecentlyPlayedItem, limit)
+			for i := range items {
+				items[i] = spotify.RecentlyPlayedItem{
+					Track:    spotify.Item{ID: fmt.Sprintf("t%d", callCount*limit+i), Name: "Song", Type: "track"},
+					PlayedAt: playedAt,
+				}
+			}
+			return spotify.RecentlyPlayedResult{
+				Limit:   limit,
+				Items:   items,
+				Cursors: &spotify.Cursors{Before: fmt.Sprintf("%d", 1700000000000-callCount)},
+				Next:    "https://api.spotify.com/v1/me/player/recently-played?before=next",
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "year", Limit: 50}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if callCount != 4 {
+		t.Fatalf("expected 4 API calls (50*4=200 cap), got %d", callCount)
+	}
+}
+
+func TestUserHistoryCmdBeforeOnly(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	var capturedBefore int64
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			capturedBefore = before
+			if after != 0 {
+				t.Fatalf("expected after=0 for before-only request, got %d", after)
+			}
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "t1", Name: "Song", Type: "track"}, PlayedAt: "2024-01-15T10:00:00Z"},
+				},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "all", Limit: 20, Before: 1234567890000}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if capturedBefore != 1234567890000 {
+		t.Fatalf("expected before=1234567890000, got %d", capturedBefore)
+	}
+}
+
+func TestUserHistoryCmdAfterAndBeforeFilter(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	callCount := 0
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			if after != 0 {
+				t.Fatalf("expected after=0; pagination should use before and filter lower bound client-side, got %d", after)
+			}
+			callCount++
+			if callCount == 1 && before != 1705363200000 {
+				t.Fatalf("expected first request to honor explicit before, got %d", before)
+			}
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "t1", Name: "S1", Type: "track"}, PlayedAt: "2024-01-15T10:00:00Z"},
+					{Track: spotify.Item{ID: "t2", Name: "S2", Type: "track"}, PlayedAt: "2024-01-16T10:00:00Z"},
+				},
+				Cursors: &spotify.Cursors{Before: "1705312800000"},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "year", Limit: 20, Before: 1705363200000}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+}
+
+func TestParseRFC3339Milli(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int64
+	}{
+		{"2024-01-15T10:00:00Z", 1705312800000},
+		{"2024-01-15T10:00:00.000Z", 1705312800000},
+	}
+	for _, tt := range tests {
+		got, err := parseRFC3339Milli(tt.input)
+		if err != nil {
+			t.Fatalf("parseRFC3339Milli(%q): %v", tt.input, err)
+		}
+		if got != tt.want {
+			t.Errorf("parseRFC3339Milli(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseRFC3339MilliError(t *testing.T) {
+	if _, err := parseRFC3339Milli("invalid"); err == nil {
+		t.Fatalf("expected error for invalid input")
+	}
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -105,6 +105,15 @@ func (w *Writer) Errorf(format string, args ...any) {
 		return
 	}
 	msg := fmt.Sprintf(format, args...)
+	if w.Format == FormatJSON {
+		data, err := json.Marshal(map[string]string{"error": msg})
+		if err != nil {
+			_, _ = fmt.Fprintln(w.Err, msg)
+			return
+		}
+		_, _ = fmt.Fprintln(w.Err, string(data))
+		return
+	}
 	if w.Color {
 		msg = w.Theme.Error(msg)
 	}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -121,3 +121,31 @@ func TestErrorfNilWriter(t *testing.T) {
 	var w *Writer
 	w.Errorf("oops")
 }
+
+func TestErrorfJSON(t *testing.T) {
+	errOut := &bytes.Buffer{}
+	w, err := New(Options{Format: FormatJSON, Out: &bytes.Buffer{}, Err: errOut})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	w.Errorf("something went wrong: %d", 42)
+	got := strings.TrimSpace(errOut.String())
+	want := `{"error":"something went wrong: 42"}`
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestErrorfJSONWithColor(t *testing.T) {
+	errOut := &bytes.Buffer{}
+	w, err := New(Options{Format: FormatJSON, Out: &bytes.Buffer{}, Err: errOut, Color: true})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	w.Errorf("oops %d", 99)
+	got := strings.TrimSpace(errOut.String())
+	want := `{"error":"oops 99"}`
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/internal/spotify/api.go
+++ b/internal/spotify/api.go
@@ -33,4 +33,6 @@ type API interface {
 	CreatePlaylist(ctx context.Context, name string, public, collaborative bool) (Item, error)
 	AddTracks(ctx context.Context, playlistID string, uris []string) error
 	RemoveTracks(ctx context.Context, playlistID string, uris []string) error
+	GetUsersTopTracks(ctx context.Context, timeRange string, limit, offset int) (TopTracksResult, error)
+	GetRecentlyPlayed(ctx context.Context, limit int, after, before int64) (RecentlyPlayedResult, error)
 }

--- a/internal/spotify/applescript.go
+++ b/internal/spotify/applescript.go
@@ -298,3 +298,17 @@ func (c *AppleScriptClient) RemoveTracks(ctx context.Context, playlistID string,
 	}
 	return ErrUnsupported
 }
+
+func (c *AppleScriptClient) GetUsersTopTracks(ctx context.Context, timeRange string, limit, offset int) (TopTracksResult, error) {
+	if c.fallback != nil {
+		return c.fallback.GetUsersTopTracks(ctx, timeRange, limit, offset)
+	}
+	return TopTracksResult{}, ErrUnsupported
+}
+
+func (c *AppleScriptClient) GetRecentlyPlayed(ctx context.Context, limit int, after, before int64) (RecentlyPlayedResult, error) {
+	if c.fallback != nil {
+		return c.fallback.GetRecentlyPlayed(ctx, limit, after, before)
+	}
+	return RecentlyPlayedResult{}, ErrUnsupported
+}

--- a/internal/spotify/auto.go
+++ b/internal/spotify/auto.go
@@ -247,3 +247,15 @@ func (c *autoClient) RemoveTracks(ctx context.Context, playlistID string, uris [
 		return api.RemoveTracks(ctx, playlistID, uris)
 	})
 }
+
+func (c *autoClient) GetUsersTopTracks(ctx context.Context, timeRange string, limit, offset int) (TopTracksResult, error) {
+	return autoCall(c, func(api API) (TopTracksResult, error) {
+		return api.GetUsersTopTracks(ctx, timeRange, limit, offset)
+	})
+}
+
+func (c *autoClient) GetRecentlyPlayed(ctx context.Context, limit int, after, before int64) (RecentlyPlayedResult, error) {
+	return autoCall(c, func(api API) (RecentlyPlayedResult, error) {
+		return api.GetRecentlyPlayed(ctx, limit, after, before)
+	})
+}

--- a/internal/spotify/client.go
+++ b/internal/spotify/client.go
@@ -404,6 +404,60 @@ func (c *Client) RemoveTracks(ctx context.Context, playlistID string, uris []str
 	return c.send(ctx, http.MethodDelete, "/playlists/"+playlistID+"/tracks", nil, payload, nil)
 }
 
+func (c *Client) GetUsersTopTracks(ctx context.Context, timeRange string, limit, offset int) (TopTracksResult, error) {
+	params := url.Values{}
+	params.Set("time_range", timeRange)
+	params.Set("limit", fmt.Sprint(limit))
+	params.Set("offset", fmt.Sprint(offset))
+	var raw topTracksResponse
+	if err := c.get(ctx, "/me/top/tracks", params, &raw); err != nil {
+		return TopTracksResult{}, err
+	}
+	items := make([]Item, 0, len(raw.Items))
+	for _, t := range raw.Items {
+		items = append(items, mapTrack(t))
+	}
+	return TopTracksResult{
+		Total:  raw.Total,
+		Limit:  raw.Limit,
+		Offset: raw.Offset,
+		Items:  items,
+	}, nil
+}
+
+func (c *Client) GetRecentlyPlayed(ctx context.Context, limit int, after, before int64) (RecentlyPlayedResult, error) {
+	params := url.Values{}
+	params.Set("limit", fmt.Sprint(limit))
+	if after > 0 {
+		params.Set("after", fmt.Sprint(after))
+	} else if before > 0 {
+		params.Set("before", fmt.Sprint(before))
+	}
+	var raw recentlyPlayedResponse
+	if err := c.get(ctx, "/me/player/recently-played", params, &raw); err != nil {
+		return RecentlyPlayedResult{}, err
+	}
+	items := make([]RecentlyPlayedItem, 0, len(raw.Items))
+	for _, item := range raw.Items {
+		items = append(items, RecentlyPlayedItem{
+			Track:    mapTrack(item.Track),
+			PlayedAt: item.PlayedAt,
+		})
+	}
+	result := RecentlyPlayedResult{
+		Items: items,
+		Next:  raw.Next,
+		Limit: raw.Limit,
+	}
+	if raw.Cursors != nil {
+		result.Cursors = &Cursors{
+			After:  raw.Cursors.After,
+			Before: raw.Cursors.Before,
+		}
+	}
+	return result, nil
+}
+
 func (c *Client) currentUserID(ctx context.Context) (string, error) {
 	var raw userProfile
 	if err := c.get(ctx, "/me", nil, &raw); err != nil {

--- a/internal/spotify/client_more_test.go
+++ b/internal/spotify/client_more_test.go
@@ -85,6 +85,59 @@ func TestClientEndpoints(t *testing.T) {
 	mux.HandleFunc("/me/playlists", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(playlistListResponse{Items: []playlistItem{{ID: "p1", Name: "Playlist"}}, Total: 1})
 	})
+	mux.HandleFunc("/me/top/tracks", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("time_range"); got != "medium_term" {
+			t.Errorf("top tracks time_range = %q, want medium_term", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "7" {
+			t.Errorf("top tracks limit = %q, want 7", got)
+		}
+		if got := r.URL.Query().Get("offset"); got != "2" {
+			t.Errorf("top tracks offset = %q, want 2", got)
+		}
+		_ = json.NewEncoder(w).Encode(topTracksResponse{
+			Items:  []trackItem{{ID: "t1", URI: "spotify:track:t1", Name: "Track", Album: albumRef{Name: "Album"}, Artists: []artistRef{{Name: "Artist"}}}},
+			Total:  1,
+			Limit:  7,
+			Offset: 2,
+		})
+	})
+	recentlyPlayedCalls := 0
+	mux.HandleFunc("/me/player/recently-played", func(w http.ResponseWriter, r *http.Request) {
+		recentlyPlayedCalls++
+		if got := r.URL.Query().Get("limit"); got != "3" {
+			t.Errorf("recently played limit = %q, want 3", got)
+		}
+		switch recentlyPlayedCalls {
+		case 1:
+			if got := r.URL.Query().Get("after"); got != "1700000000000" {
+				t.Errorf("recently played after = %q, want 1700000000000", got)
+			}
+			if got := r.URL.Query().Get("before"); got != "" {
+				t.Errorf("recently played before = %q, want empty when after is set", got)
+			}
+		case 2:
+			if got := r.URL.Query().Get("after"); got != "" {
+				t.Errorf("recently played after = %q, want empty when before is set", got)
+			}
+			if got := r.URL.Query().Get("before"); got != "1705312800000" {
+				t.Errorf("recently played before = %q, want 1705312800000", got)
+			}
+		default:
+			t.Errorf("unexpected recently-played call %d", recentlyPlayedCalls)
+		}
+		_ = json.NewEncoder(w).Encode(recentlyPlayedResponse{
+			Items: []struct {
+				Track    trackItem `json:"track"`
+				PlayedAt string    `json:"played_at"`
+			}{
+				{Track: trackItem{ID: "t1", URI: "spotify:track:t1", Name: "Track", Album: albumRef{Name: "Album"}, Artists: []artistRef{{Name: "Artist"}}}, PlayedAt: "2024-01-15T10:00:00Z"},
+			},
+			Cursors: &cursorsItem{After: "1705312800001", Before: "1705312799999"},
+			Next:    "https://api.spotify.com/v1/me/player/recently-played?before=1705312799999",
+			Limit:   3,
+		})
+	})
 	mux.HandleFunc("/playlists/p1/tracks", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodDelete || r.Method == http.MethodPost {
 			w.WriteHeader(http.StatusNoContent)
@@ -176,6 +229,23 @@ func TestClientEndpoints(t *testing.T) {
 	}
 	if _, _, err := client.Playlists(context.Background(), 1, 0); err != nil {
 		t.Fatalf("playlists: %v", err)
+	}
+	topTracks, err := client.GetUsersTopTracks(context.Background(), "medium_term", 7, 2)
+	if err != nil {
+		t.Fatalf("top tracks: %v", err)
+	}
+	if topTracks.Total != 1 || topTracks.Limit != 7 || topTracks.Offset != 2 || topTracks.Items[0].Name != "Track" {
+		t.Fatalf("unexpected top tracks result: %+v", topTracks)
+	}
+	recent, err := client.GetRecentlyPlayed(context.Background(), 3, 1700000000000, 0)
+	if err != nil {
+		t.Fatalf("recently played: %v", err)
+	}
+	if recent.Limit != 3 || recent.Cursors == nil || recent.Cursors.Before != "1705312799999" || recent.Items[0].PlayedAt != "2024-01-15T10:00:00Z" {
+		t.Fatalf("unexpected recently played result: %+v", recent)
+	}
+	if _, err := client.GetRecentlyPlayed(context.Background(), 3, 0, 1705312800000); err != nil {
+		t.Fatalf("recently played before: %v", err)
 	}
 	if _, _, err := client.PlaylistTracks(context.Background(), "p1", 1, 0); err != nil {
 		t.Fatalf("playlist tracks: %v", err)

--- a/internal/spotify/connect.go
+++ b/internal/spotify/connect.go
@@ -225,6 +225,27 @@ func (c *ConnectClient) RemoveTracks(ctx context.Context, playlistID string, uri
 	})
 }
 
+func (c *ConnectClient) GetUsersTopTracks(ctx context.Context, timeRange string, limit, offset int) (TopTracksResult, error) {
+	return withWebResult(c, func(web *Client) (TopTracksResult, error) {
+		return web.GetUsersTopTracks(ctx, timeRange, limit, offset)
+	})
+}
+
+func (c *ConnectClient) GetRecentlyPlayed(ctx context.Context, limit int, after, before int64) (RecentlyPlayedResult, error) {
+	return withWebResult(c, func(web *Client) (RecentlyPlayedResult, error) {
+		return web.GetRecentlyPlayed(ctx, limit, after, before)
+	})
+}
+
+func withWebResult[T any](c *ConnectClient, fn func(*Client) (T, error)) (T, error) {
+	web, err := c.webClient()
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	return fn(web)
+}
+
 func withWebCollectionFallback(c *ConnectClient, primary func() ([]Item, int, error), fallback func(*Client) ([]Item, int, error)) ([]Item, int, error) {
 	items, total, err := primary()
 	if err == nil {

--- a/internal/spotify/fallback.go
+++ b/internal/spotify/fallback.go
@@ -218,3 +218,15 @@ func (c *fallbackClient) RemoveTracks(ctx context.Context, playlistID string, ur
 		return api.RemoveTracks(ctx, playlistID, uris)
 	})
 }
+
+func (c *fallbackClient) GetUsersTopTracks(ctx context.Context, timeRange string, limit, offset int) (TopTracksResult, error) {
+	return fallbackCall(c, true, func(api API) (TopTracksResult, error) {
+		return api.GetUsersTopTracks(ctx, timeRange, limit, offset)
+	})
+}
+
+func (c *fallbackClient) GetRecentlyPlayed(ctx context.Context, limit int, after, before int64) (RecentlyPlayedResult, error) {
+	return fallbackCall(c, true, func(api API) (RecentlyPlayedResult, error) {
+		return api.GetRecentlyPlayed(ctx, limit, after, before)
+	})
+}

--- a/internal/spotify/fallback_test.go
+++ b/internal/spotify/fallback_test.go
@@ -204,6 +204,16 @@ func (a apiStub) RemoveTracks(ctx context.Context, playlistID string, uris []str
 	return nil
 }
 
+func (a apiStub) GetUsersTopTracks(context.Context, string, int, int) (TopTracksResult, error) {
+	a.note("GetUsersTopTracks")
+	return TopTracksResult{}, nil
+}
+
+func (a apiStub) GetRecentlyPlayed(context.Context, int, int64, int64) (RecentlyPlayedResult, error) {
+	a.note("GetRecentlyPlayed")
+	return RecentlyPlayedResult{}, nil
+}
+
 func (a apiStub) note(name string) {
 	if a.calls == nil {
 		return

--- a/internal/spotify/models.go
+++ b/internal/spotify/models.go
@@ -159,3 +159,25 @@ type artistsContainer struct {
 type artistTopTracksResponse struct {
 	Tracks []trackItem `json:"tracks"`
 }
+
+type topTracksResponse struct {
+	Items  []trackItem `json:"items"`
+	Total  int         `json:"total"`
+	Limit  int         `json:"limit"`
+	Offset int         `json:"offset"`
+}
+
+type recentlyPlayedResponse struct {
+	Items []struct {
+		Track    trackItem `json:"track"`
+		PlayedAt string    `json:"played_at"`
+	} `json:"items"`
+	Cursors *cursorsItem `json:"cursors"`
+	Next    string       `json:"next"`
+	Limit   int          `json:"limit"`
+}
+
+type cursorsItem struct {
+	After  string `json:"after"`
+	Before string `json:"before"`
+}

--- a/internal/spotify/types.go
+++ b/internal/spotify/types.go
@@ -70,3 +70,27 @@ type Queue struct {
 	CurrentlyPlaying *Item  `json:"currently_playing,omitempty"`
 	Queue            []Item `json:"queue"`
 }
+
+type TopTracksResult struct {
+	Total  int    `json:"total"`
+	Limit  int    `json:"limit"`
+	Offset int    `json:"offset"`
+	Items  []Item `json:"items"`
+}
+
+type RecentlyPlayedResult struct {
+	Items   []RecentlyPlayedItem `json:"items"`
+	Cursors *Cursors             `json:"cursors,omitempty"`
+	Next    string               `json:"next,omitempty"`
+	Limit   int                  `json:"limit"`
+}
+
+type RecentlyPlayedItem struct {
+	Track    Item   `json:"track"`
+	PlayedAt string `json:"played_at"`
+}
+
+type Cursors struct {
+	After  string `json:"after"`
+	Before string `json:"before"`
+}

--- a/internal/testutil/spotify_mock.go
+++ b/internal/testutil/spotify_mock.go
@@ -10,35 +10,37 @@ import (
 var ErrNotImplemented = errors.New("not implemented")
 
 type SpotifyMock struct {
-	SearchFn          func(context.Context, string, string, int, int) (spotify.SearchResult, error)
-	GetTrackFn        func(context.Context, string) (spotify.Item, error)
-	GetAlbumFn        func(context.Context, string) (spotify.Item, error)
-	GetArtistFn       func(context.Context, string) (spotify.Item, error)
-	GetPlaylistFn     func(context.Context, string) (spotify.Item, error)
-	GetShowFn         func(context.Context, string) (spotify.Item, error)
-	GetEpisodeFn      func(context.Context, string) (spotify.Item, error)
-	ArtistTopTracksFn func(context.Context, string, int) ([]spotify.Item, error)
-	PlaybackFn        func(context.Context) (spotify.PlaybackStatus, error)
-	PlayFn            func(context.Context, string) error
-	PauseFn           func(context.Context) error
-	NextFn            func(context.Context) error
-	PreviousFn        func(context.Context) error
-	SeekFn            func(context.Context, int) error
-	VolumeFn          func(context.Context, int) error
-	ShuffleFn         func(context.Context, bool) error
-	RepeatFn          func(context.Context, string) error
-	DevicesFn         func(context.Context) ([]spotify.Device, error)
-	TransferFn        func(context.Context, string) error
-	QueueAddFn        func(context.Context, string) error
-	QueueFn           func(context.Context) (spotify.Queue, error)
-	LibraryTracksFn   func(context.Context, int, int) ([]spotify.Item, int, error)
-	LibraryAlbumsFn   func(context.Context, int, int) ([]spotify.Item, int, error)
-	LibraryModifyFn   func(context.Context, string, []string, string) error
-	FollowArtistsFn   func(context.Context, []string, string) error
-	FollowedArtistsFn func(context.Context, int, string) ([]spotify.Item, int, string, error)
-	PlaylistsFn       func(context.Context, int, int) ([]spotify.Item, int, error)
-	PlaylistTracksFn  func(context.Context, string, int, int) ([]spotify.Item, int, error)
-	CreatePlaylistFn  func(context.Context, string, bool, bool) (spotify.Item, error)
-	AddTracksFn       func(context.Context, string, []string) error
-	RemoveTracksFn    func(context.Context, string, []string) error
+	SearchFn            func(context.Context, string, string, int, int) (spotify.SearchResult, error)
+	GetTrackFn          func(context.Context, string) (spotify.Item, error)
+	GetAlbumFn          func(context.Context, string) (spotify.Item, error)
+	GetArtistFn         func(context.Context, string) (spotify.Item, error)
+	GetPlaylistFn       func(context.Context, string) (spotify.Item, error)
+	GetShowFn           func(context.Context, string) (spotify.Item, error)
+	GetEpisodeFn        func(context.Context, string) (spotify.Item, error)
+	ArtistTopTracksFn   func(context.Context, string, int) ([]spotify.Item, error)
+	PlaybackFn          func(context.Context) (spotify.PlaybackStatus, error)
+	PlayFn              func(context.Context, string) error
+	PauseFn             func(context.Context) error
+	NextFn              func(context.Context) error
+	PreviousFn          func(context.Context) error
+	SeekFn              func(context.Context, int) error
+	VolumeFn            func(context.Context, int) error
+	ShuffleFn           func(context.Context, bool) error
+	RepeatFn            func(context.Context, string) error
+	DevicesFn           func(context.Context) ([]spotify.Device, error)
+	TransferFn          func(context.Context, string) error
+	QueueAddFn          func(context.Context, string) error
+	QueueFn             func(context.Context) (spotify.Queue, error)
+	LibraryTracksFn     func(context.Context, int, int) ([]spotify.Item, int, error)
+	LibraryAlbumsFn     func(context.Context, int, int) ([]spotify.Item, int, error)
+	LibraryModifyFn     func(context.Context, string, []string, string) error
+	FollowArtistsFn     func(context.Context, []string, string) error
+	FollowedArtistsFn   func(context.Context, int, string) ([]spotify.Item, int, string, error)
+	PlaylistsFn         func(context.Context, int, int) ([]spotify.Item, int, error)
+	PlaylistTracksFn    func(context.Context, string, int, int) ([]spotify.Item, int, error)
+	CreatePlaylistFn    func(context.Context, string, bool, bool) (spotify.Item, error)
+	AddTracksFn         func(context.Context, string, []string) error
+	RemoveTracksFn      func(context.Context, string, []string) error
+	GetUsersTopTracksFn func(context.Context, string, int, int) (spotify.TopTracksResult, error)
+	GetRecentlyPlayedFn func(context.Context, int, int64, int64) (spotify.RecentlyPlayedResult, error)
 }

--- a/internal/testutil/spotify_mock_library.go
+++ b/internal/testutil/spotify_mock_library.go
@@ -75,3 +75,17 @@ func (m *SpotifyMock) RemoveTracks(ctx context.Context, playlistID string, uris 
 	}
 	return m.RemoveTracksFn(ctx, playlistID, uris)
 }
+
+func (m *SpotifyMock) GetUsersTopTracks(ctx context.Context, timeRange string, limit, offset int) (spotify.TopTracksResult, error) {
+	if m.GetUsersTopTracksFn == nil {
+		return spotify.TopTracksResult{}, ErrNotImplemented
+	}
+	return m.GetUsersTopTracksFn(ctx, timeRange, limit, offset)
+}
+
+func (m *SpotifyMock) GetRecentlyPlayed(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+	if m.GetRecentlyPlayedFn == nil {
+		return spotify.RecentlyPlayedResult{}, ErrNotImplemented
+	}
+	return m.GetRecentlyPlayedFn(ctx, limit, after, before)
+}

--- a/internal/testutil/spotify_mock_notimpl_test.go
+++ b/internal/testutil/spotify_mock_notimpl_test.go
@@ -38,4 +38,6 @@ func TestSpotifyMockAllNotImplemented(t *testing.T) {
 	_, _ = m.CreatePlaylist(context.Background(), "name", true, false)
 	_ = m.AddTracks(context.Background(), "p", []string{"u"})
 	_ = m.RemoveTracks(context.Background(), "p", []string{"u"})
+	_, _ = m.GetUsersTopTracks(context.Background(), "long_term", 20, 0)
+	_, _ = m.GetRecentlyPlayed(context.Background(), 20, 0, 0)
 }


### PR DESCRIPTION
## Summary
- Add `spogo user top-tracks` for Spotify `/me/top/tracks` affinity-ranked user top tracks.
- Add `spogo user history` for Spotify `/me/player/recently-played` with backward cursor pagination and a 200-item client cap.
- Wire the new user APIs through web/connect/auto/applescript fallback clients, mocks, docs, and command references.

## Spotify API limitations surfaced in the CLI/docs
- Top tracks are Spotify affinity rankings, not play counts.
- Spotify only supports `long_term`, `medium_term`, and `short_term` top-track windows: `year` maps to `long_term`, `6mo` maps to `medium_term`, `month`/`week` map to `short_term` (~4 weeks), and `day` returns an explicit unsupported-period error.
- Recently played is not a complete listening archive. Spotify returns retained recent plays only, at up to 50 items per page; spogo walks `before` cursors and applies `period`/`--after` as local lower-bound filters over available data.

## Test plan
- `gofmt -w internal/cli/history.go internal/spotify/client_more_test.go`
- `go vet ./...`
- `go test ./...`
- `go run ./cmd/spogo user --help`
- `go run ./cmd/spogo user top-tracks --help`
- `go run ./cmd/spogo user history --help`
- `git diff --cached --check`

## Review notes
- Independent review found no remaining blockers after docs/help/output wording and endpoint tests were added.
