### PR TITLE
Add user listening history commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - Play artists (starts with top tracks)
 - Queue management
 - Library management (save/remove/follow)
+- User listening data: top tracks by Spotify affinity and available recent plays
 - Playlist management (create/add/remove/list)
 - Device selection and status
 - Browser cookie import via `sweetcookie`
@@ -83,6 +84,7 @@ Commands:
 - `play [<id|url>] [--type ...] [--shuffle]`, `pause`, `next`, `prev`, `seek`, `volume`, `shuffle`, `repeat`, `status`
 - `queue add|show`
 - `library tracks|albums|artists|playlists`
+- `user top-tracks|history`
 - `playlist create|add|remove|tracks`
 - `device list|set`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -119,6 +119,19 @@ Saved tracks, albums, followed artists, owned/followed playlists. See [Library](
 | `spogo library artists unfollow <id|url...>` | Unfollow artists. |
 | `spogo library playlists list [--limit N]` | List owned/followed playlists. |
 
+## user
+
+Read-only listening data from Spotify's web endpoints.
+
+| Command | Purpose |
+| --- | --- |
+| `spogo user top-tracks [--period long_term|medium_term|short_term] [--limit N] [--offset N]` | Show Spotify top tracks by affinity ranking. |
+| `spogo user history [--period long_term|medium_term|short_term] [--limit N] [--after <ms>] [--before <ms>]` | Show recently played tracks available from Spotify. |
+
+- Top tracks are Spotify affinity rankings, not play counts.
+- `long_term` = years of listening data; `medium_term` = about 6 months; `short_term` = about 4 weeks.
+- Recently played is not a full archive. spogo paginates backward until it reaches `--limit` (max 200), the selected period, or Spotify's retained history. `medium_term`, `short_term`, and `--after` are local lower-bound filters.
+
 ## playlist
 
 Mutate playlists. See [Library](library.md).

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -102,6 +102,16 @@ spogo [global flags] <command> [args]
 - `spogo library artists unfollow <id|url...>`
 - `spogo library playlists list [--limit N]`
 
+### user
+
+- `spogo user top-tracks [--period long_term|medium_term|short_term] [--limit N] [--offset N]`
+  - returns Spotify affinity-ranked tracks, not play counts
+  - `long_term` = years of listening data; `medium_term` = about 6 months; `short_term` = about 4 weeks
+- `spogo user history [--period long_term|medium_term|short_term] [--limit N] [--after <ms>] [--before <ms>]`
+  - returns retained recent plays available from Spotify, not a complete listening archive
+  - paginates backward with `before` cursors until it reaches `--limit`, the selected period, or Spotify's retained history; client cap is 200 items
+  - `medium_term`, `short_term`, and `--after` are local lower-bound filters
+
 ### playlists
 
 - `spogo playlist create <name> [--public] [--collab]`

--- a/internal/app/context_test.go
+++ b/internal/app/context_test.go
@@ -417,3 +417,10 @@ func (dummySpotify) CreatePlaylist(context.Context, string, bool, bool) (spotify
 }
 func (dummySpotify) AddTracks(context.Context, string, []string) error    { return nil }
 func (dummySpotify) RemoveTracks(context.Context, string, []string) error { return nil }
+func (dummySpotify) GetUsersTopTracks(context.Context, string, int, int) (spotify.TopTracksResult, error) {
+	return spotify.TopTracksResult{}, nil
+}
+
+func (dummySpotify) GetRecentlyPlayed(context.Context, int, int64, int64) (spotify.RecentlyPlayedResult, error) {
+	return spotify.RecentlyPlayedResult{}, nil
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -41,6 +41,7 @@ type CLI struct {
 	Queue   QueueCmd   `kong:"cmd,help='Queue operations.'"`
 	Library LibraryCmd `kong:"cmd,help='Library operations.'"`
 	Device  DeviceCmd  `kong:"cmd,help='Playback devices.'"`
+	User    UserCmd    `kong:"cmd,help='User listening data.'"`
 }
 
 type Globals struct {

--- a/internal/cli/history.go
+++ b/internal/cli/history.go
@@ -1,0 +1,218 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/steipete/spogo/internal/app"
+	"github.com/steipete/spogo/internal/output"
+	"github.com/steipete/spogo/internal/spotify"
+)
+
+const (
+	maxHistoryItems = 200
+	maxHistoryPage  = 50
+	userPeriodList  = "long_term, medium_term, short_term"
+)
+
+type UserCmd struct {
+	TopTracks UserTopTracksCmd `kong:"cmd,help='Show your top tracks by affinity ranking.'"`
+	History   UserHistoryCmd   `kong:"cmd,help='Show recently played tracks available from Spotify.'"`
+}
+
+type UserTopTracksCmd struct {
+	Period string `help:"Time range: long_term (years), medium_term (~6 months), short_term (~4 weeks)." default:"long_term"`
+	Limit  int    `help:"Limit results." default:"20"`
+	Offset int    `help:"Offset results." default:"0"`
+}
+
+type UserHistoryCmd struct {
+	Period string `help:"History window: long_term, medium_term, short_term." default:"long_term"`
+	Limit  int    `help:"Limit results (max 200)." default:"20"`
+	After  int64  `help:"Lower-bound filter, Unix timestamp (ms)."`
+	Before int64  `help:"Return items played before this Unix timestamp (ms)."`
+}
+
+var validUserPeriods = map[string]bool{
+	"long_term":   true,
+	"medium_term": true,
+	"short_term":  true,
+}
+
+func topTracksTimeRange(period string) string {
+	if validUserPeriods[period] {
+		return period
+	}
+	return ""
+}
+
+var historyPeriodDurations = map[string]time.Duration{
+	"medium_term": 182 * 24 * time.Hour,
+	"short_term":  28 * 24 * time.Hour,
+}
+
+func historyAfter(period string) int64 {
+	d, ok := historyPeriodDurations[period]
+	if !ok {
+		return 0
+	}
+	return time.Now().Add(-d).UnixMilli()
+}
+
+func (cmd *UserTopTracksCmd) Run(ctx *app.Context) error {
+	timeRange := topTracksTimeRange(cmd.Period)
+	if timeRange == "" {
+		return fmt.Errorf("invalid top-tracks period %q; use one of: %s", cmd.Period, userPeriodList)
+	}
+	client, cmdCtx, err := spotifyClient(ctx)
+	if err != nil {
+		return err
+	}
+	limit := clampLimit(cmd.Limit)
+	res, err := client.GetUsersTopTracks(cmdCtx, timeRange, limit, cmd.Offset)
+	if err != nil {
+		return err
+	}
+	plain, human := renderTopTracks(ctx.Output, res.Items)
+	payload := map[string]any{
+		"total":      res.Total,
+		"limit":      res.Limit,
+		"offset":     res.Offset,
+		"items":      res.Items,
+		"time_range": timeRange,
+		"period":     cmd.Period,
+	}
+	if ctx.Output.Format == output.FormatHuman {
+		header := fmt.Sprintf("Top tracks (%s): %d", timeRange, res.Total)
+		human = append([]string{header}, human...)
+	}
+	return ctx.Output.Emit(payload, plain, human)
+}
+
+func (cmd *UserHistoryCmd) Run(ctx *app.Context) error {
+	if !validUserPeriods[cmd.Period] {
+		return fmt.Errorf("invalid history period %q; use one of: %s", cmd.Period, userPeriodList)
+	}
+	client, cmdCtx, err := spotifyClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	limit := clampHistoryLimit(cmd.Limit)
+	after := historyAfter(cmd.Period)
+	if cmd.After > after {
+		after = cmd.After
+	}
+
+	var allItems []spotify.RecentlyPlayedItem
+	var lastCursors *spotify.Cursors
+	before := cmd.Before
+	stopAtLowerBound := false
+
+	for {
+		remaining := limit - len(allItems)
+		if remaining <= 0 {
+			break
+		}
+		pageLimit := remaining
+		if pageLimit > maxHistoryPage {
+			pageLimit = maxHistoryPage
+		}
+
+		res, err := client.GetRecentlyPlayed(cmdCtx, pageLimit, 0, before)
+		if err != nil {
+			return err
+		}
+		if res.Cursors != nil {
+			lastCursors = res.Cursors
+		}
+		for _, item := range res.Items {
+			ms, err := parseRFC3339Milli(item.PlayedAt)
+			if err != nil {
+				return fmt.Errorf("invalid played_at %q: %w", item.PlayedAt, err)
+			}
+			if cmd.Before > 0 && ms >= cmd.Before {
+				continue
+			}
+			if after > 0 && ms < after {
+				stopAtLowerBound = true
+				continue
+			}
+			allItems = append(allItems, item)
+			if len(allItems) >= limit {
+				break
+			}
+		}
+		if len(res.Items) == 0 || res.Cursors == nil || res.Cursors.Before == "" || len(allItems) >= limit || stopAtLowerBound {
+			break
+		}
+		nextBefore, err := strconv.ParseInt(res.Cursors.Before, 10, 64)
+		if err != nil || nextBefore == before {
+			break
+		}
+		before = nextBefore
+	}
+
+	plain, human := renderRecentlyPlayed(ctx.Output, allItems)
+	payload := map[string]any{
+		"items":                 allItems,
+		"cursors":               lastCursors,
+		"total_fetched":         len(allItems),
+		"limit":                 limit,
+		"max_allowed":           maxHistoryItems,
+		"period":                cmd.Period,
+		"requested_after":       cmd.After,
+		"requested_before":      cmd.Before,
+		"effective_lower_bound": after,
+	}
+	if ctx.Output.Format == output.FormatHuman {
+		header := fmt.Sprintf("Recently played (%s): %d", cmd.Period, len(allItems))
+		human = append([]string{header}, human...)
+	}
+	return ctx.Output.Emit(payload, plain, human)
+}
+
+func clampHistoryLimit(limit int) int {
+	if limit <= 0 {
+		return 20
+	}
+	if limit > maxHistoryItems {
+		return maxHistoryItems
+	}
+	return limit
+}
+
+func parseRFC3339Milli(s string) (int64, error) {
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return 0, err
+	}
+	return t.UnixMilli(), nil
+}
+
+func renderTopTracks(w *output.Writer, items []spotify.Item) (plain []string, human []string) {
+	accent := w.Theme.Accent
+	muted := w.Theme.Muted
+	plain = make([]string, 0, len(items))
+	human = make([]string, 0, len(items))
+	for i, item := range items {
+		rank := i + 1
+		plain = append(plain, fmt.Sprintf("%d\ttrack\t%s\t%s\t%s\t%s\t%s", rank, item.ID, item.Name, strings.Join(item.Artists, ", "), item.Album, item.URI))
+		human = append(human, fmt.Sprintf("%d. %s — %s %s", rank, accent(item.Name), strings.Join(item.Artists, ", "), muted("· "+item.Album)))
+	}
+	return plain, human
+}
+
+func renderRecentlyPlayed(w *output.Writer, items []spotify.RecentlyPlayedItem) (plain []string, human []string) {
+	accent := w.Theme.Accent
+	muted := w.Theme.Muted
+	plain = make([]string, 0, len(items))
+	human = make([]string, 0, len(items))
+	for _, item := range items {
+		plain = append(plain, fmt.Sprintf("%s\ttrack\t%s\t%s\t%s\t%s\t%s", item.PlayedAt, item.Track.ID, item.Track.Name, strings.Join(item.Track.Artists, ", "), item.Track.Album, item.Track.URI))
+		human = append(human, fmt.Sprintf("%s — %s %s", accent(item.Track.Name), strings.Join(item.Track.Artists, ", "), muted("· "+item.PlayedAt)))
+	}
+	return plain, human
+}

--- a/internal/cli/history_test.go
+++ b/internal/cli/history_test.go
@@ -1,0 +1,658 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steipete/spogo/internal/output"
+	"github.com/steipete/spogo/internal/spotify"
+	"github.com/steipete/spogo/internal/testutil"
+)
+
+func TestUserTopTracksCmdLongTerm(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetUsersTopTracksFn: func(ctx context.Context, timeRange string, limit, offset int) (spotify.TopTracksResult, error) {
+			if timeRange != "long_term" {
+				t.Fatalf("unexpected time_range: %s", timeRange)
+			}
+			return spotify.TopTracksResult{
+				Total: 1, Limit: 20, Offset: 0,
+				Items: []spotify.Item{{ID: "t1", Name: "Song", Type: "track", Artists: []string{"A"}, Album: "Album", URI: "spotify:track:t1"}},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserTopTracksCmd{Period: "long_term", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out.String() == "" {
+		t.Fatalf("expected output")
+	}
+}
+
+func TestUserTopTracksCmdMediumTerm(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetUsersTopTracksFn: func(ctx context.Context, timeRange string, limit, offset int) (spotify.TopTracksResult, error) {
+			if timeRange != "medium_term" {
+				t.Fatalf("expected medium_term, got %s", timeRange)
+			}
+			return spotify.TopTracksResult{Total: 1, Items: []spotify.Item{{ID: "t1", Name: "Song", Type: "track"}}}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserTopTracksCmd{Period: "medium_term", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+}
+
+func TestUserTopTracksCmdShortTerm(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetUsersTopTracksFn: func(ctx context.Context, timeRange string, limit, offset int) (spotify.TopTracksResult, error) {
+			if timeRange != "short_term" {
+				t.Fatalf("expected short_term, got %s", timeRange)
+			}
+			return spotify.TopTracksResult{Total: 1, Items: []spotify.Item{{ID: "t1", Name: "Song", Type: "track"}}}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserTopTracksCmd{Period: "short_term", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+}
+
+func TestUserTopTracksCmdInvalidPeriodError(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	cmd := UserTopTracksCmd{Period: "day", Limit: 20}
+	if err := cmd.Run(ctx); err == nil {
+		t.Fatalf("expected error for invalid period")
+	}
+}
+
+func TestUserTopTracksCmdError(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetUsersTopTracksFn: func(ctx context.Context, timeRange string, limit, offset int) (spotify.TopTracksResult, error) {
+			return spotify.TopTracksResult{}, errors.New("boom")
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserTopTracksCmd{Period: "long_term", Limit: 20}
+	if err := cmd.Run(ctx); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestUserTopTracksCmdJSON(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatJSON)
+	mock := &testutil.SpotifyMock{
+		GetUsersTopTracksFn: func(ctx context.Context, timeRange string, limit, offset int) (spotify.TopTracksResult, error) {
+			if timeRange != "long_term" || limit != 20 || offset != 0 {
+				t.Fatalf("unexpected request: timeRange=%s limit=%d offset=%d", timeRange, limit, offset)
+			}
+			return spotify.TopTracksResult{
+				Total: 1, Limit: 20, Offset: 0,
+				Items: []spotify.Item{{ID: "t1", Name: "Song", Type: "track", Artists: []string{"A"}, Album: "Album"}},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserTopTracksCmd{Period: "long_term", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var payload struct {
+		Total     int            `json:"total"`
+		Limit     int            `json:"limit"`
+		Offset    int            `json:"offset"`
+		TimeRange string         `json:"time_range"`
+		Period    string         `json:"period"`
+		Items     []spotify.Item `json:"items"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("json: %v\n%s", err, out.String())
+	}
+	if payload.Total != 1 || payload.Limit != 20 || payload.Offset != 0 || payload.TimeRange != "long_term" || payload.Period != "long_term" || len(payload.Items) != 1 {
+		t.Fatalf("unexpected payload: %#v", payload)
+	}
+}
+
+func TestUserTopTracksCmdClampsLimitAndPassesOffset(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetUsersTopTracksFn: func(ctx context.Context, timeRange string, limit, offset int) (spotify.TopTracksResult, error) {
+			if timeRange != "medium_term" || limit != 50 || offset != 7 {
+				t.Fatalf("unexpected request: timeRange=%s limit=%d offset=%d", timeRange, limit, offset)
+			}
+			return spotify.TopTracksResult{Total: 0, Limit: limit, Offset: offset}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserTopTracksCmd{Period: "medium_term", Limit: 100, Offset: 7}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+}
+
+func TestUserHistoryCmd(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "t1", Name: "Song", Type: "track", Artists: []string{"A"}, Album: "Album", URI: "spotify:track:t1"}, PlayedAt: "2024-01-15T10:00:00Z"},
+				},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "long_term", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	want := "2024-01-15T10:00:00Z\ttrack\tt1\tSong\tA\tAlbum\tspotify:track:t1\n"
+	if out.String() != want {
+		t.Fatalf("output = %q, want %q", out.String(), want)
+	}
+}
+
+func TestUserHistoryCmdWithPeriod(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			if after != 0 {
+				t.Fatalf("period history should page with before and filter lower bound client-side, got after=%d", after)
+			}
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "t1", Name: "Song", Type: "track"}, PlayedAt: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)},
+				},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "short_term", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+}
+
+func TestUserHistoryCmdCustomAfter(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	var capturedAfter int64
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			capturedAfter = after
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "t1", Name: "Song", Type: "track"}, PlayedAt: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)},
+				},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "long_term", Limit: 20, After: 1234567890000}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if capturedAfter != 0 {
+		t.Fatalf("expected API after=0; custom after is a client-side lower bound, got %d", capturedAfter)
+	}
+}
+
+func TestUserHistoryCmdAfterCannotBypassPeriod(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatJSON)
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "old", Name: "Old", Type: "track"}, PlayedAt: time.Now().Add(-29 * 24 * time.Hour).UTC().Format(time.RFC3339)},
+				},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "short_term", Limit: 20, After: 1}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var payload struct {
+		RequestedAfter      int64                        `json:"requested_after"`
+		EffectiveLowerBound int64                        `json:"effective_lower_bound"`
+		Items               []spotify.RecentlyPlayedItem `json:"items"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("json: %v\n%s", err, out.String())
+	}
+	if payload.RequestedAfter != 1 || payload.EffectiveLowerBound <= payload.RequestedAfter || len(payload.Items) != 0 {
+		t.Fatalf("unexpected payload: %#v", payload)
+	}
+}
+
+func TestUserHistoryCmdCustomBefore(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	var capturedBefore int64
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			capturedBefore = before
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "t1", Name: "Song", Type: "track"}, PlayedAt: "2024-01-15T10:00:00Z"},
+				},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "long_term", Limit: 20, Before: 1234567890000}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if capturedBefore != 1234567890000 {
+		t.Fatalf("expected before=1234567890000, got %d", capturedBefore)
+	}
+}
+
+func TestUserHistoryCmdError(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			return spotify.RecentlyPlayedResult{}, errors.New("boom")
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "long_term", Limit: 20}
+	if err := cmd.Run(ctx); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestUserHistoryCmdJSON(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatJSON)
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "t1", Name: "Song", Type: "track", Artists: []string{"A"}}, PlayedAt: "2024-01-15T10:00:00Z"},
+				},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "long_term", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var payload struct {
+		Period              string                       `json:"period"`
+		RequestedAfter      int64                        `json:"requested_after"`
+		RequestedBefore     int64                        `json:"requested_before"`
+		EffectiveLowerBound int64                        `json:"effective_lower_bound"`
+		TotalFetched        int                          `json:"total_fetched"`
+		Limit               int                          `json:"limit"`
+		MaxAllowed          int                          `json:"max_allowed"`
+		Items               []spotify.RecentlyPlayedItem `json:"items"`
+		Cursors             *spotify.Cursors             `json:"cursors"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("json: %v\n%s", err, out.String())
+	}
+	if payload.Period != "long_term" || payload.TotalFetched != 1 || payload.Limit != 20 || payload.MaxAllowed != maxHistoryItems || len(payload.Items) != 1 || payload.Items[0].PlayedAt != "2024-01-15T10:00:00Z" {
+		t.Fatalf("unexpected payload: %#v", payload)
+	}
+}
+
+func TestUserHistoryCmdLimitCapsOutput(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatJSON)
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			if limit != 2 {
+				t.Fatalf("expected page limit to match remaining result limit, got %d", limit)
+			}
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "t1", Name: "S1", Type: "track"}, PlayedAt: "2024-01-15T10:00:00Z"},
+					{Track: spotify.Item{ID: "t2", Name: "S2", Type: "track"}, PlayedAt: "2024-01-15T09:00:00Z"},
+				},
+				Cursors: &spotify.Cursors{Before: "1705309200000"},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "long_term", Limit: 2}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var payload struct {
+		TotalFetched int                          `json:"total_fetched"`
+		Limit        int                          `json:"limit"`
+		Items        []spotify.RecentlyPlayedItem `json:"items"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("json: %v\n%s", err, out.String())
+	}
+	if payload.TotalFetched != 2 || payload.Limit != 2 || len(payload.Items) != 2 {
+		t.Fatalf("unexpected payload: %#v", payload)
+	}
+}
+
+func TestUserHistoryCmdShortTermFiltersOlderItems(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatJSON)
+	calls := 0
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			calls++
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "old", Name: "Old", Type: "track"}, PlayedAt: time.Now().Add(-29 * 24 * time.Hour).UTC().Format(time.RFC3339)},
+				},
+				Cursors: &spotify.Cursors{Before: "1700000000000"},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "short_term", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var payload struct {
+		EffectiveLowerBound int64                        `json:"effective_lower_bound"`
+		TotalFetched        int                          `json:"total_fetched"`
+		Items               []spotify.RecentlyPlayedItem `json:"items"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("json: %v\n%s", err, out.String())
+	}
+	if payload.EffectiveLowerBound <= 0 || payload.TotalFetched != 0 || len(payload.Items) != 0 {
+		t.Fatalf("unexpected payload: %#v", payload)
+	}
+	if calls != 1 {
+		t.Fatalf("expected one page before lower-bound stop, got %d", calls)
+	}
+}
+
+func TestUserHistoryCmdInvalidPlayedAt(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "t1", Name: "Song", Type: "track"}, PlayedAt: "not-a-date"},
+				},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "long_term", Limit: 20}
+	err := cmd.Run(ctx)
+	if err == nil || !strings.Contains(err.Error(), "invalid played_at") {
+		t.Fatalf("expected invalid played_at error, got %v", err)
+	}
+}
+
+func TestUserHistoryCmdLongTermNoAfter(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	var capturedAfter int64
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			capturedAfter = after
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "t1", Name: "Song", Type: "track"}, PlayedAt: "2024-01-15T10:00:00Z"},
+				},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "long_term", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if capturedAfter != 0 {
+		t.Fatalf("expected API after=0 for long_term, got %d", capturedAfter)
+	}
+}
+
+func TestTopTrackPeriodMapping(t *testing.T) {
+	tests := []struct {
+		period   string
+		expected string
+	}{
+		{"long_term", "long_term"},
+		{"medium_term", "medium_term"},
+		{"short_term", "short_term"},
+		{"bogus", ""},
+	}
+	for _, tt := range tests {
+		got := topTracksTimeRange(tt.period)
+		if got != tt.expected {
+			t.Errorf("topTracksTimeRange(%q) = %q, want %q", tt.period, got, tt.expected)
+		}
+	}
+}
+
+func TestHistoryPeriodProducesAfter(t *testing.T) {
+	periods := []string{"medium_term", "short_term"}
+	for _, p := range periods {
+		after := historyAfter(p)
+		if after <= 0 {
+			t.Errorf("historyAfter(%q) = %d, expected > 0", p, after)
+		}
+	}
+}
+
+func TestHistoryPeriodLongTermReturnsZero(t *testing.T) {
+	if after := historyAfter("long_term"); after != 0 {
+		t.Fatalf("historyAfter(long_term) = %d, expected 0", after)
+	}
+}
+
+func TestUserHistoryCmdInvalidPeriodError(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	for _, period := range []string{"all", "year", "month", "week", "day"} {
+		cmd := UserHistoryCmd{Period: period, Limit: 20}
+		if err := cmd.Run(ctx); err == nil {
+			t.Fatalf("expected error for invalid history period %q", period)
+		}
+	}
+}
+
+func TestUserHistoryCmdPagination(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatPlain)
+	playedAt1 := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	playedAt2 := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+	callCount := 0
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			if after != 0 {
+				t.Fatalf("pagination should use before cursor, got after=%d", after)
+			}
+			callCount++
+			switch callCount {
+			case 1:
+				if before != 0 {
+					t.Fatalf("expected first page to start from now, got before=%d", before)
+				}
+				return spotify.RecentlyPlayedResult{
+					Limit: limit,
+					Items: []spotify.RecentlyPlayedItem{
+						{Track: spotify.Item{ID: "t1", Name: "Song1", Type: "track"}, PlayedAt: playedAt1},
+					},
+					Cursors: &spotify.Cursors{Before: "1705226400000"},
+					Next:    "https://api.spotify.com/v1/me/player/recently-played?before=1705226400000",
+				}, nil
+			case 2:
+				if before != 1705226400000 {
+					t.Fatalf("expected second page before cursor, got %d", before)
+				}
+				return spotify.RecentlyPlayedResult{
+					Limit: limit,
+					Items: []spotify.RecentlyPlayedItem{
+						{Track: spotify.Item{ID: "t2", Name: "Song2", Type: "track"}, PlayedAt: playedAt2},
+					},
+					Cursors: &spotify.Cursors{Before: "1705140000000"},
+					Next:    "https://api.spotify.com/v1/me/player/recently-played?before=1705140000000",
+				}, nil
+			default:
+				return spotify.RecentlyPlayedResult{Limit: limit}, nil
+			}
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "long_term", Limit: 20}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if callCount != 3 {
+		t.Fatalf("expected 3 API calls for pagination, got %d", callCount)
+	}
+	if out.String() == "" {
+		t.Fatalf("expected output")
+	}
+}
+
+func TestUserHistoryCmdPaginationStopsAtCap(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	playedAt := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	callCount := 0
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			callCount++
+			items := make([]spotify.RecentlyPlayedItem, limit)
+			for i := range items {
+				items[i] = spotify.RecentlyPlayedItem{
+					Track:    spotify.Item{ID: fmt.Sprintf("t%d", callCount*limit+i), Name: "Song", Type: "track"},
+					PlayedAt: playedAt,
+				}
+			}
+			return spotify.RecentlyPlayedResult{
+				Limit:   limit,
+				Items:   items,
+				Cursors: &spotify.Cursors{Before: fmt.Sprintf("%d", 1700000000000-callCount)},
+				Next:    "https://api.spotify.com/v1/me/player/recently-played?before=next",
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "long_term", Limit: 300}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if callCount != 4 {
+		t.Fatalf("expected 4 API calls (50*4=200 cap), got %d", callCount)
+	}
+}
+
+func TestUserHistoryCmdBeforeOnly(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	var capturedBefore int64
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			capturedBefore = before
+			if after != 0 {
+				t.Fatalf("expected after=0 for before-only request, got %d", after)
+			}
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "t1", Name: "Song", Type: "track"}, PlayedAt: "2024-01-15T10:00:00Z"},
+				},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "long_term", Limit: 20, Before: 1234567890000}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if capturedBefore != 1234567890000 {
+		t.Fatalf("expected before=1234567890000, got %d", capturedBefore)
+	}
+}
+
+func TestUserHistoryCmdAfterAndBeforeFilter(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatJSON)
+	callCount := 0
+	mock := &testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+			if after != 0 {
+				t.Fatalf("expected after=0; pagination should use before and filter lower bound client-side, got %d", after)
+			}
+			callCount++
+			if callCount == 1 && before != 1705363200000 {
+				t.Fatalf("expected first request to honor explicit before, got %d", before)
+			}
+			return spotify.RecentlyPlayedResult{
+				Limit: limit,
+				Items: []spotify.RecentlyPlayedItem{
+					{Track: spotify.Item{ID: "t1", Name: "S1", Type: "track"}, PlayedAt: "2024-01-15T10:00:00Z"},
+					{Track: spotify.Item{ID: "t2", Name: "S2", Type: "track"}, PlayedAt: "2024-01-16T10:00:00Z"},
+				},
+			}, nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := UserHistoryCmd{Period: "long_term", Limit: 20, After: 1705310000000, Before: 1705363200000}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var payload struct {
+		RequestedAfter  int64                        `json:"requested_after"`
+		RequestedBefore int64                        `json:"requested_before"`
+		TotalFetched    int                          `json:"total_fetched"`
+		Items           []spotify.RecentlyPlayedItem `json:"items"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("json: %v\n%s", err, out.String())
+	}
+	if payload.RequestedAfter != 1705310000000 || payload.RequestedBefore != 1705363200000 || payload.TotalFetched != 1 || len(payload.Items) != 1 || payload.Items[0].Track.ID != "t1" {
+		t.Fatalf("unexpected payload: %#v", payload)
+	}
+	if callCount != 1 {
+		t.Fatalf("expected one API page, got %d", callCount)
+	}
+}
+
+func TestParseRFC3339Milli(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int64
+	}{
+		{"2024-01-15T10:00:00Z", 1705312800000},
+		{"2024-01-15T10:00:00.000Z", 1705312800000},
+	}
+	for _, tt := range tests {
+		got, err := parseRFC3339Milli(tt.input)
+		if err != nil {
+			t.Fatalf("parseRFC3339Milli(%q): %v", tt.input, err)
+		}
+		if got != tt.want {
+			t.Errorf("parseRFC3339Milli(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseRFC3339MilliError(t *testing.T) {
+	if _, err := parseRFC3339Milli("invalid"); err == nil {
+		t.Fatalf("expected error for invalid input")
+	}
+}

--- a/internal/spotify/api.go
+++ b/internal/spotify/api.go
@@ -33,4 +33,6 @@ type API interface {
 	CreatePlaylist(ctx context.Context, name string, public, collaborative bool) (Item, error)
 	AddTracks(ctx context.Context, playlistID string, uris []string) error
 	RemoveTracks(ctx context.Context, playlistID string, uris []string) error
+	GetUsersTopTracks(ctx context.Context, timeRange string, limit, offset int) (TopTracksResult, error)
+	GetRecentlyPlayed(ctx context.Context, limit int, after, before int64) (RecentlyPlayedResult, error)
 }

--- a/internal/spotify/applescript.go
+++ b/internal/spotify/applescript.go
@@ -298,3 +298,17 @@ func (c *AppleScriptClient) RemoveTracks(ctx context.Context, playlistID string,
 	}
 	return ErrUnsupported
 }
+
+func (c *AppleScriptClient) GetUsersTopTracks(ctx context.Context, timeRange string, limit, offset int) (TopTracksResult, error) {
+	if c.fallback != nil {
+		return c.fallback.GetUsersTopTracks(ctx, timeRange, limit, offset)
+	}
+	return TopTracksResult{}, ErrUnsupported
+}
+
+func (c *AppleScriptClient) GetRecentlyPlayed(ctx context.Context, limit int, after, before int64) (RecentlyPlayedResult, error) {
+	if c.fallback != nil {
+		return c.fallback.GetRecentlyPlayed(ctx, limit, after, before)
+	}
+	return RecentlyPlayedResult{}, ErrUnsupported
+}

--- a/internal/spotify/auto.go
+++ b/internal/spotify/auto.go
@@ -247,3 +247,15 @@ func (c *autoClient) RemoveTracks(ctx context.Context, playlistID string, uris [
 		return api.RemoveTracks(ctx, playlistID, uris)
 	})
 }
+
+func (c *autoClient) GetUsersTopTracks(ctx context.Context, timeRange string, limit, offset int) (TopTracksResult, error) {
+	return autoCall(c, func(api API) (TopTracksResult, error) {
+		return api.GetUsersTopTracks(ctx, timeRange, limit, offset)
+	})
+}
+
+func (c *autoClient) GetRecentlyPlayed(ctx context.Context, limit int, after, before int64) (RecentlyPlayedResult, error) {
+	return autoCall(c, func(api API) (RecentlyPlayedResult, error) {
+		return api.GetRecentlyPlayed(ctx, limit, after, before)
+	})
+}

--- a/internal/spotify/auto_test.go
+++ b/internal/spotify/auto_test.go
@@ -197,11 +197,54 @@ func TestAutoPassThrough(t *testing.T) {
 	_, _ = client.CreatePlaylist(ctx, "name", false, false)
 	_ = client.AddTracks(ctx, "1", []string{"spotify:track:1"})
 	_ = client.RemoveTracks(ctx, "1", []string{"spotify:track:1"})
+	_, _ = client.GetUsersTopTracks(ctx, "long_term", 20, 0)
+	_, _ = client.GetRecentlyPlayed(ctx, 20, 0, 0)
 
 	if len(webCalls) != 0 {
 		t.Fatalf("expected no web calls, got %#v", webCalls)
 	}
-	if connectCalls["Search"] == 0 || connectCalls["Play"] == 0 || connectCalls["RemoveTracks"] == 0 {
+	if connectCalls["Search"] == 0 || connectCalls["Play"] == 0 || connectCalls["RemoveTracks"] == 0 || connectCalls["GetUsersTopTracks"] == 0 || connectCalls["GetRecentlyPlayed"] == 0 {
 		t.Fatalf("expected connect calls, got %#v", connectCalls)
+	}
+}
+
+func TestAutoUserReadsFallback(t *testing.T) {
+	ctx := context.Background()
+	calls := map[string]int{}
+	connect := apiStub{
+		calls: calls,
+		topTracksFn: func(context.Context, string, int, int) (TopTracksResult, error) {
+			return TopTracksResult{}, ErrUnsupported
+		},
+		recentlyPlayedFn: func(context.Context, int, int64, int64) (RecentlyPlayedResult, error) {
+			return RecentlyPlayedResult{}, ErrUnsupported
+		},
+	}
+	web := apiStub{
+		calls: calls,
+		topTracksFn: func(context.Context, string, int, int) (TopTracksResult, error) {
+			return TopTracksResult{Items: []Item{{ID: "t1"}}}, nil
+		},
+		recentlyPlayedFn: func(context.Context, int, int64, int64) (RecentlyPlayedResult, error) {
+			return RecentlyPlayedResult{Items: []RecentlyPlayedItem{{Track: Item{ID: "t1"}}}}, nil
+		},
+	}
+	client := NewAutoClient(connect, web)
+	top, err := client.GetUsersTopTracks(ctx, "medium_term", 5, 1)
+	if err != nil {
+		t.Fatalf("top tracks: %v", err)
+	}
+	if len(top.Items) != 1 {
+		t.Fatalf("unexpected top tracks result: %#v", top)
+	}
+	history, err := client.GetRecentlyPlayed(ctx, 5, 0, 123)
+	if err != nil {
+		t.Fatalf("recently played: %v", err)
+	}
+	if len(history.Items) != 1 {
+		t.Fatalf("unexpected recently played result: %#v", history)
+	}
+	if calls["GetUsersTopTracks"] != 2 || calls["GetRecentlyPlayed"] != 2 {
+		t.Fatalf("expected fallback calls, got %#v", calls)
 	}
 }

--- a/internal/spotify/client.go
+++ b/internal/spotify/client.go
@@ -404,6 +404,60 @@ func (c *Client) RemoveTracks(ctx context.Context, playlistID string, uris []str
 	return c.send(ctx, http.MethodDelete, "/playlists/"+playlistID+"/tracks", nil, payload, nil)
 }
 
+func (c *Client) GetUsersTopTracks(ctx context.Context, timeRange string, limit, offset int) (TopTracksResult, error) {
+	params := url.Values{}
+	params.Set("time_range", timeRange)
+	params.Set("limit", fmt.Sprint(limit))
+	params.Set("offset", fmt.Sprint(offset))
+	var raw topTracksResponse
+	if err := c.get(ctx, "/me/top/tracks", params, &raw); err != nil {
+		return TopTracksResult{}, err
+	}
+	items := make([]Item, 0, len(raw.Items))
+	for _, t := range raw.Items {
+		items = append(items, mapTrack(t))
+	}
+	return TopTracksResult{
+		Total:  raw.Total,
+		Limit:  raw.Limit,
+		Offset: raw.Offset,
+		Items:  items,
+	}, nil
+}
+
+func (c *Client) GetRecentlyPlayed(ctx context.Context, limit int, after, before int64) (RecentlyPlayedResult, error) {
+	params := url.Values{}
+	params.Set("limit", fmt.Sprint(limit))
+	if after > 0 {
+		params.Set("after", fmt.Sprint(after))
+	} else if before > 0 {
+		params.Set("before", fmt.Sprint(before))
+	}
+	var raw recentlyPlayedResponse
+	if err := c.get(ctx, "/me/player/recently-played", params, &raw); err != nil {
+		return RecentlyPlayedResult{}, err
+	}
+	items := make([]RecentlyPlayedItem, 0, len(raw.Items))
+	for _, item := range raw.Items {
+		items = append(items, RecentlyPlayedItem{
+			Track:    mapTrack(item.Track),
+			PlayedAt: item.PlayedAt,
+		})
+	}
+	result := RecentlyPlayedResult{
+		Items: items,
+		Next:  raw.Next,
+		Limit: raw.Limit,
+	}
+	if raw.Cursors != nil {
+		result.Cursors = &Cursors{
+			After:  raw.Cursors.After,
+			Before: raw.Cursors.Before,
+		}
+	}
+	return result, nil
+}
+
 func (c *Client) currentUserID(ctx context.Context) (string, error) {
 	var raw userProfile
 	if err := c.get(ctx, "/me", nil, &raw); err != nil {

--- a/internal/spotify/client_more_test.go
+++ b/internal/spotify/client_more_test.go
@@ -85,6 +85,59 @@ func TestClientEndpoints(t *testing.T) {
 	mux.HandleFunc("/me/playlists", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(playlistListResponse{Items: []playlistItem{{ID: "p1", Name: "Playlist"}}, Total: 1})
 	})
+	mux.HandleFunc("/me/top/tracks", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("time_range"); got != "medium_term" {
+			t.Errorf("top tracks time_range = %q, want medium_term", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "7" {
+			t.Errorf("top tracks limit = %q, want 7", got)
+		}
+		if got := r.URL.Query().Get("offset"); got != "2" {
+			t.Errorf("top tracks offset = %q, want 2", got)
+		}
+		_ = json.NewEncoder(w).Encode(topTracksResponse{
+			Items:  []trackItem{{ID: "t1", URI: "spotify:track:t1", Name: "Track", Album: albumRef{Name: "Album"}, Artists: []artistRef{{Name: "Artist"}}}},
+			Total:  1,
+			Limit:  7,
+			Offset: 2,
+		})
+	})
+	recentlyPlayedCalls := 0
+	mux.HandleFunc("/me/player/recently-played", func(w http.ResponseWriter, r *http.Request) {
+		recentlyPlayedCalls++
+		if got := r.URL.Query().Get("limit"); got != "3" {
+			t.Errorf("recently played limit = %q, want 3", got)
+		}
+		switch recentlyPlayedCalls {
+		case 1:
+			if got := r.URL.Query().Get("after"); got != "1700000000000" {
+				t.Errorf("recently played after = %q, want 1700000000000", got)
+			}
+			if got := r.URL.Query().Get("before"); got != "" {
+				t.Errorf("recently played before = %q, want empty when after is set", got)
+			}
+		case 2:
+			if got := r.URL.Query().Get("after"); got != "" {
+				t.Errorf("recently played after = %q, want empty when before is set", got)
+			}
+			if got := r.URL.Query().Get("before"); got != "1705312800000" {
+				t.Errorf("recently played before = %q, want 1705312800000", got)
+			}
+		default:
+			t.Errorf("unexpected recently-played call %d", recentlyPlayedCalls)
+		}
+		_ = json.NewEncoder(w).Encode(recentlyPlayedResponse{
+			Items: []struct {
+				Track    trackItem `json:"track"`
+				PlayedAt string    `json:"played_at"`
+			}{
+				{Track: trackItem{ID: "t1", URI: "spotify:track:t1", Name: "Track", Album: albumRef{Name: "Album"}, Artists: []artistRef{{Name: "Artist"}}}, PlayedAt: "2024-01-15T10:00:00Z"},
+			},
+			Cursors: &cursorsItem{After: "1705312800001", Before: "1705312799999"},
+			Next:    "https://api.spotify.com/v1/me/player/recently-played?before=1705312799999",
+			Limit:   3,
+		})
+	})
 	mux.HandleFunc("/playlists/p1/tracks", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodDelete || r.Method == http.MethodPost {
 			w.WriteHeader(http.StatusNoContent)
@@ -176,6 +229,23 @@ func TestClientEndpoints(t *testing.T) {
 	}
 	if _, _, err := client.Playlists(context.Background(), 1, 0); err != nil {
 		t.Fatalf("playlists: %v", err)
+	}
+	topTracks, err := client.GetUsersTopTracks(context.Background(), "medium_term", 7, 2)
+	if err != nil {
+		t.Fatalf("top tracks: %v", err)
+	}
+	if topTracks.Total != 1 || topTracks.Limit != 7 || topTracks.Offset != 2 || topTracks.Items[0].Name != "Track" {
+		t.Fatalf("unexpected top tracks result: %+v", topTracks)
+	}
+	recent, err := client.GetRecentlyPlayed(context.Background(), 3, 1700000000000, 0)
+	if err != nil {
+		t.Fatalf("recently played: %v", err)
+	}
+	if recent.Limit != 3 || recent.Cursors == nil || recent.Cursors.Before != "1705312799999" || recent.Items[0].PlayedAt != "2024-01-15T10:00:00Z" {
+		t.Fatalf("unexpected recently played result: %+v", recent)
+	}
+	if _, err := client.GetRecentlyPlayed(context.Background(), 3, 0, 1705312800000); err != nil {
+		t.Fatalf("recently played before: %v", err)
 	}
 	if _, _, err := client.PlaylistTracks(context.Background(), "p1", 1, 0); err != nil {
 		t.Fatalf("playlist tracks: %v", err)

--- a/internal/spotify/connect.go
+++ b/internal/spotify/connect.go
@@ -225,6 +225,14 @@ func (c *ConnectClient) RemoveTracks(ctx context.Context, playlistID string, uri
 	})
 }
 
+func (c *ConnectClient) GetUsersTopTracks(ctx context.Context, timeRange string, limit, offset int) (TopTracksResult, error) {
+	return c.userTopTracks(ctx, timeRange, limit, offset)
+}
+
+func (c *ConnectClient) GetRecentlyPlayed(ctx context.Context, limit int, after, before int64) (RecentlyPlayedResult, error) {
+	return c.recentlyPlayed(ctx, limit, after, before)
+}
+
 func withWebCollectionFallback(c *ConnectClient, primary func() ([]Item, int, error), fallback func(*Client) ([]Item, int, error)) ([]Item, int, error) {
 	items, total, err := primary()
 	if err == nil {

--- a/internal/spotify/connect_client_test.go
+++ b/internal/spotify/connect_client_test.go
@@ -2,6 +2,7 @@ package spotify
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 )
@@ -100,5 +101,116 @@ func TestConnectUnsupported(t *testing.T) {
 	}
 	if err := client.RemoveTracks(context.Background(), "p1", nil); err == nil {
 		t.Fatalf("expected error")
+	}
+	if _, err := client.GetUsersTopTracks(context.Background(), "long_term", 20, 0); err == nil {
+		t.Fatalf("expected error")
+	}
+	if _, err := client.GetRecentlyPlayed(context.Background(), 20, 0, 0); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestConnectUserReadsUseWebPlayerEndpoints(t *testing.T) {
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Query().Get("operationName") {
+		case "userTopContent":
+			vars := req.URL.Query().Get("variables")
+			if vars == "" {
+				t.Fatalf("missing top content variables")
+			}
+			var variables map[string]any
+			if err := json.Unmarshal([]byte(vars), &variables); err != nil {
+				t.Fatalf("decode top content variables: %v", err)
+			}
+			topInput, ok := variables["topTracksInput"].(map[string]any)
+			if !ok {
+				t.Fatalf("missing topTracksInput")
+			}
+			if topInput["sortBy"] != "AFFINITY" || topInput["timeRange"] != "SHORT_TERM" {
+				t.Fatalf("unexpected topTracksInput: %#v", topInput)
+			}
+			if req.URL.Query().Get("extensions") == "" {
+				t.Fatalf("missing top content extensions")
+			}
+			return jsonResponse(http.StatusOK, map[string]any{
+				"data": map[string]any{"me": map[string]any{"profile": map[string]any{
+					"topTracks": map[string]any{
+						"totalCount": 1,
+						"items": []any{
+							map[string]any{"data": map[string]any{
+								"uri":          "spotify:track:t1",
+								"name":         "Track",
+								"albumOfTrack": map[string]any{"name": "Album"},
+								"artists": map[string]any{"items": []any{
+									map[string]any{"profile": map[string]any{"name": "Artist"}},
+								}},
+							}},
+						},
+					},
+				}}},
+			}), nil
+		case "profileAttributes":
+			return jsonResponse(http.StatusOK, map[string]any{
+				"data": map[string]any{"me": map[string]any{"profile": map[string]any{
+					"uri":      "spotify:user:user1",
+					"username": "user1",
+				}}},
+			}), nil
+		case "fetchEntitiesForRecentlyPlayed":
+			return jsonResponse(http.StatusOK, map[string]any{
+				"data": map[string]any{"lookup": []any{
+					map[string]any{
+						"_uri": "spotify:track:t1",
+						"data": map[string]any{
+							"uri":          "spotify:track:t1",
+							"name":         "Track",
+							"albumOfTrack": map[string]any{"name": "Album"},
+							"artists": map[string]any{"items": []any{
+								map[string]any{"profile": map[string]any{"name": "Artist"}},
+							}},
+						},
+					},
+				}},
+			}), nil
+		}
+		if req.URL.Host == "spclient.wg.spotify.com" && req.URL.Path == "/recently-played/v3/user/user1/recently-played" {
+			if got := req.URL.Query().Get("limit"); got != "50" {
+				t.Fatalf("history page limit = %q, want 50", got)
+			}
+			if got := req.URL.Query().Get("offset"); got != "0" {
+				t.Fatalf("history offset = %q, want 0", got)
+			}
+			return jsonResponse(http.StatusOK, recentlyPlayedContextsResponse{
+				PlayContexts: []recentlyPlayedContext{
+					{
+						URI:                "spotify:playlist:p1",
+						LastPlayedTime:     1705312800000,
+						LastPlayedTrackURI: "spotify:track:t1",
+					},
+				},
+			}), nil
+		}
+		return textResponse(http.StatusNotFound, "missing"), nil
+	})
+	client := newConnectClientForTests(transport)
+	client.hashes.hashes["userTopContent"] = "hash"
+	client.hashes.hashes["profileAttributes"] = "hash"
+	client.hashes.hashes["fetchEntitiesForRecentlyPlayed"] = "hash"
+	top, err := client.GetUsersTopTracks(context.Background(), "short_term", 5, 1)
+	if err != nil {
+		t.Fatalf("top tracks: %v", err)
+	}
+	if top.Total != 1 || top.Limit != 5 || top.Offset != 1 || len(top.Items) != 1 || top.Items[0].Album != "Album" {
+		t.Fatalf("unexpected top tracks: %#v", top)
+	}
+	history, err := client.GetRecentlyPlayed(context.Background(), 6, 0, 1705312800001)
+	if err != nil {
+		t.Fatalf("recently played: %v", err)
+	}
+	if history.Limit != 6 || history.Cursors == nil || history.Cursors.Before != "1705312800000" || len(history.Items) != 1 {
+		t.Fatalf("unexpected recently played: %#v", history)
+	}
+	if history.Items[0].Track.Name != "Track" || history.Items[0].PlayedAt != "2024-01-15T10:00:00.000Z" {
+		t.Fatalf("unexpected recently played item: %#v", history.Items[0])
 	}
 }

--- a/internal/spotify/connect_user.go
+++ b/internal/spotify/connect_user.go
@@ -1,0 +1,294 @@
+package spotify
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	recentlyPlayedBaseURL = "https://spclient.wg.spotify.com/recently-played/v3"
+	recentlyPlayedPage    = 50
+)
+
+type recentlyPlayedContextsResponse struct {
+	PlayContexts []recentlyPlayedContext `json:"playContexts"`
+}
+
+type recentlyPlayedContext struct {
+	URI                string `json:"uri"`
+	LastPlayedTime     int64  `json:"lastPlayedTime"`
+	LastPlayedTrackURI string `json:"lastPlayedTrackUri"`
+}
+
+func (c *ConnectClient) userTopTracks(ctx context.Context, timeRange string, limit, offset int) (TopTracksResult, error) {
+	vars := map[string]any{
+		"includeTopArtists": false,
+		"topArtistsInput": map[string]any{
+			"offset":    0,
+			"limit":     0,
+			"sortBy":    "AFFINITY",
+			"timeRange": connectTopTimeRange(timeRange),
+		},
+		"includeTopTracks": true,
+		"topTracksInput": map[string]any{
+			"offset":    offset,
+			"limit":     limit,
+			"sortBy":    "AFFINITY",
+			"timeRange": connectTopTimeRange(timeRange),
+		},
+	}
+	payload, err := c.graphQL(ctx, "userTopContent", vars)
+	if err != nil {
+		return TopTracksResult{}, err
+	}
+	items, total := extractUserTopTracks(payload)
+	return TopTracksResult{
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+		Items:  items,
+	}, nil
+}
+
+func connectTopTimeRange(timeRange string) string {
+	switch timeRange {
+	case "long_term":
+		return "LONG_TERM"
+	case "medium_term":
+		return "MID_TERM"
+	case "short_term":
+		return "SHORT_TERM"
+	default:
+		return timeRange
+	}
+}
+
+func extractUserTopTracks(payload map[string]any) ([]Item, int) {
+	container, ok := getMap(payload, "data", "me", "profile", "topTracks")
+	if !ok {
+		return nil, 0
+	}
+	rawItems, _ := container["items"].([]any)
+	items := make([]Item, 0, len(rawItems))
+	for _, raw := range rawItems {
+		wrapper, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		data, ok := wrapper["data"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if item, ok := extractItem(data, "track"); ok {
+			items = append(items, item)
+		}
+	}
+	total := getInt(container, "totalCount")
+	if total == 0 && len(items) > 0 {
+		total = len(items)
+	}
+	return items, total
+}
+
+func (c *ConnectClient) recentlyPlayed(ctx context.Context, limit int, after, before int64) (RecentlyPlayedResult, error) {
+	if limit <= 0 {
+		limit = recentlyPlayedPage
+	}
+	username, err := c.currentUsername(ctx)
+	if err != nil {
+		return RecentlyPlayedResult{}, err
+	}
+	contexts, err := c.recentlyPlayedContexts(ctx, username, limit, after, before)
+	if err != nil {
+		return RecentlyPlayedResult{}, err
+	}
+	tracks, err := c.recentlyPlayedTracks(ctx, contexts)
+	if err != nil {
+		return RecentlyPlayedResult{}, err
+	}
+	items := make([]RecentlyPlayedItem, 0, len(contexts))
+	for _, ctxItem := range contexts {
+		track, ok := tracks[ctxItem.LastPlayedTrackURI]
+		if !ok {
+			id := idFromURI(ctxItem.LastPlayedTrackURI)
+			track = Item{
+				ID:   id,
+				URI:  ctxItem.LastPlayedTrackURI,
+				Type: "track",
+				URL:  fmt.Sprintf("https://open.spotify.com/track/%s", id),
+			}
+		}
+		items = append(items, RecentlyPlayedItem{
+			Track:    track,
+			PlayedAt: time.UnixMilli(ctxItem.LastPlayedTime).UTC().Format("2006-01-02T15:04:05.000Z07:00"),
+		})
+	}
+	result := RecentlyPlayedResult{Items: items, Limit: limit}
+	if len(contexts) > 0 {
+		result.Cursors = &Cursors{
+			After:  fmt.Sprint(contexts[0].LastPlayedTime),
+			Before: fmt.Sprint(contexts[len(contexts)-1].LastPlayedTime),
+		}
+	}
+	return result, nil
+}
+
+func (c *ConnectClient) currentUsername(ctx context.Context) (string, error) {
+	payload, err := c.graphQL(ctx, "profileAttributes", map[string]any{})
+	if err != nil {
+		return "", err
+	}
+	profile, ok := getMap(payload, "data", "me", "profile")
+	if !ok {
+		return "", errors.New("missing profile")
+	}
+	username := getString(profile, "username")
+	if username == "" {
+		username = idFromURI(getString(profile, "uri"))
+	}
+	if username == "" || username == "me" {
+		return "", errors.New("missing user id")
+	}
+	return username, nil
+}
+
+func (c *ConnectClient) recentlyPlayedContexts(ctx context.Context, username string, limit int, after, before int64) ([]recentlyPlayedContext, error) {
+	out := make([]recentlyPlayedContext, 0, limit)
+	for offset := 0; len(out) < limit; offset += recentlyPlayedPage {
+		page, err := c.recentlyPlayedContextPage(ctx, username, recentlyPlayedPage, offset)
+		if err != nil {
+			return nil, err
+		}
+		if len(page.PlayContexts) == 0 {
+			break
+		}
+		for _, item := range page.PlayContexts {
+			if item.LastPlayedTrackURI == "" || item.LastPlayedTime == 0 {
+				continue
+			}
+			if before > 0 && item.LastPlayedTime >= before {
+				continue
+			}
+			if after > 0 && item.LastPlayedTime <= after {
+				continue
+			}
+			out = append(out, item)
+			if len(out) >= limit {
+				break
+			}
+		}
+		oldest := page.PlayContexts[len(page.PlayContexts)-1].LastPlayedTime
+		if len(page.PlayContexts) < recentlyPlayedPage || (after > 0 && oldest <= after) {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (c *ConnectClient) recentlyPlayedContextPage(ctx context.Context, username string, limit, offset int) (recentlyPlayedContextsResponse, error) {
+	params := url.Values{}
+	params.Set("format", "json")
+	params.Set("offset", fmt.Sprint(offset))
+	params.Set("limit", fmt.Sprint(limit))
+	params.Set("filter", "default,collection-new-episodes")
+	requestURL := fmt.Sprintf("%s/user/%s/recently-played?%s", recentlyPlayedBaseURL, url.PathEscape(username), params.Encode())
+	var payload recentlyPlayedContextsResponse
+	if err := c.connectGet(ctx, requestURL, &payload); err != nil {
+		return recentlyPlayedContextsResponse{}, err
+	}
+	return payload, nil
+}
+
+func (c *ConnectClient) recentlyPlayedTracks(ctx context.Context, contexts []recentlyPlayedContext) (map[string]Item, error) {
+	seen := map[string]struct{}{}
+	uris := make([]string, 0, len(contexts))
+	for _, item := range contexts {
+		if item.LastPlayedTrackURI == "" {
+			continue
+		}
+		if _, ok := seen[item.LastPlayedTrackURI]; ok {
+			continue
+		}
+		seen[item.LastPlayedTrackURI] = struct{}{}
+		uris = append(uris, item.LastPlayedTrackURI)
+	}
+	if len(uris) == 0 {
+		return map[string]Item{}, nil
+	}
+	payload, err := c.graphQL(ctx, "fetchEntitiesForRecentlyPlayed", map[string]any{"uris": uris})
+	if err != nil {
+		return nil, err
+	}
+	return extractRecentlyPlayedTracks(payload), nil
+}
+
+func extractRecentlyPlayedTracks(payload map[string]any) map[string]Item {
+	out := map[string]Item{}
+	data, ok := getMap(payload, "data")
+	if !ok {
+		return out
+	}
+	rawItems, _ := data["lookup"].([]any)
+	for _, raw := range rawItems {
+		wrapper, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		data, ok := wrapper["data"].(map[string]any)
+		if !ok {
+			continue
+		}
+		item, ok := extractItem(data, "track")
+		if !ok {
+			continue
+		}
+		if uri := getString(wrapper, "_uri"); uri != "" {
+			out[uri] = item
+		}
+		out[item.URI] = item
+	}
+	return out
+}
+
+func (c *ConnectClient) connectGet(ctx context.Context, requestURL string, dest any) error {
+	if c == nil || c.session == nil || c.client == nil {
+		return errors.New("connect client not initialized")
+	}
+	auth, err := c.session.auth(ctx)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return err
+	}
+	applyRequestHeaders(req, requestHeaders{
+		AccessToken:   auth.AccessToken,
+		ClientToken:   auth.ClientToken,
+		ClientVersion: auth.ClientVersion,
+		Accept:        "application/json",
+		Language:      c.language,
+		AppPlatform:   defaultSpotifyAppPlatform,
+	})
+	client := c.searchClient
+	if client == nil {
+		client = c.client
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return apiErrorFromResponse(resp)
+	}
+	if dest == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(dest)
+}

--- a/internal/spotify/fallback.go
+++ b/internal/spotify/fallback.go
@@ -218,3 +218,15 @@ func (c *fallbackClient) RemoveTracks(ctx context.Context, playlistID string, ur
 		return api.RemoveTracks(ctx, playlistID, uris)
 	})
 }
+
+func (c *fallbackClient) GetUsersTopTracks(ctx context.Context, timeRange string, limit, offset int) (TopTracksResult, error) {
+	return fallbackCall(c, true, func(api API) (TopTracksResult, error) {
+		return api.GetUsersTopTracks(ctx, timeRange, limit, offset)
+	})
+}
+
+func (c *fallbackClient) GetRecentlyPlayed(ctx context.Context, limit int, after, before int64) (RecentlyPlayedResult, error) {
+	return fallbackCall(c, true, func(api API) (RecentlyPlayedResult, error) {
+		return api.GetRecentlyPlayed(ctx, limit, after, before)
+	})
+}

--- a/internal/spotify/fallback_test.go
+++ b/internal/spotify/fallback_test.go
@@ -17,6 +17,8 @@ type apiStub struct {
 	artistTopTracksFn func(context.Context, string, int) ([]Item, error)
 	addTracksFn       func(context.Context, string, []string) error
 	removeTracksFn    func(context.Context, string, []string) error
+	topTracksFn       func(context.Context, string, int, int) (TopTracksResult, error)
+	recentlyPlayedFn  func(context.Context, int, int64, int64) (RecentlyPlayedResult, error)
 }
 
 func (a apiStub) Search(ctx context.Context, kind, query string, limit, offset int) (SearchResult, error) {
@@ -202,6 +204,22 @@ func (a apiStub) RemoveTracks(ctx context.Context, playlistID string, uris []str
 		return a.removeTracksFn(ctx, playlistID, uris)
 	}
 	return nil
+}
+
+func (a apiStub) GetUsersTopTracks(ctx context.Context, timeRange string, limit, offset int) (TopTracksResult, error) {
+	a.note("GetUsersTopTracks")
+	if a.topTracksFn != nil {
+		return a.topTracksFn(ctx, timeRange, limit, offset)
+	}
+	return TopTracksResult{}, nil
+}
+
+func (a apiStub) GetRecentlyPlayed(ctx context.Context, limit int, after, before int64) (RecentlyPlayedResult, error) {
+	a.note("GetRecentlyPlayed")
+	if a.recentlyPlayedFn != nil {
+		return a.recentlyPlayedFn(ctx, limit, after, before)
+	}
+	return RecentlyPlayedResult{}, nil
 }
 
 func (a apiStub) note(name string) {
@@ -450,8 +468,55 @@ func TestFallbackDelegatesToWeb(t *testing.T) {
 	if err := client.RemoveTracks(ctx, "p1", []string{"spotify:track:t1"}); err != nil {
 		t.Fatalf("remove tracks: %v", err)
 	}
+	if _, err := client.GetUsersTopTracks(ctx, "long_term", 20, 0); err != nil {
+		t.Fatalf("top tracks: %v", err)
+	}
+	if _, err := client.GetRecentlyPlayed(ctx, 20, 0, 0); err != nil {
+		t.Fatalf("recently played: %v", err)
+	}
 
-	if calls["GetTrack"] == 0 || calls["Queue"] == 0 || calls["RemoveTracks"] == 0 {
+	if calls["GetTrack"] == 0 || calls["Queue"] == 0 || calls["RemoveTracks"] == 0 || calls["GetUsersTopTracks"] == 0 || calls["GetRecentlyPlayed"] == 0 {
 		t.Fatalf("expected web calls to be recorded")
+	}
+}
+
+func TestFallbackUserReadsOnRateLimit(t *testing.T) {
+	ctx := context.Background()
+	calls := map[string]int{}
+	web := apiStub{
+		calls: calls,
+		topTracksFn: func(context.Context, string, int, int) (TopTracksResult, error) {
+			return TopTracksResult{}, APIError{Status: 429, Message: "rate limit"}
+		},
+		recentlyPlayedFn: func(context.Context, int, int64, int64) (RecentlyPlayedResult, error) {
+			return RecentlyPlayedResult{}, APIError{Status: 429, Message: "rate limit"}
+		},
+	}
+	connect := apiStub{
+		calls: calls,
+		topTracksFn: func(context.Context, string, int, int) (TopTracksResult, error) {
+			return TopTracksResult{Total: 1, Items: []Item{{ID: "t1"}}}, nil
+		},
+		recentlyPlayedFn: func(context.Context, int, int64, int64) (RecentlyPlayedResult, error) {
+			return RecentlyPlayedResult{Items: []RecentlyPlayedItem{{Track: Item{ID: "t1"}}}}, nil
+		},
+	}
+	client := NewPlaybackFallbackClient(web, connect)
+	top, err := client.GetUsersTopTracks(ctx, "short_term", 10, 2)
+	if err != nil {
+		t.Fatalf("top tracks: %v", err)
+	}
+	if top.Total != 1 || len(top.Items) != 1 {
+		t.Fatalf("unexpected top tracks result: %#v", top)
+	}
+	history, err := client.GetRecentlyPlayed(ctx, 10, 0, 123)
+	if err != nil {
+		t.Fatalf("recently played: %v", err)
+	}
+	if len(history.Items) != 1 {
+		t.Fatalf("unexpected recently played result: %#v", history)
+	}
+	if calls["GetUsersTopTracks"] != 2 || calls["GetRecentlyPlayed"] != 2 {
+		t.Fatalf("expected fallback calls: %#v", calls)
 	}
 }

--- a/internal/spotify/models.go
+++ b/internal/spotify/models.go
@@ -159,3 +159,25 @@ type artistsContainer struct {
 type artistTopTracksResponse struct {
 	Tracks []trackItem `json:"tracks"`
 }
+
+type topTracksResponse struct {
+	Items  []trackItem `json:"items"`
+	Total  int         `json:"total"`
+	Limit  int         `json:"limit"`
+	Offset int         `json:"offset"`
+}
+
+type recentlyPlayedResponse struct {
+	Items []struct {
+		Track    trackItem `json:"track"`
+		PlayedAt string    `json:"played_at"`
+	} `json:"items"`
+	Cursors *cursorsItem `json:"cursors"`
+	Next    string       `json:"next"`
+	Limit   int          `json:"limit"`
+}
+
+type cursorsItem struct {
+	After  string `json:"after"`
+	Before string `json:"before"`
+}

--- a/internal/spotify/types.go
+++ b/internal/spotify/types.go
@@ -70,3 +70,27 @@ type Queue struct {
 	CurrentlyPlaying *Item  `json:"currently_playing,omitempty"`
 	Queue            []Item `json:"queue"`
 }
+
+type TopTracksResult struct {
+	Total  int    `json:"total"`
+	Limit  int    `json:"limit"`
+	Offset int    `json:"offset"`
+	Items  []Item `json:"items"`
+}
+
+type RecentlyPlayedResult struct {
+	Items   []RecentlyPlayedItem `json:"items"`
+	Cursors *Cursors             `json:"cursors,omitempty"`
+	Next    string               `json:"next,omitempty"`
+	Limit   int                  `json:"limit"`
+}
+
+type RecentlyPlayedItem struct {
+	Track    Item   `json:"track"`
+	PlayedAt string `json:"played_at"`
+}
+
+type Cursors struct {
+	After  string `json:"after"`
+	Before string `json:"before"`
+}

--- a/internal/testutil/spotify_mock.go
+++ b/internal/testutil/spotify_mock.go
@@ -10,35 +10,37 @@ import (
 var ErrNotImplemented = errors.New("not implemented")
 
 type SpotifyMock struct {
-	SearchFn          func(context.Context, string, string, int, int) (spotify.SearchResult, error)
-	GetTrackFn        func(context.Context, string) (spotify.Item, error)
-	GetAlbumFn        func(context.Context, string) (spotify.Item, error)
-	GetArtistFn       func(context.Context, string) (spotify.Item, error)
-	GetPlaylistFn     func(context.Context, string) (spotify.Item, error)
-	GetShowFn         func(context.Context, string) (spotify.Item, error)
-	GetEpisodeFn      func(context.Context, string) (spotify.Item, error)
-	ArtistTopTracksFn func(context.Context, string, int) ([]spotify.Item, error)
-	PlaybackFn        func(context.Context) (spotify.PlaybackStatus, error)
-	PlayFn            func(context.Context, string) error
-	PauseFn           func(context.Context) error
-	NextFn            func(context.Context) error
-	PreviousFn        func(context.Context) error
-	SeekFn            func(context.Context, int) error
-	VolumeFn          func(context.Context, int) error
-	ShuffleFn         func(context.Context, bool) error
-	RepeatFn          func(context.Context, string) error
-	DevicesFn         func(context.Context) ([]spotify.Device, error)
-	TransferFn        func(context.Context, string) error
-	QueueAddFn        func(context.Context, string) error
-	QueueFn           func(context.Context) (spotify.Queue, error)
-	LibraryTracksFn   func(context.Context, int, int) ([]spotify.Item, int, error)
-	LibraryAlbumsFn   func(context.Context, int, int) ([]spotify.Item, int, error)
-	LibraryModifyFn   func(context.Context, string, []string, string) error
-	FollowArtistsFn   func(context.Context, []string, string) error
-	FollowedArtistsFn func(context.Context, int, string) ([]spotify.Item, int, string, error)
-	PlaylistsFn       func(context.Context, int, int) ([]spotify.Item, int, error)
-	PlaylistTracksFn  func(context.Context, string, int, int) ([]spotify.Item, int, error)
-	CreatePlaylistFn  func(context.Context, string, bool, bool) (spotify.Item, error)
-	AddTracksFn       func(context.Context, string, []string) error
-	RemoveTracksFn    func(context.Context, string, []string) error
+	SearchFn            func(context.Context, string, string, int, int) (spotify.SearchResult, error)
+	GetTrackFn          func(context.Context, string) (spotify.Item, error)
+	GetAlbumFn          func(context.Context, string) (spotify.Item, error)
+	GetArtistFn         func(context.Context, string) (spotify.Item, error)
+	GetPlaylistFn       func(context.Context, string) (spotify.Item, error)
+	GetShowFn           func(context.Context, string) (spotify.Item, error)
+	GetEpisodeFn        func(context.Context, string) (spotify.Item, error)
+	ArtistTopTracksFn   func(context.Context, string, int) ([]spotify.Item, error)
+	PlaybackFn          func(context.Context) (spotify.PlaybackStatus, error)
+	PlayFn              func(context.Context, string) error
+	PauseFn             func(context.Context) error
+	NextFn              func(context.Context) error
+	PreviousFn          func(context.Context) error
+	SeekFn              func(context.Context, int) error
+	VolumeFn            func(context.Context, int) error
+	ShuffleFn           func(context.Context, bool) error
+	RepeatFn            func(context.Context, string) error
+	DevicesFn           func(context.Context) ([]spotify.Device, error)
+	TransferFn          func(context.Context, string) error
+	QueueAddFn          func(context.Context, string) error
+	QueueFn             func(context.Context) (spotify.Queue, error)
+	LibraryTracksFn     func(context.Context, int, int) ([]spotify.Item, int, error)
+	LibraryAlbumsFn     func(context.Context, int, int) ([]spotify.Item, int, error)
+	LibraryModifyFn     func(context.Context, string, []string, string) error
+	FollowArtistsFn     func(context.Context, []string, string) error
+	FollowedArtistsFn   func(context.Context, int, string) ([]spotify.Item, int, string, error)
+	PlaylistsFn         func(context.Context, int, int) ([]spotify.Item, int, error)
+	PlaylistTracksFn    func(context.Context, string, int, int) ([]spotify.Item, int, error)
+	CreatePlaylistFn    func(context.Context, string, bool, bool) (spotify.Item, error)
+	AddTracksFn         func(context.Context, string, []string) error
+	RemoveTracksFn      func(context.Context, string, []string) error
+	GetUsersTopTracksFn func(context.Context, string, int, int) (spotify.TopTracksResult, error)
+	GetRecentlyPlayedFn func(context.Context, int, int64, int64) (spotify.RecentlyPlayedResult, error)
 }

--- a/internal/testutil/spotify_mock_library.go
+++ b/internal/testutil/spotify_mock_library.go
@@ -75,3 +75,17 @@ func (m *SpotifyMock) RemoveTracks(ctx context.Context, playlistID string, uris 
 	}
 	return m.RemoveTracksFn(ctx, playlistID, uris)
 }
+
+func (m *SpotifyMock) GetUsersTopTracks(ctx context.Context, timeRange string, limit, offset int) (spotify.TopTracksResult, error) {
+	if m.GetUsersTopTracksFn == nil {
+		return spotify.TopTracksResult{}, ErrNotImplemented
+	}
+	return m.GetUsersTopTracksFn(ctx, timeRange, limit, offset)
+}
+
+func (m *SpotifyMock) GetRecentlyPlayed(ctx context.Context, limit int, after, before int64) (spotify.RecentlyPlayedResult, error) {
+	if m.GetRecentlyPlayedFn == nil {
+		return spotify.RecentlyPlayedResult{}, ErrNotImplemented
+	}
+	return m.GetRecentlyPlayedFn(ctx, limit, after, before)
+}

--- a/internal/testutil/spotify_mock_notimpl_test.go
+++ b/internal/testutil/spotify_mock_notimpl_test.go
@@ -38,4 +38,6 @@ func TestSpotifyMockAllNotImplemented(t *testing.T) {
 	_, _ = m.CreatePlaylist(context.Background(), "name", true, false)
 	_ = m.AddTracks(context.Background(), "p", []string{"u"})
 	_ = m.RemoveTracks(context.Background(), "p", []string{"u"})
+	_, _ = m.GetUsersTopTracks(context.Background(), "long_term", 20, 0)
+	_, _ = m.GetRecentlyPlayed(context.Background(), 20, 0, 0)
 }


### PR DESCRIPTION
## Summary

Adds a new `spogo user` command group with read-only listening-data commands:

- `spogo user top-tracks` for Spotify affinity-ranked top tracks
- `spogo user history` for retained recently played tracks

The commands support human, plain, and JSON output and document the important distinction that top tracks are affinity rankings, while recent history is limited to Spotify's retained playback data rather than a complete archive.

## Implementation

- Wires `user top-tracks` and `user history` into the CLI.
- Adds Web API support for `/me/top/tracks` and `/me/player/recently-played`.
- Adds Connect/web-player support for top content, profile lookup, retained recent-play contexts, and track metadata lookup.
- Handles fallback clients, AppleScript fallback delegation, API interface updates, and test mocks.
- Paginates history backward with `before` cursors, applies period and explicit `--after` lower-bound filtering client-side, and caps user history output at 200 items.
- Updates README and command/spec docs with command usage and data-retention semantics.

## Verification

- `git diff --check upstream/main...HEAD`
- `go test ./...`
- `go test ./internal/cli ./internal/spotify ./internal/app ./internal/testutil`
- `go test -race ./internal/cli ./internal/spotify`
- `go vet ./...`
- `go build ./cmd/spogo`
- `go run ./cmd/spogo user --help`
- `go run ./cmd/spogo user history --help`
- `go run ./cmd/spogo user top-tracks --help`