### PR TITLE
fix: surface Spotify rate-limit cooldowns

### DIFF
--- a/internal/spotify/client_retry_test.go
+++ b/internal/spotify/client_retry_test.go
@@ -3,8 +3,10 @@ package spotify
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -57,5 +59,67 @@ func TestClientRetriesOnRateLimit(t *testing.T) {
 	}
 	if provider.calls < 2 {
 		t.Fatalf("expected token refresh, got %d calls", provider.calls)
+	}
+}
+
+// TestClientRetriesRateLimitedMutationAndSurfacesRetryAfter proves the default
+// retry policy is unchanged: a mutating request (PUT /me/player/play) is still
+// retried across all attempts on repeated 429s, and the final surfaced error
+// carries the Retry-After from the last response so callers can see the
+// cooldown.
+func TestClientRetriesRateLimitedMutationAndSurfacesRetryAfter(t *testing.T) {
+	provider := &countingTokenProvider{}
+	requests := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/me/player/play", func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		// Non-final attempts advertise a short cooldown to keep the retry
+		// delay small; the final attempt advertises the real cooldown that
+		// must be surfaced to the caller.
+		if requests < 3 {
+			w.Header().Set("Retry-After", "1")
+		} else {
+			w.Header().Set("Retry-After", "42")
+		}
+		w.WriteHeader(http.StatusTooManyRequests)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"status":  http.StatusTooManyRequests,
+				"message": "rate limit",
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client, err := NewClient(Options{
+		TokenProvider: provider,
+		BaseURL:       srv.URL,
+		HTTPClient:    srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+
+	err = client.Play(context.Background(), "spotify:track:t1")
+	if err == nil {
+		t.Fatalf("expected rate limit error")
+	}
+	// Default policy retries all methods across the full 3 attempts.
+	if requests != 3 {
+		t.Fatalf("expected 3 requests, got %d", requests)
+	}
+	var apiErr APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected APIError, got %T", err)
+	}
+	if apiErr.Status != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", apiErr.Status)
+	}
+	if apiErr.RetryAfter != 42*time.Second {
+		t.Fatalf("retry after = %v, want 42s", apiErr.RetryAfter)
+	}
+	if !strings.Contains(apiErr.Error(), "retry after 42s") {
+		t.Fatalf("expected retry-after in error string, got %q", apiErr.Error())
 	}
 }

--- a/internal/spotify/client_retry_test.go
+++ b/internal/spotify/client_retry_test.go
@@ -66,7 +66,8 @@ func TestClientRetriesOnRateLimit(t *testing.T) {
 // retry policy is unchanged: a mutating request (PUT /me/player/play) is still
 // retried across all attempts on repeated 429s, and the final surfaced error
 // carries the Retry-After from the last response so callers can see the
-// cooldown.
+// cooldown hint. The hint is Spotify's earliest-retry guidance, not a
+// guarantee that waiting it out clears the rate limit.
 func TestClientRetriesRateLimitedMutationAndSurfacesRetryAfter(t *testing.T) {
 	provider := &countingTokenProvider{}
 	requests := 0
@@ -119,7 +120,7 @@ func TestClientRetriesRateLimitedMutationAndSurfacesRetryAfter(t *testing.T) {
 	if apiErr.RetryAfter != 42*time.Second {
 		t.Fatalf("retry after = %v, want 42s", apiErr.RetryAfter)
 	}
-	if !strings.Contains(apiErr.Error(), "retry after 42s") {
-		t.Fatalf("expected retry-after in error string, got %q", apiErr.Error())
+	if !strings.Contains(apiErr.Error(), "retry-after hint 42s") {
+		t.Fatalf("expected retry-after hint in error string, got %q", apiErr.Error())
 	}
 }

--- a/internal/spotify/errors.go
+++ b/internal/spotify/errors.go
@@ -6,23 +6,30 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"time"
 )
 
 var ErrNoContent = fmt.Errorf("no content")
 var ErrUnsupported = errors.New("unsupported operation")
 
 type APIError struct {
-	Status  int
-	Message string
-	Body    string
+	Status     int
+	Message    string
+	Body       string
+	RetryAfter time.Duration
 }
 
 func (e APIError) Error() string {
+	suffix := ""
+	if e.RetryAfter > 0 {
+		suffix = fmt.Sprintf(" (retry after %s)", e.RetryAfter.Round(time.Second))
+	}
 	if e.Message != "" {
-		return fmt.Sprintf("spotify api error (%d): %s", e.Status, e.Message)
+		return fmt.Sprintf("spotify api error (%d): %s%s", e.Status, e.Message, suffix)
 	}
 	if e.Status != 0 {
-		return fmt.Sprintf("spotify api error (%d)", e.Status)
+		return fmt.Sprintf("spotify api error (%d)%s", e.Status, suffix)
 	}
 	return "spotify api error"
 }
@@ -47,5 +54,30 @@ func apiErrorFromResponse(resp *http.Response) error {
 	if message == "" {
 		message = payload.Message
 	}
-	return APIError{Status: status, Message: message, Body: string(body)}
+	return APIError{Status: status, Message: message, Body: string(body), RetryAfter: retryAfterFromResponse(resp)}
+}
+
+func retryAfterFromResponse(resp *http.Response) time.Duration {
+	if resp == nil {
+		return 0
+	}
+	header := resp.Header.Get("Retry-After")
+	if header == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(header); err == nil {
+		if seconds <= 0 {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+	when, err := http.ParseTime(header)
+	if err != nil {
+		return 0
+	}
+	delay := time.Until(when)
+	if delay <= 0 {
+		return 0
+	}
+	return delay
 }

--- a/internal/spotify/errors.go
+++ b/internal/spotify/errors.go
@@ -69,8 +69,9 @@ func retryAfterFromResponse(resp *http.Response) time.Duration {
 	if header == "" {
 		return 0
 	}
-	if seconds, err := strconv.Atoi(header); err == nil {
-		if seconds <= 0 {
+	if seconds, err := strconv.ParseInt(header, 10, 64); err == nil {
+		const maxDurationSeconds = int64(^uint64(0)>>1) / int64(time.Second)
+		if seconds <= 0 || seconds > maxDurationSeconds {
 			return 0
 		}
 		return time.Duration(seconds) * time.Second

--- a/internal/spotify/errors.go
+++ b/internal/spotify/errors.go
@@ -14,16 +14,20 @@ var ErrNoContent = fmt.Errorf("no content")
 var ErrUnsupported = errors.New("unsupported operation")
 
 type APIError struct {
-	Status     int
-	Message    string
-	Body       string
+	Status  int
+	Message string
+	Body    string
+	// RetryAfter is the cooldown Spotify advertised via the Retry-After header.
+	// It is guidance for the earliest sensible retry, not a promise that the
+	// next request will succeed: Spotify may answer a post-cooldown retry with
+	// another 429 and a fresh Retry-After.
 	RetryAfter time.Duration
 }
 
 func (e APIError) Error() string {
 	suffix := ""
 	if e.RetryAfter > 0 {
-		suffix = fmt.Sprintf(" (retry after %s)", e.RetryAfter.Round(time.Second))
+		suffix = fmt.Sprintf(" (retry-after hint %s)", e.RetryAfter.Round(time.Second))
 	}
 	if e.Message != "" {
 		return fmt.Sprintf("spotify api error (%d): %s%s", e.Status, e.Message, suffix)

--- a/internal/spotify/errors_test.go
+++ b/internal/spotify/errors_test.go
@@ -45,8 +45,8 @@ func TestAPIErrorFromResponseRetryAfter(t *testing.T) {
 	if apiErr.RetryAfter != 42*time.Second {
 		t.Fatalf("retry after = %v, want 42s", apiErr.RetryAfter)
 	}
-	if !strings.Contains(apiErr.Error(), "retry after 42s") {
-		t.Fatalf("expected retry-after in error string, got %q", apiErr.Error())
+	if !strings.Contains(apiErr.Error(), "retry-after hint 42s") {
+		t.Fatalf("expected retry-after hint in error string, got %q", apiErr.Error())
 	}
 }
 

--- a/internal/spotify/errors_test.go
+++ b/internal/spotify/errors_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestAPIErrorFromResponse(t *testing.T) {
@@ -25,6 +26,47 @@ func TestAPIErrorFromResponseNil(t *testing.T) {
 	err := apiErrorFromResponse(nil)
 	if err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestAPIErrorFromResponseRetryAfter(t *testing.T) {
+	body := io.NopCloser(strings.NewReader(`{"error":{"status":429,"message":"rate limit"}}`))
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Status:     "429",
+		Header:     http.Header{"Retry-After": []string{"42"}},
+		Body:       body,
+	}
+	err := apiErrorFromResponse(resp)
+	var apiErr APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected APIError")
+	}
+	if apiErr.RetryAfter != 42*time.Second {
+		t.Fatalf("retry after = %v, want 42s", apiErr.RetryAfter)
+	}
+	if !strings.Contains(apiErr.Error(), "retry after 42s") {
+		t.Fatalf("expected retry-after in error string, got %q", apiErr.Error())
+	}
+}
+
+func TestAPIErrorFromResponseRetryAfterHTTPDate(t *testing.T) {
+	when := time.Now().Add(30 * time.Second).UTC().Format(http.TimeFormat)
+	body := io.NopCloser(strings.NewReader(`{"error":{"status":429,"message":"rate limit"}}`))
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Status:     "429",
+		Header:     http.Header{"Retry-After": []string{when}},
+		Body:       body,
+	}
+	err := apiErrorFromResponse(resp)
+	var apiErr APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected APIError")
+	}
+	// HTTP-date has one-second granularity, so allow a small window below 30s.
+	if apiErr.RetryAfter <= 25*time.Second || apiErr.RetryAfter > 30*time.Second {
+		t.Fatalf("retry after = %v, want ~30s from HTTP-date", apiErr.RetryAfter)
 	}
 }
 

--- a/internal/spotify/errors_test.go
+++ b/internal/spotify/errors_test.go
@@ -70,6 +70,13 @@ func TestAPIErrorFromResponseRetryAfterHTTPDate(t *testing.T) {
 	}
 }
 
+func TestRetryAfterFromResponseRejectsDurationOverflow(t *testing.T) {
+	resp := &http.Response{Header: http.Header{"Retry-After": []string{"9223372037"}}}
+	if got := retryAfterFromResponse(resp); got != 0 {
+		t.Fatalf("retry after = %v, want 0 for duration overflow", got)
+	}
+}
+
 func TestAPIErrorError(t *testing.T) {
 	err := APIError{Status: 400, Message: "bad"}
 	if err.Error() == "" {


### PR DESCRIPTION
"## Summary\n\nSurfaces Spotify Web API `Retry-After` cooldown hints on `APIError` so CLI callers and agents can see Spotify's advertised earliest-retry guidance after a 429.\n\nExample surfaced error shape:\n\n```text\nspotify api error (429): API rate limit exceeded (retry-after hint 42s)\n```\n\n## Why this is still useful\n\nSpotify's `Retry-After` value is **not** a guarantee that the next request will succeed after that duration. Live probes during #40 showed a request can wait out the advertised cooldown and still receive another 429 with a fresh `Retry-After` value.\n\nThis PR is still valuable because it makes Spotify's hidden cooldown hint visible instead of collapsing every 429 into a generic error. That gives agents and scripts enough context to back off, schedule a later attempt, or explain the current blocker without guessing.\n\n## What changed\n\n- Adds `RetryAfter time.Duration` to `APIError`.\n- Parses `Retry-After` from Spotify responses in both supported HTTP forms:\n  - integer seconds, e.g. `Retry-After: 42`\n  - HTTP-date, e.g. `Retry-After: Tue, 14 Jul 2026 18:30:00 GMT`\n- Includes the parsed cooldown in `APIError.Error()` as a `retry-after hint`, making clear it is guidance rather than a success timer.\n- Adds focused tests for seconds parsing, HTTP-date parsing, and retry exhaustion surfacing the final cooldown hint.\n\n## Scope boundary\n\nThis PR intentionally does **not** change spogo's retry behavior. The retry loop remains unchanged from `main`: same 3 attempts, same delay logic, same 3s cap, and the same retry policy for mutating requests.\n\nA possible future developer opportunity is to revisit whether Spotify write requests should honor long `Retry-After` values, fail fast with better guidance, or avoid retrying inside the same limit window. That is deliberately out of scope here; this PR only makes Spotify's cooldown hint visible to callers.\n\nThis is separate from #40, which is about ordered track-list playback.\n\n## Evidence\n\nCurrent head: `e23782812bea5f2a3f1e3a4ff9ddd6538f1eb28c`\\n\\nLive Spotify proof (2026-07-16 20:13 UTC): a temporary local harness built from this exact head instantiated the production `spotify.Client` with authenticated cookies and called the real `GET /v1/me/player/devices` endpoint. Tokens, cookies, account data, device names/IDs, and local paths are omitted. The real Spotify response traversed the unchanged three-attempt request path and surfaced the new final error text:\\n\\n```text\\n$ go run ./pr41_live_proof.go\\nspotify api error (429): API rate limit exceeded (retry-after hint 36s)\\n```\\n\n- `go test -count=1 ./internal/spotify`\n- `go test -count=1 ./...`\n- `go build ./...`\n- `git diff --check`\n\nRegression note: `internal/spotify/client_request.go` is unchanged versus `main`. `TestClientRetriesRateLimitedMutationAndSurfacesRetryAfter` proves a mutating `PUT /me/player/play` still makes 3 attempts on repeated 429s, and the final surfaced `APIError` includes the final `Retry-After` hint.\n\nRelated context: #20 reported hard-to-debug Spotify 429 write behavior, but this PR does not claim to fix the underlying throttling.\n\n## AI assistance\n\nImplemented with AI-assisted tooling and human review.\n"
