### PR TITLE
ci: refresh analysis tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
       - name: Deadcode
         run: |
           output_file=$(mktemp)
-          go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./... > "$output_file"
+          go run golang.org/x/tools/cmd/deadcode@v0.47.0 -test ./... > "$output_file"
           if [ -s "$output_file" ]; then
             cat "$output_file"
             exit 1
           fi
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.7.2
+          version: v2.12.2
       - run: ./scripts/check-coverage.sh 90


### PR DESCRIPTION
## Summary

- update the CI deadcode analyzer from `golang.org/x/tools` v0.45.0 to v0.47.0
- update golangci-lint from v2.7.2 to current stable v2.12.2

Both are CI-only maintenance updates; runtime dependencies and product behavior are unchanged.

## Validation

- `GOTOOLCHAIN=go1.25.11 go test -race ./...`
- `GOTOOLCHAIN=go1.25.11 ./scripts/check-coverage.sh 90` — 90.5%
- `GOTOOLCHAIN=go1.25.11 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — zero issues
- `GOTOOLCHAIN=go1.25.11 go vet ./...`
- `GOTOOLCHAIN=go1.25.11 go run golang.org/x/tools/cmd/deadcode@v0.47.0 -test ./...` — no output
- structured Codex autoreview: clean; no accepted/actionable findings

## Risk

Low: two pinned CI analyzer versions only. No runtime dependency, changelog, product version, release, or publication changes.
