### PR TITLE
fix: stamp release version from GoReleaser

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -18,7 +18,7 @@ jobs:
       contents: write
       pull-requests: write
       statuses: read
-    uses: openclaw/release-workflows/.github/workflows/release-go-cli.yml@v1.0.0-alpha.12
+    uses: openclaw/release-workflows/.github/workflows/release-go-cli.yml@v1.0.0-alpha.13
     with:
       version: ${{ inputs.version }}
       repository-type: openclaw

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,8 @@ builds:
     binary: spogo
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/steipete/spogo/internal/cli.version={{ .Version }}
     targets:
       - linux_amd64
       - linux_arm64
@@ -21,6 +23,8 @@ builds:
     binary: spogo
     env:
       - CGO_ENABLED=1
+    ldflags:
+      - -s -w -X github.com/steipete/spogo/internal/cli.version={{ .Version }}
     targets:
       - darwin_amd64
       - darwin_arm64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
-## Unreleased
+## 0.10.3 - 2026-07-18
+
+### Highlights
+
+- Make release and Homebrew-installed binaries report their actual tagged version
+
+### Fixed
+
+- Stamp the CLI version from the GoReleaser tag while retaining a `dev` fallback for every unstamped build
+- Remove stale hardcoded `0.10.1` version labels from the CLI and specification
+
+### Release engineering
+
+- Upgrade the unified release caller to `openclaw/release-workflows@v1.0.0-alpha.13`, including exact verified asset names and SHA-256 digests in the Homebrew handoff
 
 ## 0.10.2 - 2026-07-18
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,4 +1,4 @@
-# spogo CLI spec (v0.10.1)
+# spogo CLI spec
 
 One-liner: Spotify power CLI using web cookies; search + playback control.
 Parser: Kong.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -10,8 +10,6 @@ import (
 	"github.com/steipete/spogo/internal/output"
 )
 
-const Version = "0.10.1"
-
 func New() *CLI {
 	return &CLI{}
 }
@@ -100,10 +98,10 @@ func outputFormat(jsonFlag, plainFlag bool) (output.Format, error) {
 
 func VersionVars() map[string]string {
 	return map[string]string{
-		"version": Version,
+		"version": currentVersion(),
 	}
 }
 
 func Usage() string {
-	return fmt.Sprintf("spogo %s", Version)
+	return fmt.Sprintf("spogo %s", currentVersion())
 }

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,0 +1,14 @@
+package cli
+
+import (
+	"strings"
+)
+
+var version = "dev"
+
+func currentVersion() string {
+	if linkedVersion := strings.TrimPrefix(strings.TrimSpace(version), "v"); linkedVersion != "" {
+		return linkedVersion
+	}
+	return "dev"
+}

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import "testing"
+
+func TestResolveVersion(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		linked string
+		want   string
+	}{
+		{name: "release linker override", linked: "0.10.3", want: "0.10.3"},
+		{name: "release linker override with prefix", linked: " v0.10.3 ", want: "0.10.3"},
+		{name: "local build", linked: "dev", want: "dev"},
+		{name: "missing linker value", want: "dev"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			original := version
+			version = test.linked
+			t.Cleanup(func() { version = original })
+			if got := currentVersion(); got != test.want {
+				t.Fatalf("currentVersion() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- stamp release versions from the GoReleaser tag through linker flags
- keep unstamped builds on the explicit `dev` fallback and remove stale 0.10.1 labels
- prepare the dated 0.10.3 changelog and pin the unified caller to alpha.13

## Proof

- `./scripts/check-coverage.sh 90` (90.5%)
- `golangci-lint run` (0 issues)
- `go run golang.org/x/tools/cmd/deadcode@v0.47.0 -test ./...`
- `goreleaser check`
- GoReleaser snapshot binary reports its generated snapshot version
- source-blind CLI checks: unstamped `dev`, stamped `0.10.3`, stable repeat output, invalid command exit 2
- actionlint
- AutoReview clean
