### PR TITLE
ci: use v1 release workflow

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -18,7 +18,7 @@ jobs:
       contents: write
       pull-requests: write
       statuses: read
-    uses: openclaw/release-workflows/.github/workflows/release-go-cli.yml@v1.0.0-alpha.13
+    uses: openclaw/release-workflows/.github/workflows/release-go-cli.yml@v1
     with:
       version: ${{ inputs.version }}
       repository-type: openclaw


### PR DESCRIPTION
## Summary

- switch the unified release caller from the alpha.13 implementation tag to the promoted `@v1` compatibility tag
- retain the existing OpenClaw signing and steipete/homebrew-tap contract

## Proof

- `v1` is an annotated tag peeling to the proven alpha.13 commit `8a393a95f56a3932935fbe28e30d8b14bce1eb99`
- actionlint
- AutoReview clean

No release dispatch.
