### PR TITLE
chore: open next Unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## 0.10.2 - 2026-07-18
 
 ### Highlights


### PR DESCRIPTION
Opens the next Unreleased changelog section after the verified release.

Created by the fleet release closeout stage.
