### PR TITLE
ci: migrate releases to unified pipeline

### DIFF
--- a/.github/workflows/release-legacy.yml
+++ b/.github/workflows/release-legacy.yml
@@ -1,13 +1,12 @@
-name: release
+# Legacy publishing fallback retained by migration policy. Tags do not trigger it.
+# This path bypasses unified signing and notarization; use only with explicit approval.
+name: Release (legacy manual fallback)
 
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to (re)release (e.g. v0.1.0)"
+        description: "Existing tag to release (for example, v0.10.1)"
         required: true
         type: string
 
@@ -33,7 +32,6 @@ jobs:
         run: cp .goreleaser.yaml /tmp/.goreleaser.yaml
 
       - name: Checkout release tag
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: git checkout ${{ inputs.tag }}
 
       - name: GoReleaser
@@ -50,12 +48,7 @@ jobs:
     needs: goreleaser
     steps:
       - name: Resolve release tag
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "RELEASE_TAG=${{ inputs.tag }}" >> "$GITHUB_ENV"
-          else
-            echo "RELEASE_TAG=${{ github.ref_name }}" >> "$GITHUB_ENV"
-          fi
+        run: echo "RELEASE_TAG=${{ inputs.tag }}" >> "$GITHUB_ENV"
 
       - name: Dispatch tap formula update
         env:

--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -1,0 +1,33 @@
+name: Release (unified)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (for example, 0.10.2)"
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  release:
+    permissions:
+      actions: read
+      checks: read
+      contents: write
+      pull-requests: write
+      statuses: read
+    uses: openclaw/release-workflows/.github/workflows/release-go-cli.yml@v1.0.0-alpha.12
+    with:
+      version: ${{ inputs.version }}
+      repository-type: openclaw
+      homebrew-tap: steipete/homebrew-tap
+      homebrew-formula: spogo
+    secrets:
+      MACOS_SIGNING_P12: ${{ secrets.MACOS_SIGNING_P12 }}
+      MACOS_SIGNING_P12_PASSWORD: ${{ secrets.MACOS_SIGNING_P12_PASSWORD }}
+      ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+      ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+      ASC_PRIVATE_KEY_P8: ${{ secrets.ASC_PRIVATE_KEY_P8 }}
+      TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-## 0.10.2 - Unreleased
+## 0.10.2 - 2026-07-18
+
+### Highlights
+
+- Ship the first spogo release through the unified signed pipeline, using the OpenClaw Foundation Developer ID and Apple notarization for every macOS binary
+
+### Release engineering
+
+- Replace the tag-triggered release workflow with a thin, manually dispatched caller pinned to `openclaw/release-workflows@v1.0.0-alpha.12`
+- Bind published release notes byte-for-byte to this dated changelog section and verify immutable artifacts before publication
+- Hand verified release metadata to the Homebrew tap updater after publication
 
 ## 0.10.1 - 2026-07-17
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -35,32 +35,37 @@ gh run list -L 5 --branch main
 Example heading:
 - `## 0.1.0 - 2026-01-02`
 
-## 3) Commit, tag & push
+## 3) Merge the release prep
 ```sh
 git checkout main
-git pull
+git pull --ff-only
 
-# commit changelog + any release tweaks
-git commit -am "release: vX.Y.Z"
-
-git tag -a vX.Y.Z -m "Release X.Y.Z"
-git push origin main --tags
+# Commit the dated changelog section and any release tweaks on a PR.
+# Merge only after required CI is green.
 ```
 
-## 4) Verify GitHub release artifacts
-The tag push triggers `.github/workflows/release.yml` (GoReleaser). Ensure it completes successfully and the release has assets.
+Do not create or push the release tag manually. The unified workflow freezes the release source and creates the tag.
+
+## 4) Dispatch and verify the unified release
+
+Run the thin caller with the version without a `v` prefix:
 
 ```sh
-gh run list -L 5 --workflow release.yml
-gh release view vX.Y.Z
+gh workflow run release-unified.yml -f version=X.Y.Z
+gh run list -L 5 --workflow release-unified.yml
+gh run watch <run-id> --exit-status
 ```
 
-Ensure GitHub release notes are not empty (mirror the changelog section).
+Watch validation, tag creation, build/sign/notarize, draft creation, independent verification, publication, Homebrew handoff, and closeout. The legacy workflow in `release-legacy.yml` is manual-only and is not the production release path.
 
-If the workflow needs a rerun:
-```sh
-gh workflow run release.yml -f tag=vX.Y.Z
-```
+After success:
+
+- Download every published asset listed in `SHA256SUMS` and verify its SHA-256 digest.
+- Run `codesign --verify --strict --check-notarization` on every macOS binary and confirm its designated requirement is stable.
+- Confirm published release notes are byte-identical to the dated changelog section.
+- Confirm the `spogo` formula in the Homebrew tap points at the new version and matching SHA-256 hashes.
+- Confirm the closeout PR merged and opened the next `Unreleased` changelog section.
 
 ## Notes
 - GoReleaser publishes binaries for macOS, Linux, and Windows.
+- macOS binaries are signed with the OpenClaw Foundation Developer ID and notarized by Apple.


### PR DESCRIPTION
## Summary

- migrate releases to the unified Go CLI workflow at `v1.0.0-alpha.12`
- keep OpenClaw Foundation signing while routing Homebrew handoff to `steipete/homebrew-tap`
- retire tag-triggered legacy publishing and update the release runbook
- prepare the curated `0.10.2` changelog section

## Verification

- `actionlint .github/workflows/release-unified.yml .github/workflows/release-legacy.yml`
- `./scripts/lint.sh`
- `./scripts/check-coverage.sh 90` (`90.5%`)

No release dispatch in this PR.
