### PR TITLE
feat: play ordered track URI lists

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -108,7 +108,7 @@ Drive what's playing. See [Playback](playback.md).
 
 | Command | Purpose |
 | --- | --- |
-| `spogo play [<id|url>] [--type <kind>] [--shuffle]` | Resume, or start a track / album / playlist / show / artist. |
+| `spogo play [<id\|url> ...] [--type <kind>] [--shuffle]` | Resume, start a track / album / playlist / show / artist, or start an ordered list from two or more track URIs. |
 | `spogo pause` | Pause current playback. |
 | `spogo next` | Skip to the next item. |
 | `spogo prev` | Previous (restart current if past ~3s). |

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -10,7 +10,7 @@ All playback commands act on the currently active Spotify Connect device unless 
 ## play
 
 ```bash
-spogo play [<id|url>] [--type <track|album|playlist|show|episode>] [--shuffle]
+spogo play [<id|url> ...] [--type <track|album|playlist|show|episode>] [--shuffle]
 ```
 
 Accepts:
@@ -18,6 +18,7 @@ Accepts:
 - A Spotify URI: `spotify:track:7hQJA50XrCWABAu5v6QZ4i`, `spotify:album:...`, `spotify:playlist:...`, `spotify:show:...`, `spotify:episode:...`, `spotify:artist:...`.
 - A web URL: `https://open.spotify.com/track/7hQJA50XrCWABAu5v6QZ4i`.
 - A bare ID — combine with `--type` to disambiguate.
+- Two or more track URIs/IDs — starts an ordered track list (see below).
 - No argument — resumes the current item.
 
 Behavior:
@@ -25,7 +26,8 @@ Behavior:
 - **Tracks** start immediately.
 - **Albums / playlists / shows** start a context — `spogo next` walks through items.
 - **Artists** start with the artist's top tracks (first track first).
-- `--shuffle` enables shuffle on the device before play, randomizing the first track for context URIs.
+- **Multiple tracks** — passing two or more track URIs starts an ordered list in a single request: Spotify plays the first, then continues through the rest, without creating a playlist. This mode is tracks-only; albums, playlists, shows, episodes, and artists are rejected. With raw IDs, pass `--type track`. This is not a queue append — the list replaces the current playback context (use [`spogo queue add`](queue.md) to append a single item instead).
+- `--shuffle` enables shuffle on the device before play, randomizing the first track for context URIs and for an ordered track list.
 
 Examples:
 
@@ -36,6 +38,8 @@ spogo play https://open.spotify.com/album/4aawyAB9vmqN3uQ7FjRGTy
 spogo play 37i9dQZF1DXcBWIGoYBM5M --type playlist               # bare ID
 spogo play spotify:playlist:37i9dQZF1DXcBWIGoYBM5M --shuffle    # shuffle on
 spogo play spotify:artist:6sFIWsNpZYqfjUpaCgueju                # top tracks
+spogo play spotify:track:7hQJA50XrCWABAu5v6QZ4i spotify:track:1301WleyT98MSxVHPZCA6M  # ordered list
+spogo play 7hQJA50XrCWABAu5v6QZ4i 1301WleyT98MSxVHPZCA6M --type track                 # ordered list, raw IDs
 ```
 
 ## pause / resume

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -78,10 +78,11 @@ spogo [global flags] <command> [args]
 
 ### playback
 
-- `spogo play [<id|url>]` (track/album/playlist/show)
+- `spogo play [<id|url> ...]` (track/album/playlist/show)
   - optional: `--type <track|album|playlist|show|episode>` for raw IDs
   - optional: `--shuffle` enable shuffle before playing (randomizes first track for context URIs)
   - artist URIs play top tracks (starts with the first)
+  - two or more track URIs start an ordered track list in one request (plays the first, then continues through the rest, without creating a playlist); tracks only — contexts and artists are rejected in this mode. Raw IDs require `--type track`. This is not a queue append; the list replaces the current playback context.
 - `spogo pause`
 - `spogo next`
 - `spogo prev`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -80,7 +80,7 @@ spogo [global flags] <command> [args]
 
 - `spogo play [<id|url> ...]` (track/album/playlist/show)
   - optional: `--type <track|album|playlist|show|episode>` for raw IDs
-  - optional: `--shuffle` enable shuffle before playing (randomizes first track for context URIs)
+  - optional: `--shuffle` enable shuffle before playing (randomizes first track for context URIs and ordered track lists)
   - artist URIs play top tracks (starts with the first)
   - two or more track URIs start an ordered track list in one request (plays the first, then continues through the rest, without creating a playlist); tracks only — contexts and artists are rejected in this mode. Raw IDs require `--type track`. This is not a queue append; the list replaces the current playback context.
 - `spogo pause`

--- a/internal/app/context_test.go
+++ b/internal/app/context_test.go
@@ -380,6 +380,7 @@ func (dummySpotify) Playback(context.Context) (spotify.PlaybackStatus, error) {
 	return spotify.PlaybackStatus{}, nil
 }
 func (dummySpotify) Play(context.Context, string) error                { return nil }
+func (dummySpotify) PlayTracks(context.Context, []string) error        { return nil }
 func (dummySpotify) Pause(context.Context) error                       { return nil }
 func (dummySpotify) Next(context.Context) error                        { return nil }
 func (dummySpotify) Previous(context.Context) error                    { return nil }

--- a/internal/cli/playback.go
+++ b/internal/cli/playback.go
@@ -13,9 +13,9 @@ import (
 )
 
 type PlayCmd struct {
-	Item    string `arg:"" optional:"" help:"Spotify ID/URL/URI."`
-	Type    string `help:"Type for raw IDs (track|album|playlist|show|episode)."`
-	Shuffle bool   `help:"Enable shuffle before playing."`
+	Items   []string `arg:"" optional:"" help:"Spotify ID/URL/URI. Pass two or more track URIs to start an ordered track list."`
+	Type    string   `help:"Type for raw IDs (track|album|playlist|show|episode)."`
+	Shuffle bool     `help:"Enable shuffle before playing."`
 }
 
 type PauseCmd struct{}
@@ -51,53 +51,17 @@ func (cmd *PlayCmd) Run(ctx *app.Context) error {
 	if err != nil {
 		return err
 	}
+	// Two or more arguments start an ordered list of tracks in a single request
+	// (not a queue append). One argument keeps the existing single-item behavior
+	// (track/context/artist top-track); no argument resumes.
+	if len(cmd.Items) > 1 {
+		return cmd.runTracks(ctx, cmdCtx, client)
+	}
 	uri := ""
-	if cmd.Item != "" {
-		res, err := spotify.ParseResource(cmd.Item)
+	if len(cmd.Items) == 1 {
+		uri, err = resolvePlayURI(cmdCtx, client, cmd.Items[0], cmd.Type)
 		if err != nil {
 			return err
-		}
-		if res.URI == "" {
-			if cmd.Type == "" {
-				return errors.New("type required for raw id")
-			}
-			res.Type = cmd.Type
-			res.URI = "spotify:" + cmd.Type + ":" + res.ID
-		}
-		if res.Type == "artist" {
-			topTracks, ok := client.(artistTopTracks)
-			if !ok {
-				return errors.New("artist playback not supported by engine")
-			}
-			tracks, err := topTracks.ArtistTopTracks(cmdCtx, res.ID, 10)
-			if err == nil && len(tracks) > 0 {
-				uri = tracks[0].URI
-			} else {
-				artist, aerr := client.GetArtist(cmdCtx, res.ID)
-				if aerr != nil || artist.Name == "" {
-					if err != nil {
-						return err
-					}
-					return errors.New("no artist tracks found")
-				}
-				query := fmt.Sprintf("artist:%q", artist.Name)
-				search, serr := client.Search(cmdCtx, "track", query, 1, 0)
-				if serr != nil {
-					if err != nil {
-						return err
-					}
-					return serr
-				}
-				if len(search.Items) == 0 {
-					if err != nil {
-						return err
-					}
-					return errors.New("no artist tracks found")
-				}
-				uri = search.Items[0].URI
-			}
-		} else {
-			uri = res.URI
 		}
 	}
 	if cmd.Shuffle {
@@ -109,6 +73,104 @@ func (cmd *PlayCmd) Run(ctx *app.Context) error {
 		return err
 	}
 	return emitOK(ctx, nil, "Playback started")
+}
+
+// runTracks starts an ordered list of track URIs. Every argument must resolve to
+// a track; contexts (album/playlist/show/episode) and artists are rejected so
+// the ordered list stays unambiguous.
+func (cmd *PlayCmd) runTracks(ctx *app.Context, cmdCtx context.Context, client spotify.API) error {
+	uris := make([]string, 0, len(cmd.Items))
+	for _, item := range cmd.Items {
+		uri, err := resolveTrackURI(item, cmd.Type)
+		if err != nil {
+			return err
+		}
+		uris = append(uris, uri)
+	}
+	if cmd.Shuffle {
+		if err := client.Shuffle(cmdCtx, true); err != nil {
+			return err
+		}
+	}
+	if err := client.PlayTracks(cmdCtx, uris); err != nil {
+		return err
+	}
+	return emitOK(ctx, map[string]any{"status": "ok", "count": len(uris)}, fmt.Sprintf("Playing %d tracks", len(uris)))
+}
+
+// resolvePlayURI resolves a single play target, preserving artist top-track and
+// raw-id-with-type behavior.
+func resolvePlayURI(ctx context.Context, client spotify.API, item, typeFlag string) (string, error) {
+	res, err := spotify.ParseResource(item)
+	if err != nil {
+		return "", err
+	}
+	if res.URI == "" {
+		if typeFlag == "" {
+			return "", errors.New("type required for raw id")
+		}
+		res.Type = typeFlag
+		res.URI = "spotify:" + typeFlag + ":" + res.ID
+	}
+	if res.Type != "artist" {
+		return res.URI, nil
+	}
+	return resolveArtistURI(ctx, client, res)
+}
+
+func resolveArtistURI(ctx context.Context, client spotify.API, res spotify.Resource) (string, error) {
+	topTracks, ok := client.(artistTopTracks)
+	if !ok {
+		return "", errors.New("artist playback not supported by engine")
+	}
+	tracks, err := topTracks.ArtistTopTracks(ctx, res.ID, 10)
+	if err == nil && len(tracks) > 0 {
+		return tracks[0].URI, nil
+	}
+	artist, aerr := client.GetArtist(ctx, res.ID)
+	if aerr != nil || artist.Name == "" {
+		if err != nil {
+			return "", err
+		}
+		return "", errors.New("no artist tracks found")
+	}
+	query := fmt.Sprintf("artist:%q", artist.Name)
+	search, serr := client.Search(ctx, "track", query, 1, 0)
+	if serr != nil {
+		if err != nil {
+			return "", err
+		}
+		return "", serr
+	}
+	if len(search.Items) == 0 {
+		if err != nil {
+			return "", err
+		}
+		return "", errors.New("no artist tracks found")
+	}
+	return search.Items[0].URI, nil
+}
+
+// resolveTrackURI resolves one argument to a track URI for ordered multi-track
+// play. Raw IDs require --type track; any non-track resource is rejected.
+func resolveTrackURI(item, typeFlag string) (string, error) {
+	res, err := spotify.ParseResource(item)
+	if err != nil {
+		return "", err
+	}
+	if res.URI == "" {
+		if typeFlag == "" {
+			return "", errors.New("type required for raw id")
+		}
+		if typeFlag != "track" {
+			return "", fmt.Errorf("multi-track play only supports tracks, got type %q", typeFlag)
+		}
+		return "spotify:track:" + res.ID, nil
+	}
+	if res.Type != "track" {
+		return "", fmt.Errorf("multi-track play only supports tracks, got %s %q", res.Type, item)
+	}
+	return res.URI, nil
 }
 
 func (cmd *PauseCmd) Run(ctx *app.Context) error {

--- a/internal/cli/playback_artist_test.go
+++ b/internal/cli/playback_artist_test.go
@@ -30,7 +30,7 @@ func TestPlayCmdArtistTopTrack(t *testing.T) {
 		},
 	}
 	ctx.SetSpotify(mock)
-	cmd := PlayCmd{Item: "spotify:artist:abc"}
+	cmd := PlayCmd{Items: []string{"spotify:artist:abc"}}
 	if err := cmd.Run(ctx); err != nil {
 		t.Fatalf("run: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestPlayCmdArtistFallbackSearch(t *testing.T) {
 		PlayFn: func(context.Context, string) error { return nil },
 	}
 	ctx.SetSpotify(mock)
-	if err := (&PlayCmd{Item: "spotify:artist:abc"}).Run(ctx); err != nil {
+	if err := (&PlayCmd{Items: []string{"spotify:artist:abc"}}).Run(ctx); err != nil {
 		t.Fatalf("run: %v", err)
 	}
 }
@@ -58,7 +58,7 @@ func TestPlayCmdArtistFallbackArtistError(t *testing.T) {
 		ArtistTopTracksFn: func(context.Context, string, int) ([]spotify.Item, error) { return nil, errors.New("boom") },
 		GetArtistFn:       func(context.Context, string) (spotify.Item, error) { return spotify.Item{}, errors.New("missing") },
 	})
-	if err := (&PlayCmd{Item: "spotify:artist:abc"}).Run(ctx); err == nil {
+	if err := (&PlayCmd{Items: []string{"spotify:artist:abc"}}).Run(ctx); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -72,7 +72,7 @@ func TestPlayCmdArtistFallbackSearchEmpty(t *testing.T) {
 			return spotify.SearchResult{}, nil
 		},
 	})
-	if err := (&PlayCmd{Item: "spotify:artist:abc"}).Run(ctx); err == nil {
+	if err := (&PlayCmd{Items: []string{"spotify:artist:abc"}}).Run(ctx); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -86,7 +86,7 @@ func TestPlayCmdArtistFallbackSearchError(t *testing.T) {
 			return spotify.SearchResult{}, errors.New("search fail")
 		},
 	})
-	if err := (&PlayCmd{Item: "spotify:artist:abc"}).Run(ctx); err == nil {
+	if err := (&PlayCmd{Items: []string{"spotify:artist:abc"}}).Run(ctx); err == nil {
 		t.Fatalf("expected error")
 	}
 }

--- a/internal/cli/playback_more_test.go
+++ b/internal/cli/playback_more_test.go
@@ -21,7 +21,7 @@ func TestPlayCmdURI(t *testing.T) {
 		},
 	}
 	ctx.SetSpotify(mock)
-	cmd := PlayCmd{Item: "spotify:track:t1"}
+	cmd := PlayCmd{Items: []string{"spotify:track:t1"}}
 	if err := cmd.Run(ctx); err != nil {
 		t.Fatalf("run: %v", err)
 	}
@@ -30,7 +30,7 @@ func TestPlayCmdURI(t *testing.T) {
 func TestPlayCmdInvalidResource(t *testing.T) {
 	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
 	ctx.SetSpotify(&testutil.SpotifyMock{PlayFn: func(ctx context.Context, uri string) error { return nil }})
-	cmd := PlayCmd{Item: "spotify:bad:t1"}
+	cmd := PlayCmd{Items: []string{"spotify:bad:t1"}}
 	if err := cmd.Run(ctx); err == nil {
 		t.Fatalf("expected error")
 	}
@@ -152,8 +152,103 @@ func TestPlayCmdShuffleError(t *testing.T) {
 		ShuffleFn: func(ctx context.Context, enabled bool) error { return errors.New("boom") },
 		PlayFn:    func(ctx context.Context, uri string) error { t.Fatalf("play should not run"); return nil },
 	})
-	cmd := PlayCmd{Item: "spotify:track:t1", Shuffle: true}
+	cmd := PlayCmd{Items: []string{"spotify:track:t1"}, Shuffle: true}
 	if err := cmd.Run(ctx); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestPlayCmdMultiTrackOrdered(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	var got []string
+	mock := &testutil.SpotifyMock{
+		PlayTracksFn: func(ctx context.Context, uris []string) error {
+			got = uris
+			return nil
+		},
+		PlayFn: func(context.Context, string) error { t.Fatalf("Play should not run for multi-track"); return nil },
+	}
+	ctx.SetSpotify(mock)
+	cmd := PlayCmd{Items: []string{"spotify:track:t1", "spotify:track:t2", "spotify:track:t3"}}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	want := []string{"spotify:track:t1", "spotify:track:t2", "spotify:track:t3"}
+	if len(got) != len(want) {
+		t.Fatalf("got %#v want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("uri[%d]=%s want %s (order matters)", i, got[i], want[i])
+		}
+	}
+}
+
+func TestPlayCmdMultiTrackRawIDsRequireTrackType(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	var got []string
+	mock := &testutil.SpotifyMock{
+		PlayTracksFn: func(ctx context.Context, uris []string) error {
+			got = uris
+			return nil
+		},
+	}
+	ctx.SetSpotify(mock)
+
+	// Raw IDs without --type are rejected.
+	if err := (&PlayCmd{Items: []string{"id1", "id2"}}).Run(ctx); err == nil {
+		t.Fatalf("expected error for raw ids without type")
+	}
+	// Raw IDs with --type track build ordered track URIs.
+	if err := (&PlayCmd{Items: []string{"id1", "id2"}, Type: "track"}).Run(ctx); err != nil {
+		t.Fatalf("run with type track: %v", err)
+	}
+	if len(got) != 2 || got[0] != "spotify:track:id1" || got[1] != "spotify:track:id2" {
+		t.Fatalf("unexpected uris: %#v", got)
+	}
+	// Raw IDs with a non-track --type are rejected.
+	if err := (&PlayCmd{Items: []string{"id1", "id2"}, Type: "album"}).Run(ctx); err == nil {
+		t.Fatalf("expected error for non-track type in multi-track mode")
+	}
+}
+
+func TestPlayCmdMultiTrackRejectsNonTrack(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	mock := &testutil.SpotifyMock{
+		PlayTracksFn: func(context.Context, []string) error {
+			t.Fatalf("PlayTracks should not run when a non-track item is present")
+			return nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := PlayCmd{Items: []string{"spotify:track:t1", "spotify:album:a1"}}
+	if err := cmd.Run(ctx); err == nil {
+		t.Fatalf("expected error for album in multi-track mode")
+	}
+}
+
+func TestPlayCmdMultiTrackShuffle(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
+	calls := []string{}
+	mock := &testutil.SpotifyMock{
+		ShuffleFn: func(ctx context.Context, enabled bool) error {
+			if !enabled {
+				t.Fatalf("expected shuffle enabled")
+			}
+			calls = append(calls, "shuffle")
+			return nil
+		},
+		PlayTracksFn: func(ctx context.Context, uris []string) error {
+			calls = append(calls, "playtracks")
+			return nil
+		},
+	}
+	ctx.SetSpotify(mock)
+	cmd := PlayCmd{Items: []string{"spotify:track:t1", "spotify:track:t2"}, Shuffle: true}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(calls) != 2 || calls[0] != "shuffle" || calls[1] != "playtracks" {
+		t.Fatalf("unexpected call order: %#v", calls)
 	}
 }

--- a/internal/cli/playback_test.go
+++ b/internal/cli/playback_test.go
@@ -37,7 +37,7 @@ func TestPlayCmdWithType(t *testing.T) {
 		},
 	}
 	ctx.SetSpotify(mock)
-	cmd := PlayCmd{Item: "abc", Type: "track"}
+	cmd := PlayCmd{Items: []string{"abc"}, Type: "track"}
 	if err := cmd.Run(ctx); err != nil {
 		t.Fatalf("run: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestPlayCmdShuffle(t *testing.T) {
 		},
 	}
 	ctx.SetSpotify(mock)
-	cmd := PlayCmd{Item: "abc", Type: "track", Shuffle: true}
+	cmd := PlayCmd{Items: []string{"abc"}, Type: "track", Shuffle: true}
 	if err := cmd.Run(ctx); err != nil {
 		t.Fatalf("run: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestPlayCmdMissingType(t *testing.T) {
 	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
 	mock := &testutil.SpotifyMock{PlayFn: func(ctx context.Context, uri string) error { return nil }}
 	ctx.SetSpotify(mock)
-	cmd := PlayCmd{Item: "abc"}
+	cmd := PlayCmd{Items: []string{"abc"}}
 	if err := cmd.Run(ctx); err == nil {
 		t.Fatalf("expected error")
 	}

--- a/internal/spotify/api.go
+++ b/internal/spotify/api.go
@@ -12,6 +12,7 @@ type API interface {
 	GetEpisode(ctx context.Context, id string) (Item, error)
 	Playback(ctx context.Context) (PlaybackStatus, error)
 	Play(ctx context.Context, uri string) error
+	PlayTracks(ctx context.Context, uris []string) error
 	Pause(ctx context.Context) error
 	Next(ctx context.Context) error
 	Previous(ctx context.Context) error

--- a/internal/spotify/applescript.go
+++ b/internal/spotify/applescript.go
@@ -49,6 +49,17 @@ func (c *AppleScriptClient) Play(ctx context.Context, uri string) error {
 	return err
 }
 
+// PlayTracks starts an ordered list of track URIs. The local Spotify app can
+// only start one track at a time via AppleScript, so an ordered remote list is
+// delegated to the fallback engine (Web/Connect), consistent with how other
+// Web-API-shaped operations behave here.
+func (c *AppleScriptClient) PlayTracks(ctx context.Context, uris []string) error {
+	if c.fallback != nil {
+		return c.fallback.PlayTracks(ctx, uris)
+	}
+	return ErrUnsupported
+}
+
 func (c *AppleScriptClient) Pause(ctx context.Context) error {
 	_, err := c.runScript(ctx, `tell application "Spotify" to pause`)
 	return err

--- a/internal/spotify/auto.go
+++ b/internal/spotify/auto.go
@@ -122,6 +122,12 @@ func (c *autoClient) Play(ctx context.Context, uri string) error {
 	})
 }
 
+func (c *autoClient) PlayTracks(ctx context.Context, uris []string) error {
+	return autoVoid(c, func(api API) error {
+		return api.PlayTracks(ctx, uris)
+	})
+}
+
 func (c *autoClient) Pause(ctx context.Context) error {
 	return autoVoid(c, func(api API) error {
 		return api.Pause(ctx)

--- a/internal/spotify/client.go
+++ b/internal/spotify/client.go
@@ -197,6 +197,27 @@ func (c *Client) Play(ctx context.Context, uri string) error {
 	return c.put(ctx, "/me/player/play", payload)
 }
 
+// PlayTracks starts playback from an ordered list of track URIs in a single
+// request. Spotify plays the first URI and continues through the rest, without
+// creating a playlist. It is not queue-append; the list replaces the current
+// playback context.
+func (c *Client) PlayTracks(ctx context.Context, uris []string) error {
+	return c.playTracks(ctx, uris, "")
+}
+
+func (c *Client) playTracks(ctx context.Context, uris []string, deviceID string) error {
+	payload := map[string]any{}
+	if len(uris) > 0 {
+		payload["uris"] = uris
+	}
+	var params url.Values
+	if deviceID != "" {
+		params = url.Values{}
+		params.Set("device_id", deviceID)
+	}
+	return c.send(ctx, http.MethodPut, "/me/player/play", params, payload, nil)
+}
+
 func (c *Client) Pause(ctx context.Context) error {
 	return c.put(ctx, "/me/player/pause", nil)
 }

--- a/internal/spotify/client_test.go
+++ b/internal/spotify/client_test.go
@@ -214,6 +214,37 @@ func TestPlayContextURI(t *testing.T) {
 	}
 }
 
+func TestPlayTracksPayloadOrder(t *testing.T) {
+	var captured []byte
+	var method, path string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method, path = r.Method, r.URL.Path
+		captured, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	client, closeFn := newTestClient(t, handler)
+	defer closeFn()
+	uris := []string{"spotify:track:t1", "spotify:track:t2", "spotify:track:t3"}
+	if err := client.PlayTracks(context.Background(), uris); err != nil {
+		t.Fatalf("play tracks: %v", err)
+	}
+	if method != http.MethodPut || path != "/me/player/play" {
+		t.Fatalf("unexpected request %s %s", method, path)
+	}
+	var payload struct {
+		URIs []string `json:"uris"`
+	}
+	if err := json.Unmarshal(captured, &payload); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, captured)
+	}
+	if len(payload.URIs) != 3 || payload.URIs[0] != "spotify:track:t1" || payload.URIs[1] != "spotify:track:t2" || payload.URIs[2] != "spotify:track:t3" {
+		t.Fatalf("expected ordered uris array, got: %#v", payload.URIs)
+	}
+	if strings.Contains(string(captured), "context_uri") {
+		t.Fatalf("unexpected context_uri in body: %s", captured)
+	}
+}
+
 func TestQueueNoContent(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)

--- a/internal/spotify/connect.go
+++ b/internal/spotify/connect.go
@@ -103,6 +103,10 @@ func (c *ConnectClient) Play(ctx context.Context, uri string) error {
 	return c.play(ctx, uri)
 }
 
+func (c *ConnectClient) PlayTracks(ctx context.Context, uris []string) error {
+	return c.playTracks(ctx, uris)
+}
+
 func (c *ConnectClient) Pause(ctx context.Context) error {
 	return c.pause(ctx)
 }

--- a/internal/spotify/connect_commands.go
+++ b/internal/spotify/connect_commands.go
@@ -69,6 +69,37 @@ func (c *ConnectClient) playViaWebAPI(ctx context.Context, uri string) error {
 	})
 }
 
+// playTracks starts an ordered list of track URIs. The Connect play command
+// models a single context plus an optional skip_to target, so it cannot cleanly
+// represent an ad-hoc ordered track list. Zero/one URIs keep the native Connect
+// path (resume / single play); two or more delegate to the Web API's
+// /me/player/play endpoint, which natively accepts an ordered uris array. The
+// web fallback carries the same device targeting as the single-track fallback.
+func (c *ConnectClient) playTracks(ctx context.Context, uris []string) error {
+	if len(uris) <= 1 {
+		uri := ""
+		if len(uris) == 1 {
+			uri = uris[0]
+		}
+		return c.play(ctx, uri)
+	}
+	deviceID := strings.TrimSpace(c.device)
+	if deviceID != "" {
+		if state, err := c.connectState(ctx); err == nil {
+			if targetID := resolveConnectTargetDeviceID(state, deviceID); targetID != "" {
+				deviceID = targetID
+			}
+		}
+	}
+	return c.playTracksViaWebAPI(ctx, uris, deviceID)
+}
+
+func (c *ConnectClient) playTracksViaWebAPI(ctx context.Context, uris []string, deviceID string) error {
+	return withWebFallback(c, func(web *Client) error {
+		return web.playTracks(ctx, uris, deviceID)
+	})
+}
+
 func (c *ConnectClient) pause(ctx context.Context) error {
 	return c.sendDirectCommand(ctx, "pause", nil)
 }

--- a/internal/spotify/connect_playback_test.go
+++ b/internal/spotify/connect_playback_test.go
@@ -554,6 +554,192 @@ func TestConnectPlayContextURIPayload(t *testing.T) {
 	}
 }
 
+func TestConnectPlayTracksFallsBackToWebAPI(t *testing.T) {
+	statePayload := map[string]any{
+		"devices": map[string]any{
+			"device-1": map[string]any{
+				"name":        "Desk",
+				"device_type": "computer",
+			},
+		},
+		"player_state": map[string]any{
+			"is_paused": true,
+		},
+		"active_device_id": "device-1",
+	}
+	var sawWebPlay bool
+	var webBody string
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/devices/hobs_"):
+			return jsonResponse(http.StatusOK, statePayload), nil
+		case req.Method == http.MethodPut && req.URL.Path == "/v1/me/player/play":
+			sawWebPlay = true
+			b, _ := io.ReadAll(req.Body)
+			webBody = string(b)
+			return textResponse(http.StatusNoContent, ""), nil
+		case req.Method == http.MethodPost:
+			t.Fatalf("unexpected connect command for multi-track: %s", req.URL.Path)
+			return nil, errors.New("unexpected connect command")
+		default:
+			return textResponse(http.StatusNotFound, "missing"), nil
+		}
+	})
+	client := newRegisteredConnectClientForTests(transport)
+	webClient, err := NewClient(Options{
+		TokenProvider: staticTokenProvider{},
+		HTTPClient:    client.client,
+	})
+	if err != nil {
+		t.Fatalf("new web client: %v", err)
+	}
+	client.web = webClient
+
+	if err := client.PlayTracks(context.Background(), []string{"spotify:track:t1", "spotify:track:t2"}); err != nil {
+		t.Fatalf("play tracks: %v", err)
+	}
+	if !sawWebPlay {
+		t.Fatalf("expected web play fallback for multi-track")
+	}
+	if !strings.Contains(webBody, `"uris"`) {
+		t.Fatalf("expected uris array in web body, got: %s", webBody)
+	}
+	i1 := strings.Index(webBody, "spotify:track:t1")
+	i2 := strings.Index(webBody, "spotify:track:t2")
+	if i1 < 0 || i2 < 0 || i1 > i2 {
+		t.Fatalf("expected t1 before t2 in ordered uris, got: %s", webBody)
+	}
+}
+
+func TestConnectPlayTracksResolvesConfiguredDeviceNameForWebAPI(t *testing.T) {
+	statePayload := map[string]any{
+		"devices": map[string]any{
+			"device-1": map[string]any{
+				"name":        "Desk",
+				"device_type": "computer",
+			},
+		},
+		"active_device_id": "device-1",
+	}
+	var webDeviceID string
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/devices/hobs_"):
+			return jsonResponse(http.StatusOK, statePayload), nil
+		case req.Method == http.MethodPut && req.URL.Path == "/v1/me/player/play":
+			webDeviceID = req.URL.Query().Get("device_id")
+			return textResponse(http.StatusNoContent, ""), nil
+		case req.Method == http.MethodPost:
+			t.Fatalf("unexpected connect command for multi-track: %s", req.URL.Path)
+			return nil, errors.New("unexpected connect command")
+		default:
+			return textResponse(http.StatusNotFound, "missing"), nil
+		}
+	})
+	client := newRegisteredConnectClientForTests(transport)
+	client.device = "Desk"
+	webClient, err := NewClient(Options{
+		TokenProvider: staticTokenProvider{},
+		HTTPClient:    client.client,
+		Device:        client.device,
+	})
+	if err != nil {
+		t.Fatalf("new web client: %v", err)
+	}
+	client.web = webClient
+
+	if err := client.PlayTracks(context.Background(), []string{"spotify:track:t1", "spotify:track:t2"}); err != nil {
+		t.Fatalf("play tracks: %v", err)
+	}
+	if webDeviceID != "device-1" {
+		t.Fatalf("expected resolved device id device-1, got %q", webDeviceID)
+	}
+}
+
+func TestConnectPlayTracksPreservesConfiguredDeviceIDForWebAPI(t *testing.T) {
+	statePayload := map[string]any{
+		"devices": map[string]any{
+			"device-1": map[string]any{
+				"name":        "Desk",
+				"device_type": "computer",
+			},
+		},
+		"active_device_id": "device-1",
+	}
+	var webDeviceID string
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/devices/hobs_"):
+			return jsonResponse(http.StatusOK, statePayload), nil
+		case req.Method == http.MethodPut && req.URL.Path == "/v1/me/player/play":
+			webDeviceID = req.URL.Query().Get("device_id")
+			return textResponse(http.StatusNoContent, ""), nil
+		case req.Method == http.MethodPost:
+			t.Fatalf("unexpected connect command for multi-track: %s", req.URL.Path)
+			return nil, errors.New("unexpected connect command")
+		default:
+			return textResponse(http.StatusNotFound, "missing"), nil
+		}
+	})
+	client := newRegisteredConnectClientForTests(transport)
+	client.device = "device-1"
+	webClient, err := NewClient(Options{
+		TokenProvider: staticTokenProvider{},
+		HTTPClient:    client.client,
+		Device:        client.device,
+	})
+	if err != nil {
+		t.Fatalf("new web client: %v", err)
+	}
+	client.web = webClient
+
+	if err := client.PlayTracks(context.Background(), []string{"spotify:track:t1", "spotify:track:t2"}); err != nil {
+		t.Fatalf("play tracks: %v", err)
+	}
+	if webDeviceID != "device-1" {
+		t.Fatalf("expected device id device-1, got %q", webDeviceID)
+	}
+}
+
+func TestConnectPlayTracksSingleUsesConnect(t *testing.T) {
+	statePayload := map[string]any{
+		"devices": map[string]any{
+			"device-1": map[string]any{"name": "Desk", "device_type": "computer"},
+		},
+		"player_state": map[string]any{
+			"is_paused":   false,
+			"position_ms": 0,
+		},
+		"active_device_id": "device-1",
+	}
+	var sawConnectPlay bool
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/devices/hobs_"):
+			return jsonResponse(http.StatusOK, statePayload), nil
+		case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/player/command/"):
+			sawConnectPlay = true
+			return textResponse(http.StatusOK, "ok"), nil
+		case req.Method == http.MethodPut && req.URL.Path == "/v1/me/player/play":
+			t.Fatalf("unexpected web fallback for single track")
+			return nil, errors.New("unexpected web fallback")
+		default:
+			return textResponse(http.StatusNotFound, "missing"), nil
+		}
+	})
+	client := newConnectClientForTests(transport)
+	client.session.connectDeviceID = "device"
+	client.session.connectionID = "conn"
+	client.session.registeredAt = time.Now()
+
+	if err := client.PlayTracks(context.Background(), []string{"spotify:track:t1"}); err != nil {
+		t.Fatalf("play tracks single: %v", err)
+	}
+	if !sawConnectPlay {
+		t.Fatalf("expected native connect play for single track")
+	}
+}
+
 func TestSendConnectCommandHTTPError(t *testing.T) {
 	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		return textResponse(http.StatusInternalServerError, "fail"), nil

--- a/internal/spotify/fallback.go
+++ b/internal/spotify/fallback.go
@@ -109,6 +109,12 @@ func (c *fallbackClient) Play(ctx context.Context, uri string) error {
 	})
 }
 
+func (c *fallbackClient) PlayTracks(ctx context.Context, uris []string) error {
+	return fallbackVoid(c, true, func(api API) error {
+		return api.PlayTracks(ctx, uris)
+	})
+}
+
 func (c *fallbackClient) Pause(ctx context.Context) error {
 	return fallbackVoid(c, true, func(api API) error {
 		return api.Pause(ctx)

--- a/internal/spotify/fallback_test.go
+++ b/internal/spotify/fallback_test.go
@@ -72,6 +72,11 @@ func (a apiStub) Play(context.Context, string) error {
 	return nil
 }
 
+func (a apiStub) PlayTracks(context.Context, []string) error {
+	a.note("PlayTracks")
+	return nil
+}
+
 func (a apiStub) Pause(ctx context.Context) error {
 	a.note("Pause")
 	if a.pauseFn != nil {

--- a/internal/testutil/spotify_mock.go
+++ b/internal/testutil/spotify_mock.go
@@ -20,6 +20,7 @@ type SpotifyMock struct {
 	ArtistTopTracksFn   func(context.Context, string, int) ([]spotify.Item, error)
 	PlaybackFn          func(context.Context) (spotify.PlaybackStatus, error)
 	PlayFn              func(context.Context, string) error
+	PlayTracksFn        func(context.Context, []string) error
 	PauseFn             func(context.Context) error
 	NextFn              func(context.Context) error
 	PreviousFn          func(context.Context) error

--- a/internal/testutil/spotify_mock_notimpl_test.go
+++ b/internal/testutil/spotify_mock_notimpl_test.go
@@ -17,6 +17,7 @@ func TestSpotifyMockAllNotImplemented(t *testing.T) {
 	_, _ = m.ArtistTopTracks(context.Background(), "1", 10)
 	_, _ = m.Playback(context.Background())
 	_ = m.Play(context.Background(), "uri")
+	_ = m.PlayTracks(context.Background(), []string{"uri"})
 	_ = m.Pause(context.Background())
 	_ = m.Next(context.Background())
 	_ = m.Previous(context.Background())

--- a/internal/testutil/spotify_mock_playback.go
+++ b/internal/testutil/spotify_mock_playback.go
@@ -20,6 +20,13 @@ func (m *SpotifyMock) Play(ctx context.Context, uri string) error {
 	return m.PlayFn(ctx, uri)
 }
 
+func (m *SpotifyMock) PlayTracks(ctx context.Context, uris []string) error {
+	if m.PlayTracksFn == nil {
+		return ErrNotImplemented
+	}
+	return m.PlayTracksFn(ctx, uris)
+}
+
 func (m *SpotifyMock) Pause(ctx context.Context) error {
 	if m.PauseFn == nil {
 		return ErrNotImplemented


### PR DESCRIPTION
## Summary

Adds ordered multi-track playback to `spogo play` by exposing Spotify's `/me/player/play` `uris` array support.

This lets callers start a temporary ordered track list in one playback request:

```bash
spogo play spotify:track:t1 spotify:track:t2 spotify:track:t3
spogo play t1 t2 t3 --type track
```

## What Problem This Solves

Spotify's playback API can already start an ordered list of track URIs in one request, but `spogo play` previously exposed only single-item playback. Callers that had already resolved several tracks had to either append each item to the live queue one command at a time or create/maintain a playlist/context elsewhere.

## What changed

- `spogo play` now accepts multiple positional track arguments.
- Single-item behavior is preserved:
  - no argument resumes playback
  - one track/context still uses the existing `Play` path
  - artist URIs still resolve to a top track
- Multi-track mode is tracks-only and rejects albums, playlists, shows, episodes, and artists so the ordered list stays unambiguous.
- The Web API client sends an ordered `uris` array to `/me/player/play`.
- The Connect engine uses native Connect play for zero/one item and falls back to Web API playback for two or more tracks, since the Connect command shape models a single context plus optional skip target.
- Connect multi-track playback resolves configured device names to concrete Spotify device IDs before calling the Web API fallback, preserving the existing name-or-ID `--device` contract.
- Docs/spec playback references describe ordered track-list playback, including shuffle behavior.

## Scope boundary

This is not batch queue append. Spotify's queue endpoint still accepts one URI per call, so `spogo queue add` remains single-item. Multi-track `play` replaces/starts the playback context like a temporary ordered list; it does not append to the existing queue.

This PR also does not change Spotify Web API retry/rate-limit handling; any `Retry-After` or 429 retry behavior changes belong in a separate PR.

## Evidence

Current head: `ba58b92cb97950a5c50d1a70aae67fbadc8da08b`

- `go test -count=1 ./internal/cli ./internal/spotify ./cmd/spogo`
- `go test -count=1 ./...`
- `git diff --check`
- Added focused regression coverage for Connect multi-track playback with both configured device names and configured device IDs. The name-selector test verifies the Web playback request receives `device_id=device-1`, not the human-readable name.
- Built the current branch locally and attempted live ordered playback against named Spotify devices (`iPhone`, then `receiver`). Spotify returned Web API `429` before playback, so successful live ordered-playback proof remains outstanding.

## AI assistance

Implemented with AI-assisted tooling and human review.