### PR TITLE
fix(web): bound CookieTokenProvider HTTP client timeout

### DIFF
--- a/internal/app/context_factory.go
+++ b/internal/app/context_factory.go
@@ -101,7 +101,7 @@ func (c *Context) newConnectClient(source cookies.Source) (*spotify.ConnectClien
 
 func (c *Context) newWebClient(source cookies.Source) (*spotify.Client, error) {
 	return spotify.NewClient(spotify.Options{
-		TokenProvider: spotify.CookieTokenProvider{Source: source},
+		TokenProvider: spotify.CookieTokenProvider{Source: source, Timeout: c.Settings.Timeout},
 		Market:        c.Profile.Market,
 		Language:      c.Profile.Language,
 		Device:        c.Profile.Device,

--- a/internal/spotify/client.go
+++ b/internal/spotify/client.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+const defaultHTTPClientTimeout = 10 * time.Second
+
 type Options struct {
 	TokenProvider TokenProvider
 	HTTPClient    *http.Client
@@ -44,7 +46,7 @@ func NewClient(opts Options) (*Client, error) {
 	if client == nil {
 		timeout := opts.Timeout
 		if timeout == 0 {
-			timeout = 10 * time.Second
+			timeout = defaultHTTPClientTimeout
 		}
 		client = &http.Client{Timeout: timeout}
 	}

--- a/internal/spotify/token.go
+++ b/internal/spotify/token.go
@@ -39,6 +39,10 @@ type tokenResponse struct {
 	ClientID                       string `json:"clientId"`
 }
 
+func newCookieTokenHTTPClient(jar http.CookieJar) *http.Client {
+	return &http.Client{Jar: jar, Timeout: defaultHTTPClientTimeout}
+}
+
 func (p CookieTokenProvider) Token(ctx context.Context) (Token, error) {
 	if p.Source == nil {
 		return Token{}, errors.New("cookie source required")
@@ -62,7 +66,7 @@ func (p CookieTokenProvider) Token(ctx context.Context) (Token, error) {
 	jar.SetCookies(baseURL, cookiesList)
 	client := p.Client
 	if client == nil {
-		client = &http.Client{Jar: jar}
+		client = newCookieTokenHTTPClient(jar)
 	} else {
 		client.Jar = jar
 	}

--- a/internal/spotify/token.go
+++ b/internal/spotify/token.go
@@ -41,7 +41,7 @@ type tokenResponse struct {
 }
 
 func newCookieTokenHTTPClient(jar http.CookieJar, timeout time.Duration) *http.Client {
-	if timeout <= 0 {
+	if timeout == 0 {
 		timeout = defaultHTTPClientTimeout
 	}
 	return &http.Client{Jar: jar, Timeout: timeout}

--- a/internal/spotify/token.go
+++ b/internal/spotify/token.go
@@ -29,6 +29,7 @@ type CookieTokenProvider struct {
 	Source  cookies.Source
 	BaseURL string
 	Client  *http.Client
+	Timeout time.Duration
 }
 
 type tokenResponse struct {
@@ -39,8 +40,11 @@ type tokenResponse struct {
 	ClientID                       string `json:"clientId"`
 }
 
-func newCookieTokenHTTPClient(jar http.CookieJar) *http.Client {
-	return &http.Client{Jar: jar, Timeout: defaultHTTPClientTimeout}
+func newCookieTokenHTTPClient(jar http.CookieJar, timeout time.Duration) *http.Client {
+	if timeout <= 0 {
+		timeout = defaultHTTPClientTimeout
+	}
+	return &http.Client{Jar: jar, Timeout: timeout}
 }
 
 func (p CookieTokenProvider) Token(ctx context.Context) (Token, error) {
@@ -66,7 +70,7 @@ func (p CookieTokenProvider) Token(ctx context.Context) (Token, error) {
 	jar.SetCookies(baseURL, cookiesList)
 	client := p.Client
 	if client == nil {
-		client = newCookieTokenHTTPClient(jar)
+		client = newCookieTokenHTTPClient(jar, p.Timeout)
 	} else {
 		client.Jar = jar
 	}

--- a/internal/spotify/token_test.go
+++ b/internal/spotify/token_test.go
@@ -94,11 +94,40 @@ func TestCookieTokenProviderMissingToken(t *testing.T) {
 }
 
 func TestCookieTokenProviderFallbackClientTimeout(t *testing.T) {
-	client := newCookieTokenHTTPClient(nil)
-	if client.Timeout == 0 {
-		t.Fatal("fallback HTTP client must set Timeout so cookie token fetches cannot hang")
+	client := newCookieTokenHTTPClient(nil, 0)
+	if client.Timeout != defaultHTTPClientTimeout {
+		t.Fatalf("fallback HTTP client Timeout=%s want %s", client.Timeout, defaultHTTPClientTimeout)
 	}
-	t.Logf("fallback client Timeout=%s", client.Timeout)
+}
+
+func TestCookieTokenProviderHonorsConfiguredTimeout(t *testing.T) {
+	want := 1500 * time.Millisecond
+	client := newCookieTokenHTTPClient(nil, want)
+	if client.Timeout != want {
+		t.Fatalf("Timeout=%s want %s", client.Timeout, want)
+	}
+	restore := SetTotpSecretFetcher(func(ctx context.Context) (int, []byte, error) {
+		return 1, []byte{1, 2, 3, 4}, nil
+	})
+	t.Cleanup(restore)
+	started := time.Now()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		time.Sleep(2 * time.Second)
+	}))
+	t.Cleanup(srv.Close)
+	provider := CookieTokenProvider{
+		Source:  stubCookieSource{},
+		BaseURL: srv.URL + "/",
+		Timeout: 200 * time.Millisecond,
+	}
+	_, err := provider.Token(context.Background())
+	elapsed := time.Since(started)
+	if err == nil {
+		t.Fatal("expected configured timeout to fail a stalled token endpoint")
+	}
+	if elapsed >= time.Second {
+		t.Fatalf("elapsed %s, wanted the 200ms configured timeout", elapsed)
+	}
 }
 
 type countingProvider struct {

--- a/internal/spotify/token_test.go
+++ b/internal/spotify/token_test.go
@@ -100,6 +100,16 @@ func TestCookieTokenProviderFallbackClientTimeout(t *testing.T) {
 	}
 }
 
+func TestCookieTokenProviderPreservesNegativeTimeout(t *testing.T) {
+	// NewClient and NewConnectClient default only a zero timeout.
+	// A configured negative duration must stay unlimited, not 10s.
+	want := -time.Second
+	client := newCookieTokenHTTPClient(nil, want)
+	if client.Timeout != want {
+		t.Fatalf("Timeout=%s want %s", client.Timeout, want)
+	}
+}
+
 func TestCookieTokenProviderHonorsConfiguredTimeout(t *testing.T) {
 	want := 1500 * time.Millisecond
 	client := newCookieTokenHTTPClient(nil, want)

--- a/internal/spotify/token_test.go
+++ b/internal/spotify/token_test.go
@@ -93,6 +93,14 @@ func TestCookieTokenProviderMissingToken(t *testing.T) {
 	}
 }
 
+func TestCookieTokenProviderFallbackClientTimeout(t *testing.T) {
+	client := newCookieTokenHTTPClient(nil)
+	if client.Timeout == 0 {
+		t.Fatal("fallback HTTP client must set Timeout so cookie token fetches cannot hang")
+	}
+	t.Logf("fallback client Timeout=%s", client.Timeout)
+}
+
 type countingProvider struct {
 	calls int
 }


### PR DESCRIPTION
## What Problem This Solves

`spogo --engine web` (and auto fallback to web) fetches a Spotify access token through `CookieTokenProvider`. When no HTTP client is injected, that provider builds `&http.Client{Jar}` with no `Timeout`. `newWebClient` does not pass the timed client that `NewClient` already uses for API calls. The CLI also sets `CommandContext` to `context.Background()`, so a stalled `open.spotify.com/api/token` peer can hang the process forever. The default connect engine is already safe because it shares a client that has a timeout.

## Evidence

Call chain: `cmd/spogo/main.go` sets `CommandContext` to `Background`, `internal/app/context_factory.go` `newWebClient` builds `CookieTokenProvider{Source: source, Timeout: c.Settings.Timeout}`, and `Token()` falls back through `newCookieTokenHTTPClient`.

Introduced in the original CLI bootstrap ([`07a219b670d4`](https://github.com/openclaw/spogo/commit/07a219b670d4f10414800558c491869013b4548d), 2026-01-02, Peter Steinberger). Present for 225 days.

Same class as [openclaw/slacrawl#126](https://github.com/openclaw/slacrawl/pull/126) (merged): a nil HTTP client used `http.DefaultClient` / zero `Timeout` and could hang when the ambient context had no deadline.

Live `go run` against a server that never writes a response, using the 10s default:

```console
$ go run /tmp/proof-spogo-token-timeout.go
fallback Timeout=10s
bounded GET err=Get "http://127.0.0.1:56717": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
elapsed=10s
```

`--timeout` / `SPOGO_TIMEOUT` now reach the cookie-token client. A 200ms configured timeout against a stalled endpoint fails at that budget instead of waiting 10s.

```console
$ go test ./internal/spotify/ -count=1 -run 'TestCookieTokenProvider(FallbackClientTimeout|HonorsConfiguredTimeout)' -v
--- PASS: TestCookieTokenProviderFallbackClientTimeout
--- PASS: TestCookieTokenProviderHonorsConfiguredTimeout
```

Public CLI path after the patch (does not hang; Spotify returned a 400 for this profile):

```console
$ /tmp/spogo-web-timeout --engine web --timeout 10s status
spotify api error (400): Invalid user provided
spogo_exit=1
```

## Real behavior proof

- **Behavior or issue addressed:** CookieTokenProvider fallback HTTP client had no Timeout, so `spogo --engine web` could hang on a stalled token endpoint because CommandContext is Background. The fallback now uses `Settings.Timeout` (10s when unset).
- **Real environment tested:** macOS 15 (Darwin 25.6.0 arm64), Go 1.26.5, branch `fix/web-token-client-timeout` at `/tmp/oc-impl-spogo-timeout-full`, built `./cmd/spogo` to `/tmp/spogo-web-timeout`.
- **Exact steps or command run after this patch:** Built the CLI. Ran `spogo --engine web --timeout 10s status`. Ran `go run /tmp/proof-spogo-token-timeout.go` against a local server that never writes headers. Ran `go test ./internal/spotify/ ./internal/app/` including the 200ms stalled-endpoint case.
- **Evidence after fix:** terminal output from the patched CLI and the bounded GET:

  ```console
  $ /tmp/spogo-web-timeout --engine web --timeout 10s status
  spotify api error (400): Invalid user provided

  $ go run /tmp/proof-spogo-token-timeout.go
  fallback Timeout=10s
  bounded GET err=Get "http://127.0.0.1:56717": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
  elapsed=10s
  ```

- **Observed result after fix:** Default fallback Timeout is 10s when unset (zero). A configured negative duration stays negative, same as NewClient, and is not remapped to 10s. `newWebClient` passes `c.Settings.Timeout` into `CookieTokenProvider`. A stalled token endpoint with Timeout=200ms fails at that budget, not after 10s. `spogo --engine web status` returns instead of hanging.
- **What was not tested:** A live hung `open.spotify.com/api/token` peer. Connect-engine token fetches already inject a timed client and were left unchanged.

## Summary

Fallback cookie-token HTTP client now honors `--timeout` / `SPOGO_TIMEOUT` through `CookieTokenProvider.Timeout`, and still defaults to 10s when that value is unset (zero only). A configured negative duration stays unlimited, matching NewClient. Injected clients (connect path, tests that pass `Client`) are unchanged.

