### PR TITLE
Fix Firefox auth import cookie expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.9.1 - Unreleased
 
 - Add user top tracks and retained listening history commands (`#29`, thanks @hibachipapi)
+- Fix Firefox cookie imports when browser expiry values cannot be serialized (`#31`, thanks @meoyawn)
 
 ## 0.9.0 - 2026-05-10
 

--- a/internal/cli/auth_paste_test.go
+++ b/internal/cli/auth_paste_test.go
@@ -60,6 +60,37 @@ func TestReadPromptCookieValueRequiredRejectsEmpty(t *testing.T) {
 	}
 }
 
+func TestPromptPastedCookies(t *testing.T) {
+	ctx, _, errOut := testutil.NewTestContext(t, output.FormatPlain)
+	withStdin(t, "sp_dc=token\nsp_key=key\nsp_t=device\n", func() {
+		values, err := promptPastedCookies(ctx.Output)
+		if err != nil {
+			t.Fatalf("prompt: %v", err)
+		}
+		if values.spdc != "token" || values.spkey != "key" || values.spt != "device" {
+			t.Fatalf("unexpected values: %#v", values)
+		}
+	})
+	for _, prompt := range []string{"Paste sp_dc value:", "Paste sp_key value:", "Paste sp_t value:"} {
+		if !strings.Contains(errOut.String(), prompt) {
+			t.Fatalf("expected prompt %q in %q", prompt, errOut.String())
+		}
+	}
+}
+
+func TestPromptPastedCookiesAllowsEmptyOptionalValues(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	withStdin(t, "sp_dc=token\n\n\n", func() {
+		values, err := promptPastedCookies(ctx.Output)
+		if err != nil {
+			t.Fatalf("prompt: %v", err)
+		}
+		if values.spdc != "token" || values.spkey != "" || values.spt != "" {
+			t.Fatalf("unexpected values: %#v", values)
+		}
+	})
+}
+
 func TestParsePastedCookiesAnyOrder(t *testing.T) {
 	values, err := parsePastedCookies(strings.NewReader("sp_t=device\nsp_dc=token\nsp_key=key\n"))
 	if err != nil {

--- a/internal/cookies/source_test.go
+++ b/internal/cookies/source_test.go
@@ -12,10 +12,18 @@ import (
 )
 
 func TestBrowserSource(t *testing.T) {
+	exp := time.Now().Add(time.Hour)
 	restore := SetReadCookies(func(ctx context.Context, opts sweetcookie.Options) (sweetcookie.Result, error) {
-		exp := time.Now().Add(time.Hour)
 		return sweetcookie.Result{
-			Cookies: []sweetcookie.Cookie{{Name: "sp_dc", Value: "token", Domain: ".spotify.com", Expires: &exp}},
+			Cookies: []sweetcookie.Cookie{{
+				Name:     "sp_dc",
+				Value:    "token",
+				Domain:   ".spotify.com",
+				Path:     "/",
+				Secure:   true,
+				HTTPOnly: true,
+				Expires:  &exp,
+			}},
 		}, nil
 	})
 	defer restore()
@@ -25,6 +33,26 @@ func TestBrowserSource(t *testing.T) {
 		t.Fatalf("cookies: %v", err)
 	}
 	if len(cookies) != 1 || cookies[0].Name != "sp_dc" {
+		t.Fatalf("unexpected cookies: %#v", cookies)
+	}
+	if cookies[0].Path != "/" || !cookies[0].Secure || !cookies[0].HttpOnly || !cookies[0].Expires.Equal(exp) {
+		t.Fatalf("unexpected cookie fields: %#v", cookies[0])
+	}
+}
+
+func TestBrowserSourceCopiesNilExpiry(t *testing.T) {
+	restore := SetReadCookies(func(ctx context.Context, opts sweetcookie.Options) (sweetcookie.Result, error) {
+		return sweetcookie.Result{
+			Cookies: []sweetcookie.Cookie{{Name: "sp_dc", Value: "token", Domain: ".spotify.com"}},
+		}, nil
+	})
+	defer restore()
+	src := BrowserSource{Browser: "firefox", Domain: "spotify.com"}
+	cookies, err := src.Cookies(context.Background())
+	if err != nil {
+		t.Fatalf("cookies: %v", err)
+	}
+	if len(cookies) != 1 || !cookies[0].Expires.IsZero() {
 		t.Fatalf("unexpected cookies: %#v", cookies)
 	}
 }
@@ -71,6 +99,22 @@ func TestBrowserSourceRetriesAcrossSpotifyHosts(t *testing.T) {
 	}
 	if len(calls[1].Names) != len(authCookieNames) {
 		t.Fatalf("expected auth cookie allowlist")
+	}
+}
+
+func TestBrowserSourceRetryError(t *testing.T) {
+	calls := 0
+	restore := SetReadCookies(func(ctx context.Context, opts sweetcookie.Options) (sweetcookie.Result, error) {
+		calls++
+		if calls == 1 {
+			return sweetcookie.Result{}, nil
+		}
+		return sweetcookie.Result{}, errors.New("retry boom")
+	})
+	defer restore()
+	src := BrowserSource{Browser: "firefox", Domain: "spotify.com"}
+	if _, err := src.Cookies(context.Background()); err == nil || !strings.Contains(err.Error(), "retry boom") {
+		t.Fatalf("expected retry error, got %v", err)
 	}
 }
 
@@ -130,6 +174,51 @@ func TestBrowserSourceUsesSpotifyOrigins(t *testing.T) {
 	}
 	if got.Origins[0] != "https://accounts.spotify.com" && got.Origins[1] != "https://accounts.spotify.com" {
 		t.Fatalf("expected accounts.spotify.com origin, got %v", got.Origins)
+	}
+}
+
+func TestBrowserSourceURLDomain(t *testing.T) {
+	var got sweetcookie.Options
+	restore := SetReadCookies(func(ctx context.Context, opts sweetcookie.Options) (sweetcookie.Result, error) {
+		got = opts
+		return sweetcookie.Result{
+			Cookies: []sweetcookie.Cookie{{Name: "sp_dc", Value: "token", Domain: ".open.spotify.com"}},
+		}, nil
+	})
+	defer restore()
+	src := BrowserSource{Browser: "firefox", Domain: "https://open.spotify.com/collection"}
+	if _, err := src.Cookies(context.Background()); err != nil {
+		t.Fatalf("expected cookies: %v", err)
+	}
+	if got.URL != "https://open.spotify.com" {
+		t.Fatalf("expected parsed domain URL, got %q", got.URL)
+	}
+	if len(got.Origins) != 2 {
+		t.Fatalf("expected related spotify origins, got %v", got.Origins)
+	}
+}
+
+func TestSpotifyOriginsIgnoresEmptyAndNonSpotifyHosts(t *testing.T) {
+	for _, host := range []string{"", "example.com"} {
+		if got := spotifyOrigins(host); got != nil {
+			t.Fatalf("expected no origins for %q, got %v", host, got)
+		}
+	}
+}
+
+func TestCompactWarningsTrimsDeduplicatesAndLimits(t *testing.T) {
+	got := compactWarnings([]string{" first ", "", "first", "second", "third", "fourth"})
+	want := []string{"first", "second", "third"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+	if got := compactWarnings([]string{"", "   "}); got != nil {
+		t.Fatalf("expected nil warnings, got %v", got)
 	}
 }
 

--- a/internal/cookies/store.go
+++ b/internal/cookies/store.go
@@ -58,12 +58,18 @@ func Write(path string, cookies []*http.Cookie) error {
 		if c == nil {
 			continue
 		}
+		expires := c.Expires
+		if !expires.IsZero() {
+			if _, err := expires.MarshalJSON(); err != nil {
+				expires = time.Time{}
+			}
+		}
 		stored = append(stored, StoredCookie{
 			Name:     c.Name,
 			Value:    c.Value,
 			Domain:   c.Domain,
 			Path:     c.Path,
-			Expires:  c.Expires,
+			Expires:  expires,
 			Secure:   c.Secure,
 			HTTPOnly: c.HttpOnly,
 		})

--- a/internal/cookies/store.go
+++ b/internal/cookies/store.go
@@ -58,18 +58,12 @@ func Write(path string, cookies []*http.Cookie) error {
 		if c == nil {
 			continue
 		}
-		expires := c.Expires
-		if !expires.IsZero() {
-			if _, err := expires.MarshalJSON(); err != nil {
-				expires = time.Time{}
-			}
-		}
 		stored = append(stored, StoredCookie{
 			Name:     c.Name,
 			Value:    c.Value,
 			Domain:   c.Domain,
 			Path:     c.Path,
-			Expires:  expires,
+			Expires:  jsonSafeExpiry(c.Expires),
 			Secure:   c.Secure,
 			HTTPOnly: c.HttpOnly,
 		})
@@ -79,4 +73,14 @@ func Write(path string, cookies []*http.Cookie) error {
 		return err
 	}
 	return os.WriteFile(path, data, 0o600)
+}
+
+func jsonSafeExpiry(expires time.Time) time.Time {
+	if expires.IsZero() {
+		return time.Time{}
+	}
+	if _, err := expires.MarshalJSON(); err != nil {
+		return time.Time{}
+	}
+	return expires
 }

--- a/internal/cookies/store_test.go
+++ b/internal/cookies/store_test.go
@@ -67,6 +67,29 @@ func TestWriteSkipsNilCookie(t *testing.T) {
 	}
 }
 
+func TestWriteDropsUnmarshalableExpiry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cookies.json")
+	input := []*http.Cookie{{
+		Name:    "sp_dc",
+		Value:   "token",
+		Expires: time.Unix(1<<62, 0),
+	}}
+	if err := Write(path, input); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	out, err := Read(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(out) != 1 || out[0].Name != "sp_dc" {
+		t.Fatalf("unexpected cookies: %#v", out)
+	}
+	if !out[0].Expires.IsZero() {
+		t.Fatalf("expected zero expiry, got %v", out[0].Expires)
+	}
+}
+
 func TestReadBadJSON(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "cookies.json")

--- a/internal/cookies/store_test.go
+++ b/internal/cookies/store_test.go
@@ -34,6 +34,9 @@ func TestWriteReadCookies(t *testing.T) {
 	if len(out) != 1 || out[0].Name != "sp_dc" {
 		t.Fatalf("unexpected cookies: %#v", out)
 	}
+	if !out[0].Expires.Equal(expires) {
+		t.Fatalf("expected expiry %v, got %v", expires, out[0].Expires)
+	}
 }
 
 func TestWriteErrors(t *testing.T) {
@@ -70,11 +73,19 @@ func TestWriteSkipsNilCookie(t *testing.T) {
 func TestWriteDropsUnmarshalableExpiry(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "cookies.json")
-	input := []*http.Cookie{{
-		Name:    "sp_dc",
-		Value:   "token",
-		Expires: time.Unix(1<<62, 0),
-	}}
+	validExpires := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
+	input := []*http.Cookie{
+		{
+			Name:    "sp_dc",
+			Value:   "token",
+			Expires: time.Unix(1<<62, 0).UTC(),
+		},
+		{
+			Name:    "sp_t",
+			Value:   "token",
+			Expires: validExpires,
+		},
+	}
 	if err := Write(path, input); err != nil {
 		t.Fatalf("write: %v", err)
 	}
@@ -82,11 +93,14 @@ func TestWriteDropsUnmarshalableExpiry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
-	if len(out) != 1 || out[0].Name != "sp_dc" {
+	if len(out) != 2 || out[0].Name != "sp_dc" || out[1].Name != "sp_t" {
 		t.Fatalf("unexpected cookies: %#v", out)
 	}
 	if !out[0].Expires.IsZero() {
 		t.Fatalf("expected zero expiry, got %v", out[0].Expires)
+	}
+	if !out[1].Expires.Equal(validExpires) {
+		t.Fatalf("expected valid expiry %v, got %v", validExpires, out[1].Expires)
 	}
 }
 


### PR DESCRIPTION
## Summary
- drop cookie expiry values that cannot be marshaled to JSON before writing the cookie cache
- add a regression test for Firefox-style out-of-range cookie expiry values

## Tests
- go test ./...
- go run ./cmd/spogo auth import --browser firefox

## Proof

- go run ./cmd/spogo auth import --browser firefox

<img width="836" height="75" alt="image" src="https://github.com/user-attachments/assets/326b30b0-95c1-47a3-b5fd-2a4837e816da" />
