### PR TITLE
build: require patched Go toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.10.1 - Unreleased
 
 - Add Bash, Zsh, and Fish shell completions and show supported shells in command help (`#32`, thanks @kk-spartans)
+- Build CI and release artifacts with Go 1.25.11 so upstream standard-library security fixes are included
 
 ## 0.10.0 - 2026-06-10
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,7 @@ That's it — the formula pulls a signed binary from the latest GitHub release.
 go install github.com/steipete/spogo/cmd/spogo@latest
 ```
 
-Builds from source against your local Go toolchain. Requires Go 1.22+.
+Builds from source against your local Go toolchain. Requires Go 1.25.11+.
 
 ## Pre-built release binaries
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/steipete/spogo
 
-go 1.25.0
+go 1.25.11
 
 require (
 	github.com/alecthomas/kong v1.15.0


### PR DESCRIPTION
## Summary

- raise the repository's minimum Go toolchain from 1.25.0 to 1.25.11
- ensure CI and GoReleaser consume the patched Go 1.25 line from `go.mod`
- align source-install documentation and the unreleased changelog

## Root cause

`actions/setup-go@v6` reads the exact `go 1.25.0` directive from `go.mod`. The current main CI log confirms it downloads and runs Go 1.25.0, while Go 1.25.11 includes the intervening upstream standard-library security fixes.

## Validation

- `GOTOOLCHAIN=go1.25.11 go test -race ./...`
- `GOTOOLCHAIN=go1.25.11 ./scripts/check-coverage.sh 90` — 90.5%
- `GOTOOLCHAIN=go1.25.11 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.2 run`
- `GOTOOLCHAIN=go1.25.11 go vet ./...`
- `GOTOOLCHAIN=go1.25.11 go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...` — no output
- `GOTOOLCHAIN=go1.25.11 go run golang.org/x/vuln/cmd/govulncheck@latest -show verbose ./...` — no vulnerabilities; scanned Go 1.25.11
- source-blind built-binary behavior contract: 6/6 clauses passed; Bash/Zsh syntax passed; Fish generation passed with Fish syntax execution unavailable locally
- isolated docs-site build: 21 files; install page contains the Go 1.25.11 minimum
- `goreleaser check` and isolated `goreleaser release --snapshot`: six archives built; Darwin arm64 artifact reports Go 1.25.11
- structured Codex autoreview: clean; no accepted/actionable findings

## Risk

Low: build-security metadata and matching docs only. This intentionally rejects vulnerable Go 1.25.0–1.25.10 toolchains. No product version bump, tag, release, or publication is included.
