### PR TITLE
fix: cache Connect GraphQL hashes, resolve requested entities, populate queue metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
-## Unreleased
+## 0.10.4 - 2026-08-23
+
+### Highlights
+
+- Cache Spotify Connect GraphQL operation hashes on disk, so catalog commands answer in seconds instead of re-downloading the web-player bundle on every run
+- Return the entity you actually asked for from `artist info`, `album info`, `show info`, and `episode info`
+- Show real titles, artists, albums, and durations for every `queue show` entry
+
+### Fixed
+
+- Persist Spotify Connect GraphQL operation hashes by web-player build and resolve missing bundle chunks concurrently
+- Resolve artist, album, show, and episode metadata from the requested Spotify entity instead of unrelated nested content
+- Populate queue tracks from Spotify Connect metadata and concurrently hydrate incomplete entries without using the public Web API
+- Redact Spotify access tokens from Connect dealer WebSocket handshake errors
 
 ## 0.10.3 - 2026-07-18
 

--- a/internal/spotify/connect_cache.go
+++ b/internal/spotify/connect_cache.go
@@ -27,6 +27,9 @@ type connectCache struct {
 	ConnectVersion         string `json:"connect_version,omitempty"`
 	DeviceID               string `json:"device_id,omitempty"`
 	ConnectDeviceID        string `json:"connect_device_id,omitempty"`
+	// GraphQL operation hashes belong to the web-player client build.
+	OperationHashesClientVersion string            `json:"operation_hashes_client_version,omitempty"`
+	OperationHashes              map[string]string `json:"operation_hashes,omitempty"`
 
 	ActiveDeviceID string `json:"active_device_id,omitempty"`
 	OriginDeviceID string `json:"origin_device_id,omitempty"`

--- a/internal/spotify/connect_client_test.go
+++ b/internal/spotify/connect_client_test.go
@@ -32,14 +32,34 @@ func TestConnectInfoOperations(t *testing.T) {
 			"data": map[string]any{"playlist": map[string]any{"uri": "spotify:playlist:p1", "name": "Playlist"}},
 		},
 		"queryPodcastEpisodes": {
-			"data": map[string]any{"show": map[string]any{"uri": "spotify:show:s1", "name": "Show"}},
+			"data": map[string]any{"podcastUnionV2": map[string]any{"uri": "spotify:show:s1", "name": "Show"}},
 		},
 		"getEpisodeOrChapter": {
-			"data": map[string]any{"episode": map[string]any{"uri": "spotify:episode:e1", "name": "Episode"}},
+			"data": map[string]any{"episodeUnionV2": map[string]any{"uri": "spotify:episode:e1", "name": "Episode"}},
 		},
 	}
 	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		op := req.URL.Query().Get("operationName")
+		if op == "getAlbum" || op == "queryPodcastEpisodes" || op == "getEpisodeOrChapter" {
+			var variables map[string]any
+			if err := json.Unmarshal([]byte(req.URL.Query().Get("variables")), &variables); err != nil {
+				t.Fatalf("decode %s variables: %v", op, err)
+			}
+			switch op {
+			case "getAlbum":
+				if variables["uri"] != "spotify:album:a1" || variables["locale"] != "en-US" || variables["offset"] != float64(0) || variables["limit"] != float64(50) {
+					t.Fatalf("unexpected album variables: %#v", variables)
+				}
+			case "queryPodcastEpisodes":
+				if variables["uri"] != "spotify:show:s1" || variables["offset"] != float64(0) || variables["limit"] != float64(25) || variables["includeEpisodeContentRatingsV2"] != false {
+					t.Fatalf("unexpected show variables: %#v", variables)
+				}
+			case "getEpisodeOrChapter":
+				if variables["uri"] != "spotify:episode:e1" || variables["includeEpisodeContentRatingsV2"] != false {
+					t.Fatalf("unexpected episode variables: %#v", variables)
+				}
+			}
+		}
 		payload, ok := payloads[op]
 		if !ok {
 			return textResponse(http.StatusNotFound, "missing"), nil
@@ -47,6 +67,7 @@ func TestConnectInfoOperations(t *testing.T) {
 		return jsonResponse(http.StatusOK, payload), nil
 	})
 	client := newConnectClientForTests(transport)
+	client.language = "en-US"
 	for op := range payloads {
 		client.hashes.hashes[op] = "hash"
 	}

--- a/internal/spotify/connect_commands.go
+++ b/internal/spotify/connect_commands.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 )
+
+const queueHydrationConcurrency = 8
 
 func (c *ConnectClient) playback(ctx context.Context) (PlaybackStatus, error) {
 	return withConnectState(ctx, c, func(state connectState) (PlaybackStatus, error) {
@@ -151,8 +154,53 @@ func (c *ConnectClient) queueAdd(ctx context.Context, uri string) error {
 
 func (c *ConnectClient) queue(ctx context.Context) (Queue, error) {
 	return withConnectState(ctx, c, func(state connectState) (Queue, error) {
-		return mapQueue(state), nil
+		queue := mapQueue(state)
+		c.hydrateQueue(ctx, &queue)
+		return queue, nil
 	})
+}
+
+func (c *ConnectClient) hydrateQueue(ctx context.Context, queue *Queue) {
+	items := make([]*Item, 0, len(queue.Queue)+1)
+	if itemNeedsTrackMetadata(queue.CurrentlyPlaying) {
+		items = append(items, queue.CurrentlyPlaying)
+	}
+	for index := range queue.Queue {
+		if itemNeedsTrackMetadata(&queue.Queue[index]) {
+			items = append(items, &queue.Queue[index])
+		}
+	}
+	if len(items) == 0 || c.hashes == nil {
+		return
+	}
+	if _, err := c.hashes.Hash(ctx, "getTrack"); err != nil {
+		return
+	}
+	jobs := make(chan *Item)
+	var workers sync.WaitGroup
+	for range min(queueHydrationConcurrency, len(items)) {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for item := range jobs {
+				full, err := c.infoByOperation(ctx, "getTrack", map[string]any{"uri": item.URI}, "track")
+				if err == nil {
+					mergeItemMetadata(item, full)
+				}
+			}
+		}()
+	}
+	for _, item := range items {
+		select {
+		case jobs <- item:
+		case <-ctx.Done():
+			close(jobs)
+			workers.Wait()
+			return
+		}
+	}
+	close(jobs)
+	workers.Wait()
 }
 
 func (c *ConnectClient) sendStateCommand(ctx context.Context, endpoint string, payload map[string]any) error {

--- a/internal/spotify/connect_dealer_test.go
+++ b/internal/spotify/connect_dealer_test.go
@@ -3,6 +3,8 @@ package spotify
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -124,8 +126,20 @@ func TestGetConnectionIDDialError(t *testing.T) {
 	dealerURL = "ws://127.0.0.1:1"
 	t.Cleanup(func() { dealerURL = prev })
 
-	if _, err := getConnectionID(context.Background(), "token"); err == nil {
+	const accessToken = "sensitive-test-token"
+	_, err := getConnectionID(context.Background(), accessToken)
+	if err == nil {
 		t.Fatalf("expected error")
+	}
+	if strings.Contains(err.Error(), accessToken) {
+		t.Fatalf("dealer dial error exposed its access token")
+	}
+	if !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("dealer dial error omitted its redaction marker: %v", err)
+	}
+	var networkError net.Error
+	if !errors.As(err, &networkError) {
+		t.Fatalf("dealer dial error no longer unwraps to a network error: %T", err)
 	}
 }
 

--- a/internal/spotify/connect_extract_search.go
+++ b/internal/spotify/connect_extract_search.go
@@ -1,5 +1,7 @@
 package spotify
 
+import "strings"
+
 func extractSearchItems(payload map[string]any, kind string) ([]Item, int) {
 	for _, path := range searchPaths(kind) {
 		if container, ok := getMap(payload, path...); ok {
@@ -16,23 +18,130 @@ func extractSearchItems(payload map[string]any, kind string) ([]Item, int) {
 }
 
 func extractItemFromPayload(payload map[string]any, kind string) (Item, bool) {
-	if kind == "track" {
-		if m, ok := getMap(payload, "data", "trackUnion"); ok {
-			if item, ok := extractItem(m, kind); ok {
+	return extractRequestedItemFromPayload(payload, kind, "")
+}
+
+func extractRequestedItemFromPayload(payload map[string]any, kind, requestedURI string) (Item, bool) {
+	for _, key := range itemPayloadKeys(kind) {
+		if entity, ok := getMap(payload, "data", key); ok {
+			if item, ok := extractRequestedEntity(entity, kind, requestedURI); ok {
 				return item, true
 			}
 		}
-		if m, ok := getMap(payload, "data", "track"); ok {
-			if item, ok := extractItem(m, kind); ok {
+	}
+	if requestedURI != "" {
+		var matched map[string]any
+		walkMap(payload, func(candidate map[string]any) {
+			if matched == nil && entityMatchesURI(candidate, kind, requestedURI) {
+				matched = candidate
+			}
+		})
+		if matched != nil {
+			if item, ok := extractRequestedEntity(matched, kind, requestedURI); ok {
 				return item, true
 			}
 		}
 	}
 	items := collectItemsByKind(payload, kind)
-	if len(items) == 0 {
+	for _, item := range items {
+		if requestedURI == "" || item.URI == requestedURI {
+			return item, true
+		}
+	}
+	return Item{}, false
+}
+
+func itemPayloadKeys(kind string) []string {
+	switch kind {
+	case "track":
+		return []string{"trackUnion", "track"}
+	case "album":
+		return []string{"albumUnion", "album"}
+	case "artist":
+		return []string{"artistUnion", "artist"}
+	case "playlist":
+		return []string{"playlistV2", "playlist"}
+	case "show":
+		return []string{"podcastUnionV2", "podcastUnion", "showUnion", "podcast", "show"}
+	case "episode":
+		return []string{"episodeUnionV2", "episodeUnion", "episodeOrChapter", "episode"}
+	default:
+		return nil
+	}
+}
+
+func extractRequestedEntity(entity map[string]any, kind, requestedURI string) (Item, bool) {
+	if requestedURI != "" && !entityMatchesURI(entity, kind, requestedURI) {
 		return Item{}, false
 	}
-	return items[0], true
+	if kind == "artist" {
+		if profile, ok := getMap(entity, "profile"); ok {
+			if name := getString(profile, "name"); name != "" {
+				named := make(map[string]any, len(entity)+1)
+				for key, value := range entity {
+					named[key] = value
+				}
+				named["name"] = name
+				entity = named
+			}
+		}
+	}
+	item, ok := extractItem(entity, kind)
+	if !ok {
+		return Item{}, false
+	}
+	if kind == "artist" {
+		item.Followers = getNestedInt(entity, "stats", "followers")
+		if item.Followers == 0 {
+			item.Followers = getNestedInt(entity, "followers", "total")
+		}
+		item.Genres = extractEntityGenres(entity)
+	}
+	return item, true
+}
+
+func entityMatchesURI(entity map[string]any, kind, requestedURI string) bool {
+	if uri := getString(entity, "uri"); uri != "" {
+		return uri == requestedURI
+	}
+	return getString(entity, "id") == strings.TrimPrefix(requestedURI, "spotify:"+kind+":")
+}
+
+func extractEntityGenres(entity map[string]any) []string {
+	genres := extractGenreNames(entity["genres"])
+	if len(genres) == 0 {
+		if profile, ok := getMap(entity, "profile"); ok {
+			genres = extractGenreNames(profile["genres"])
+		}
+	}
+	return dedupeStrings(genres)
+}
+
+func extractGenreNames(value any) []string {
+	switch typed := value.(type) {
+	case []string:
+		return typed
+	case []any:
+		genres := make([]string, 0, len(typed))
+		for _, raw := range typed {
+			switch genre := raw.(type) {
+			case string:
+				genres = append(genres, genre)
+			case map[string]any:
+				if name := getString(genre, "name"); name != "" {
+					genres = append(genres, name)
+				}
+			}
+		}
+		return genres
+	case map[string]any:
+		for _, key := range []string{"items", "nodes"} {
+			if genres := extractGenreNames(typed[key]); len(genres) > 0 {
+				return genres
+			}
+		}
+	}
+	return nil
 }
 
 func searchPaths(kind string) [][]string {

--- a/internal/spotify/connect_hash.go
+++ b/internal/spotify/connect_hash.go
@@ -17,8 +17,16 @@ type hashResolver struct {
 	client  *http.Client
 	session *connectSession
 
-	mu     sync.Mutex
-	hashes map[string]string
+	mu            sync.Mutex
+	loadMu        sync.Mutex
+	hashes        map[string]string
+	clientVersion string
+}
+
+const hashChunkConcurrency = 8
+
+var commonGraphQLOperations = []string{
+	"getTrack", "getAlbum", "queryArtistOverview", "searchDesktop", "queryPodcastEpisodes", "getEpisodeOrChapter",
 }
 
 func newHashResolver(client *http.Client, session *connectSession) *hashResolver {
@@ -33,6 +41,7 @@ func (h *hashResolver) Hash(ctx context.Context, operation string) (string, erro
 	if operation == "" {
 		return "", errors.New("operation required")
 	}
+	h.loadCachedHashes()
 	h.mu.Lock()
 	if hash, ok := h.hashes[operation]; ok && hash != "" {
 		h.mu.Unlock()
@@ -52,6 +61,9 @@ func (h *hashResolver) Hash(ctx context.Context, operation string) (string, erro
 }
 
 func (h *hashResolver) load(ctx context.Context, ops []string) error {
+	h.loadMu.Lock()
+	defer h.loadMu.Unlock()
+	h.loadCachedHashes()
 	h.mu.Lock()
 	need := make([]string, 0, len(ops))
 	for _, op := range ops {
@@ -59,10 +71,17 @@ func (h *hashResolver) load(ctx context.Context, ops []string) error {
 			need = append(need, op)
 		}
 	}
-	h.mu.Unlock()
 	if len(need) == 0 {
+		h.mu.Unlock()
 		return nil
 	}
+	wanted := append([]string(nil), need...)
+	for _, op := range commonGraphQLOperations {
+		if h.hashes[op] == "" && !containsOperation(wanted, op) {
+			wanted = append(wanted, op)
+		}
+	}
+	h.mu.Unlock()
 	html, err := h.fetchWebPlayerHTML(ctx)
 	if err != nil {
 		return err
@@ -76,48 +95,193 @@ func (h *hashResolver) load(ctx context.Context, ops []string) error {
 	if err != nil {
 		return err
 	}
-	if found := findOperationHashes(mainBody, need); len(found) > 0 {
-		h.mu.Lock()
-		for op, hash := range found {
-			if h.hashes[op] == "" {
-				h.hashes[op] = hash
-			}
-		}
-		h.mu.Unlock()
+	if found := findOperationHashes(mainBody, wanted); len(found) > 0 {
+		h.storeHashes(found)
 		need = filterMissing(need, found)
-		if len(need) == 0 {
+		wanted = filterMissing(wanted, found)
+		if len(wanted) == 0 {
 			return nil
 		}
 	}
 	nameMap, hashMap, err := parseWebpackMaps(mainBody)
 	if err != nil {
+		if len(need) == 0 {
+			return nil
+		}
 		return err
 	}
-	chunks := combineChunkNames(nameMap, hashMap)
+	chunks := prioritizeOperationChunks(combineChunkNames(nameMap, hashMap), wanted)
 	if len(chunks) == 0 {
+		if len(need) == 0 {
+			return nil
+		}
 		return errors.New("no chunks found")
 	}
-	for _, chunk := range chunks {
-		body, err := h.fetchText(ctx, bundleBase+chunk)
-		if err != nil {
-			continue
-		}
-		found := findOperationHashes(body, need)
-		if len(found) > 0 {
-			h.mu.Lock()
-			for op, hash := range found {
-				if h.hashes[op] == "" {
-					h.hashes[op] = hash
-				}
-			}
-			h.mu.Unlock()
-			need = filterMissing(need, found)
-			if len(need) == 0 {
-				return nil
-			}
+	scanCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	for found := range h.scanChunks(scanCtx, bundleBase, chunks, wanted) {
+		h.storeHashes(found)
+		need = filterMissing(need, found)
+		wanted = filterMissing(wanted, found)
+		if len(wanted) == 0 {
+			return nil
 		}
 	}
+	if len(need) == 0 {
+		return nil
+	}
 	return fmt.Errorf("missing hashes for %s", strings.Join(need, ", "))
+}
+
+func (h *hashResolver) loadCachedHashes() {
+	if h.session == nil || h.session.cache == nil {
+		return
+	}
+	h.session.mu.Lock()
+	version := h.session.clientVer
+	h.session.mu.Unlock()
+	if version == "" {
+		return
+	}
+	h.mu.Lock()
+	if h.clientVersion == version {
+		h.mu.Unlock()
+		return
+	}
+	if h.clientVersion != "" {
+		h.hashes = map[string]string{}
+	}
+	h.clientVersion = version
+	h.mu.Unlock()
+	cached, err := h.session.cache.load()
+	if err != nil || cached.OperationHashesClientVersion != version {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for operation, hash := range cached.OperationHashes {
+		if h.hashes[operation] == "" {
+			h.hashes[operation] = hash
+		}
+	}
+}
+
+func (h *hashResolver) storeHashes(found map[string]string) {
+	h.mu.Lock()
+	for operation, hash := range found {
+		if h.hashes[operation] == "" {
+			h.hashes[operation] = hash
+		}
+	}
+	version := h.clientVersion
+	h.mu.Unlock()
+	if version == "" || h.session == nil || h.session.cache == nil {
+		return
+	}
+	_ = h.session.cache.update(func(cached *connectCache) {
+		if cached.OperationHashesClientVersion != version {
+			cached.OperationHashesClientVersion = version
+			cached.OperationHashes = map[string]string{}
+		}
+		if cached.OperationHashes == nil {
+			cached.OperationHashes = map[string]string{}
+		}
+		for operation, hash := range found {
+			cached.OperationHashes[operation] = hash
+		}
+	})
+}
+
+func (h *hashResolver) scanChunks(ctx context.Context, base string, chunks, operations []string) <-chan map[string]string {
+	results := make(chan map[string]string, hashChunkConcurrency)
+	jobs := make(chan string)
+	ctx, cancel := context.WithCancel(ctx)
+	var workers sync.WaitGroup
+	for range min(hashChunkConcurrency, len(chunks)) {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case chunk, ok := <-jobs:
+					if !ok {
+						return
+					}
+					body, err := h.fetchText(ctx, base+chunk)
+					if err != nil {
+						continue
+					}
+					if found := findOperationHashes(body, operations); len(found) > 0 {
+						select {
+						case results <- found:
+						case <-ctx.Done():
+							return
+						}
+					}
+				}
+			}
+		}()
+	}
+	go func() {
+		defer close(jobs)
+		for _, chunk := range chunks {
+			select {
+			case jobs <- chunk:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	go func() {
+		workers.Wait()
+		cancel()
+		close(results)
+	}()
+	return results
+}
+
+func containsOperation(operations []string, operation string) bool {
+	for _, candidate := range operations {
+		if candidate == operation {
+			return true
+		}
+	}
+	return false
+}
+
+func prioritizeOperationChunks(chunks, operations []string) []string {
+	score := func(chunk string) int {
+		chunk = strings.ToLower(chunk)
+		best := 0
+		for _, operation := range operations {
+			var term string
+			switch {
+			case strings.Contains(strings.ToLower(operation), "search"):
+				term = "search"
+			case strings.Contains(strings.ToLower(operation), "album"):
+				term = "album"
+			case strings.Contains(strings.ToLower(operation), "artist"):
+				term = "artist"
+			case strings.Contains(strings.ToLower(operation), "episode"):
+				term = "episode"
+			case strings.Contains(strings.ToLower(operation), "podcast"):
+				term = "podcast"
+			}
+			if term == "" || !strings.Contains(chunk, term) {
+				continue
+			}
+			if strings.Contains(chunk, "routes-"+term+".") {
+				best = max(best, 2)
+			} else {
+				best = max(best, 1)
+			}
+		}
+		return best
+	}
+	sort.SliceStable(chunks, func(i, j int) bool { return score(chunks[i]) > score(chunks[j]) })
+	return chunks
 }
 
 func (h *hashResolver) fetchWebPlayerHTML(ctx context.Context) (string, error) {

--- a/internal/spotify/connect_hash_load_test.go
+++ b/internal/spotify/connect_hash_load_test.go
@@ -2,9 +2,13 @@ package spotify
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestHashResolverLoad(t *testing.T) {
@@ -57,5 +61,134 @@ func TestHashResolverLoadFromMainBody(t *testing.T) {
 	}
 	if got != hash {
 		t.Fatalf("unexpected hash: %s", got)
+	}
+}
+
+func TestHashResolverPersistsHashesByClientVersion(t *testing.T) {
+	cache := newConnectCacheStore(filepath.Join(t.TempDir(), "connect.json"))
+	if err := cache.update(func(cached *connectCache) {
+		cached.ClientVersion = "1.2.3"
+	}); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+	hashes := map[string]string{
+		"getTrack":            strings.Repeat("a", 64),
+		"getAlbum":            strings.Repeat("b", 64),
+		"queryArtistOverview": strings.Repeat("c", 64),
+		"searchDesktop":       strings.Repeat("d", 64),
+	}
+	var main strings.Builder
+	for operation, hash := range hashes {
+		fmt.Fprintf(&main, `"%s","query","%s";`, operation, hash)
+	}
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Host {
+		case "open.spotify.com":
+			return textResponse(http.StatusOK, `<script src="https://open.spotifycdn.com/cdn/build/web-player/main.js"></script>`), nil
+		case "open.spotifycdn.com":
+			return textResponse(http.StatusOK, main.String()), nil
+		default:
+			return nil, fmt.Errorf("unexpected host %q", req.URL.Host)
+		}
+	})
+	client := &http.Client{Transport: transport}
+	resolver := newHashResolver(client, &connectSession{client: client, cache: cache, clientVer: "1.2.3"})
+	if got, err := resolver.Hash(context.Background(), "getTrack"); err != nil || got != hashes["getTrack"] {
+		t.Fatalf("cold hash = %q, error = %v", got, err)
+	}
+	cached, err := cache.load()
+	if err != nil {
+		t.Fatalf("load cache: %v", err)
+	}
+	if cached.OperationHashesClientVersion != "1.2.3" || len(cached.OperationHashes) != len(hashes) {
+		t.Fatalf("unexpected persisted hashes: version=%q hashes=%#v", cached.OperationHashesClientVersion, cached.OperationHashes)
+	}
+	warmClient := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("warm cache unexpectedly fetched %s", req.URL)
+	})}
+	warm := newHashResolver(warmClient, &connectSession{client: warmClient, cache: cache, clientVer: "1.2.3"})
+	for operation, want := range hashes {
+		if got, err := warm.Hash(context.Background(), operation); err != nil || got != want {
+			t.Fatalf("warm %s hash = %q, error = %v", operation, got, err)
+		}
+	}
+}
+
+func TestHashResolverInvalidatesHashesWhenClientVersionChanges(t *testing.T) {
+	cache := newConnectCacheStore(filepath.Join(t.TempDir(), "connect.json"))
+	if err := cache.update(func(cached *connectCache) {
+		cached.ClientVersion = "2.0.0"
+		cached.OperationHashesClientVersion = "1.0.0"
+		cached.OperationHashes = map[string]string{"getTrack": strings.Repeat("a", 64), "obsolete": "old"}
+	}); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+	want := strings.Repeat("b", 64)
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host == "open.spotify.com" {
+			return textResponse(http.StatusOK, `<script src="https://open.spotifycdn.com/cdn/build/web-player/main.js"></script>`), nil
+		}
+		return textResponse(http.StatusOK, `"getTrack","query","`+want+`"`), nil
+	})
+	client := &http.Client{Transport: transport}
+	resolver := newHashResolver(client, &connectSession{client: client, cache: cache, clientVer: "2.0.0"})
+	if got, err := resolver.Hash(context.Background(), "getTrack"); err != nil || got != want {
+		t.Fatalf("refreshed hash = %q, error = %v", got, err)
+	}
+	cached, err := cache.load()
+	if err != nil {
+		t.Fatalf("load cache: %v", err)
+	}
+	if cached.OperationHashesClientVersion != "2.0.0" || cached.OperationHashes["obsolete"] != "" {
+		t.Fatalf("stale hashes survived build change: %#v", cached.OperationHashes)
+	}
+}
+
+func TestHashResolverScansChunksWithBoundedConcurrency(t *testing.T) {
+	const chunkCount = 16
+	var names, hashes strings.Builder
+	names.WriteByte('{')
+	hashes.WriteByte('{')
+	for index := 1; index <= chunkCount; index++ {
+		if index > 1 {
+			names.WriteByte(',')
+			hashes.WriteByte(',')
+		}
+		fmt.Fprintf(&names, `%d:"chunk-%02d"`, index, index)
+		fmt.Fprintf(&hashes, `%d:"%08x"`, index, index)
+	}
+	names.WriteByte('}')
+	hashes.WriteByte('}')
+	want := strings.Repeat("e", 64)
+	var active, maximum atomic.Int32
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.URL.Host == "open.spotify.com":
+			return textResponse(http.StatusOK, `<script src="https://open.spotifycdn.com/cdn/build/web-player/main.js"></script>`), nil
+		case strings.HasSuffix(req.URL.Path, "/main.js"):
+			return textResponse(http.StatusOK, "var names="+names.String()+";var hashes="+hashes.String()+";"), nil
+		default:
+			current := active.Add(1)
+			for {
+				previous := maximum.Load()
+				if current <= previous || maximum.CompareAndSwap(previous, current) {
+					break
+				}
+			}
+			time.Sleep(5 * time.Millisecond)
+			active.Add(-1)
+			if strings.Contains(req.URL.Path, "chunk-16.") {
+				return textResponse(http.StatusOK, `"getAlbum","query","`+want+`"`), nil
+			}
+			return textResponse(http.StatusOK, "no operations"), nil
+		}
+	})
+	client := &http.Client{Transport: transport}
+	resolver := newHashResolver(client, &connectSession{client: client})
+	if got, err := resolver.Hash(context.Background(), "getAlbum"); err != nil || got != want {
+		t.Fatalf("chunk hash = %q, error = %v", got, err)
+	}
+	if got := maximum.Load(); got <= 1 || got > hashChunkConcurrency {
+		t.Fatalf("maximum chunk concurrency = %d, want between 2 and %d", got, hashChunkConcurrency)
 	}
 }

--- a/internal/spotify/connect_hash_test.go
+++ b/internal/spotify/connect_hash_test.go
@@ -1,6 +1,9 @@
 package spotify
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestParseMapLiteral(t *testing.T) {
 	raw := `{1:"foo",2:"bar"}`
@@ -49,5 +52,32 @@ func TestScoreMapsEmpty(t *testing.T) {
 	}
 	if scoreNameMap(nil) != 0 {
 		t.Fatalf("expected 0 for empty name map")
+	}
+}
+
+func TestPrioritizeOperationChunks(t *testing.T) {
+	tests := []struct {
+		name       string
+		operations []string
+		want       []string
+	}{
+		{
+			name:       "search route before incidental search chunks",
+			operations: []string{"searchDesktop"},
+			want:       []string{"xpui-routes-search.abc.js", "xpui-routes-recent-searches.def.js", "xpui-routes-album.ghi.js", "xpui-home.jkl.js"},
+		},
+		{
+			name:       "album route before unrelated chunks",
+			operations: []string{"getAlbum"},
+			want:       []string{"xpui-routes-album.ghi.js", "xpui-routes-recent-searches.def.js", "xpui-home.jkl.js", "xpui-routes-search.abc.js"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			chunks := []string{"xpui-routes-recent-searches.def.js", "xpui-routes-album.ghi.js", "xpui-home.jkl.js", "xpui-routes-search.abc.js"}
+			if got := prioritizeOperationChunks(chunks, test.operations); !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("prioritized chunks = %#v, want %#v", got, test.want)
+			}
+		})
 	}
 }

--- a/internal/spotify/connect_info.go
+++ b/internal/spotify/connect_info.go
@@ -15,7 +15,12 @@ func (c *ConnectClient) trackInfo(ctx context.Context, id string) (Item, error) 
 
 func (c *ConnectClient) albumInfo(ctx context.Context, id string) (Item, error) {
 	return c.infoWithWebFallback(ctx, id, "album", func() (Item, error) {
-		return c.infoByOperation(ctx, "getAlbum", map[string]any{"uri": "spotify:album:" + id}, "album")
+		return c.infoByOperation(ctx, "getAlbum", map[string]any{
+			"uri":    "spotify:album:" + id,
+			"locale": c.language,
+			"offset": 0,
+			"limit":  50,
+		}, "album")
 	}, func(web *Client) (Item, error) {
 		return web.GetAlbum(ctx, id)
 	})
@@ -48,9 +53,10 @@ func (c *ConnectClient) playlistInfo(ctx context.Context, id string) (Item, erro
 func (c *ConnectClient) showInfo(ctx context.Context, id string) (Item, error) {
 	return c.infoWithWebFallback(ctx, id, "show", func() (Item, error) {
 		return c.infoByOperation(ctx, "queryPodcastEpisodes", map[string]any{
-			"uri":    "spotify:show:" + id,
-			"offset": 0,
-			"limit":  25,
+			"uri":                            "spotify:show:" + id,
+			"offset":                         0,
+			"limit":                          25,
+			"includeEpisodeContentRatingsV2": false,
 		}, "show")
 	}, func(web *Client) (Item, error) {
 		return web.GetShow(ctx, id)
@@ -60,7 +66,8 @@ func (c *ConnectClient) showInfo(ctx context.Context, id string) (Item, error) {
 func (c *ConnectClient) episodeInfo(ctx context.Context, id string) (Item, error) {
 	return c.infoWithWebFallback(ctx, id, "episode", func() (Item, error) {
 		return c.infoByOperation(ctx, "getEpisodeOrChapter", map[string]any{
-			"uri": "spotify:episode:" + id,
+			"uri":                            "spotify:episode:" + id,
+			"includeEpisodeContentRatingsV2": false,
 		}, "episode")
 	}, func(web *Client) (Item, error) {
 		return web.GetEpisode(ctx, id)
@@ -80,7 +87,7 @@ func (c *ConnectClient) infoByOperation(ctx context.Context, operation string, v
 	if err != nil {
 		return Item{}, err
 	}
-	item, ok := extractItemFromPayload(payload, kind)
+	item, ok := extractRequestedItemFromPayload(payload, kind, getString(variables, "uri"))
 	if !ok {
 		return Item{}, fmt.Errorf("no %s found", kind)
 	}

--- a/internal/spotify/connect_mapping_test.go
+++ b/internal/spotify/connect_mapping_test.go
@@ -2,6 +2,7 @@ package spotify
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 )
 
@@ -546,5 +547,94 @@ func TestHelperNilAndOwnerFallback(t *testing.T) {
 	items := extractItemsFromContainer(container, "track")
 	if len(items) == 0 || items[0].ID != "q1" {
 		t.Fatalf("unexpected items: %#v", items)
+	}
+}
+
+func TestExtractRequestedItemFromPayloadMatchesRequestedEntity(t *testing.T) {
+	tests := []struct {
+		name      string
+		kind      string
+		key       string
+		entity    map[string]any
+		wantName  string
+		followers int
+		genres    []string
+	}{
+		{
+			name: "artist profile wins over related playlist",
+			kind: "artist",
+			key:  "artistUnion",
+			entity: map[string]any{
+				"uri":     "spotify:artist:target",
+				"profile": map[string]any{"name": "Weezer"},
+				"stats":   map[string]any{"followers": float64(123456)},
+				"genres":  map[string]any{"items": []any{map[string]any{"name": "alternative rock"}, map[string]any{"name": "power pop"}}},
+				"relatedContent": map[string]any{
+					"playlist": map[string]any{"name": "Weezer, The Shins, Silversun Pickups"},
+				},
+			},
+			wantName:  "Weezer",
+			followers: 123456,
+			genres:    []string{"alternative rock", "power pop"},
+		},
+		{
+			name:     "album union ignores nested artist album",
+			kind:     "album",
+			key:      "albumUnion",
+			entity:   map[string]any{"uri": "spotify:album:target", "name": "Target Album"},
+			wantName: "Target Album",
+		},
+		{
+			name:     "podcast union ignores related show",
+			kind:     "show",
+			key:      "podcastUnionV2",
+			entity:   map[string]any{"uri": "spotify:show:target", "name": "Target Show"},
+			wantName: "Target Show",
+		},
+		{
+			name:     "episode union ignores related episode",
+			kind:     "episode",
+			key:      "episodeUnionV2",
+			entity:   map[string]any{"uri": "spotify:episode:target", "name": "Target Episode"},
+			wantName: "Target Episode",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			payload := map[string]any{"data": map[string]any{
+				"related": map[string]any{
+					"uri":  "spotify:" + test.kind + ":other",
+					"name": "Unrelated " + test.kind,
+				},
+				test.key: test.entity,
+			}}
+			item, ok := extractRequestedItemFromPayload(payload, test.kind, "spotify:"+test.kind+":target")
+			if !ok {
+				t.Fatal("expected requested entity")
+			}
+			if item.ID != "target" || item.Name != test.wantName || item.Followers != test.followers || !reflect.DeepEqual(item.Genres, test.genres) {
+				t.Fatalf("unexpected requested entity: %#v", item)
+			}
+		})
+	}
+}
+
+func TestExtractRequestedItemFromPayloadRejectsDifferentEntity(t *testing.T) {
+	payload := map[string]any{"data": map[string]any{"artistUnion": map[string]any{
+		"uri":     "spotify:artist:other",
+		"profile": map[string]any{"name": "Other Artist"},
+	}}}
+	if item, ok := extractRequestedItemFromPayload(payload, "artist", "spotify:artist:target"); ok {
+		t.Fatalf("returned unrelated artist: %#v", item)
+	}
+}
+
+func TestExtractRequestedItemFromPayloadFindsNestedMatchingEntity(t *testing.T) {
+	payload := map[string]any{"data": map[string]any{"unexpectedContainer": map[string]any{
+		"entity": map[string]any{"uri": "spotify:show:target", "name": "Nested Show"},
+	}}}
+	item, ok := extractRequestedItemFromPayload(payload, "show", "spotify:show:target")
+	if !ok || item.Name != "Nested Show" {
+		t.Fatalf("unexpected fallback entity: %#v, found=%t", item, ok)
 	}
 }

--- a/internal/spotify/connect_playback_test.go
+++ b/internal/spotify/connect_playback_test.go
@@ -2,11 +2,14 @@ package spotify
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -567,5 +570,96 @@ func TestSendConnectCommandHTTPError(t *testing.T) {
 
 	if err := client.sendConnectCommand(context.Background(), "https://example.com", map[string]any{}); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestConnectQueueHydratesSparseTracksWithBoundedConcurrency(t *testing.T) {
+	const queuedCount = 12
+	next := make([]any, 0, queuedCount)
+	for index := 0; index < queuedCount; index++ {
+		entry := map[string]any{"uri": fmt.Sprintf("spotify:track:t%d", index)}
+		if index == 0 {
+			entry["metadata"] = map[string]any{"title": "Ready", "artist_name": "Ready Artist", "album_title": "Ready Album"}
+		}
+		next = append(next, entry)
+	}
+	statePayload := map[string]any{
+		"devices":          map[string]any{"device-1": map[string]any{"name": "Desk"}},
+		"active_device_id": "device-1",
+		"player_state": map[string]any{
+			"track":       map[string]any{"uri": "spotify:track:current"},
+			"next_tracks": next,
+		},
+	}
+	var active, maximum, lookups atomic.Int32
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/devices/hobs_"):
+			return jsonResponse(http.StatusOK, statePayload), nil
+		case req.URL.Host == "api-partner.spotify.com" && req.URL.Query().Get("operationName") == "getTrack":
+			lookups.Add(1)
+			current := active.Add(1)
+			for {
+				previous := maximum.Load()
+				if current <= previous || maximum.CompareAndSwap(previous, current) {
+					break
+				}
+			}
+			time.Sleep(5 * time.Millisecond)
+			active.Add(-1)
+			var variables map[string]any
+			if err := json.Unmarshal([]byte(req.URL.Query().Get("variables")), &variables); err != nil {
+				t.Errorf("decode track variables: %v", err)
+				return textResponse(http.StatusBadRequest, "invalid variables"), nil
+			}
+			uri := getString(variables, "uri")
+			if uri == "spotify:track:t7" {
+				return textResponse(http.StatusInternalServerError, "track unavailable"), nil
+			}
+			return jsonResponse(http.StatusOK, map[string]any{"data": map[string]any{"trackUnion": map[string]any{
+				"uri":         uri,
+				"name":        "Track " + idFromURI(uri),
+				"artists":     []any{map[string]any{"name": "Artist " + idFromURI(uri)}},
+				"album":       map[string]any{"name": "Album " + idFromURI(uri)},
+				"duration_ms": 123456,
+			}}}), nil
+		default:
+			t.Errorf("unexpected request outside internal GraphQL: %s", req.URL.Redacted())
+			return textResponse(http.StatusNotFound, "unexpected"), nil
+		}
+	})
+	client := newRegisteredConnectClientForTests(transport)
+	client.hashes.hashes["getTrack"] = "hash"
+	queue, err := client.Queue(context.Background())
+	if err != nil {
+		t.Fatalf("queue: %v", err)
+	}
+	if queue.CurrentlyPlaying == nil || queue.CurrentlyPlaying.Name != "Track current" || queue.CurrentlyPlaying.Album != "Album current" {
+		t.Fatalf("current track was not hydrated: %#v", queue.CurrentlyPlaying)
+	}
+	if len(queue.Queue) != queuedCount {
+		t.Fatalf("queue length = %d, want %d", len(queue.Queue), queuedCount)
+	}
+	for index, item := range queue.Queue {
+		switch index {
+		case 0:
+			if item.Name != "Ready" {
+				t.Fatalf("complete metadata was replaced: %#v", item)
+			}
+		case 7:
+			if item.Name != "" {
+				t.Fatalf("failed lookup unexpectedly hydrated: %#v", item)
+			}
+		default:
+			if item.Name == "" || len(item.Artists) == 0 || item.Album == "" || item.DurationMS != 123456 {
+				t.Fatalf("queue entry %d remains incomplete: %#v", index, item)
+			}
+		}
+	}
+	if got := lookups.Load(); got != queuedCount {
+		t.Fatalf("internal GraphQL lookups = %d, want %d", got, queuedCount)
+	}
+	if got := maximum.Load(); got <= 1 || got > queueHydrationConcurrency {
+		t.Fatalf("maximum queue hydration concurrency = %d, want between 2 and %d", got, queueHydrationConcurrency)
 	}
 }

--- a/internal/spotify/connect_state_map.go
+++ b/internal/spotify/connect_state_map.go
@@ -1,6 +1,8 @@
 package spotify
 
 import (
+	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -83,7 +85,7 @@ func mapQueue(state connectState) Queue {
 	}
 	if next, ok := state.playerState["next_tracks"].([]any); ok {
 		for _, entry := range next {
-			if item, ok := extractItem(entry, "track"); ok {
+			if item, ok := extractConnectTrack(entry); ok {
 				queue.Queue = append(queue.Queue, item)
 			}
 		}
@@ -97,7 +99,7 @@ func extractPlaybackTrack(player map[string]any) Item {
 	}
 	for _, key := range []string{"track", "item", "current_track"} {
 		if raw, ok := player[key]; ok {
-			if item, ok := extractItem(raw, "track"); ok {
+			if item, ok := extractConnectTrack(raw); ok {
 				return item
 			}
 		}
@@ -113,4 +115,70 @@ func extractPlaybackTrack(player map[string]any) Item {
 		}
 	}
 	return Item{}
+}
+
+func extractConnectTrack(value any) (Item, bool) {
+	item, ok := extractItem(value, "track")
+	if !ok {
+		return Item{}, false
+	}
+	entry, ok := value.(map[string]any)
+	if !ok {
+		return item, true
+	}
+	metadata, ok := getMap(entry, "metadata")
+	if !ok {
+		metadata, ok = getMap(entry, "track", "metadata")
+	}
+	if !ok {
+		return item, true
+	}
+	if title := getString(metadata, "title"); title != "" {
+		item.Name = title
+	}
+	if artists := connectMetadataArtists(metadata); len(artists) > 0 {
+		item.Artists = artists
+	}
+	if album := getString(metadata, "album_title"); album != "" {
+		item.Album = album
+	}
+	if duration, err := strconv.Atoi(getString(metadata, "duration")); err == nil && duration >= 0 {
+		item.DurationMS = duration
+	}
+	if explicit, err := strconv.ParseBool(getString(metadata, "is_explicit")); err == nil {
+		item.Explicit = explicit
+		item.ExplicitKnown = true
+	}
+	return item, true
+}
+
+func connectMetadataArtists(metadata map[string]any) []string {
+	type indexedArtist struct {
+		index int
+		name  string
+	}
+	artists := make([]indexedArtist, 0)
+	for key, value := range metadata {
+		name, ok := value.(string)
+		if !ok || strings.TrimSpace(name) == "" {
+			continue
+		}
+		if key == "artist_name" {
+			artists = append(artists, indexedArtist{index: 0, name: name})
+			continue
+		}
+		suffix, ok := strings.CutPrefix(key, "artist_name:")
+		if !ok {
+			continue
+		}
+		if index, err := strconv.Atoi(suffix); err == nil && index > 0 {
+			artists = append(artists, indexedArtist{index: index, name: name})
+		}
+	}
+	sort.Slice(artists, func(i, j int) bool { return artists[i].index < artists[j].index })
+	names := make([]string, 0, len(artists))
+	for _, artist := range artists {
+		names = append(names, artist.name)
+	}
+	return dedupeStrings(names)
 }

--- a/internal/spotify/connect_state_map_test.go
+++ b/internal/spotify/connect_state_map_test.go
@@ -1,6 +1,10 @@
 package spotify
 
-import "testing"
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
 
 func TestMapPlaybackStatusAndDevices(t *testing.T) {
 	state := connectState{
@@ -92,5 +96,116 @@ func TestExtractPlaybackTrackCurrent(t *testing.T) {
 	item := extractPlaybackTrack(player)
 	if item.URI != "spotify:track:xyz" {
 		t.Fatalf("unexpected item: %#v", item)
+	}
+}
+
+func TestConnectTrackMetadataMapping(t *testing.T) {
+	tests := []struct {
+		name     string
+		entry    map[string]any
+		wantName string
+		artists  []string
+		album    string
+		duration int
+		explicit bool
+		known    bool
+	}{
+		{
+			name: "ordered connect metadata",
+			entry: map[string]any{
+				"uri": "spotify:track:one",
+				"metadata": map[string]any{
+					"title":         "Sun & You",
+					"artist_name:2": "Third Artist",
+					"artist_name":   "Stoneface & Terminal",
+					"artist_name:1": "Second Artist",
+					"album_title":   "Sun & You",
+					"duration":      "207884",
+					"is_explicit":   "false",
+				},
+			},
+			wantName: "Sun & You",
+			artists:  []string{"Stoneface & Terminal", "Second Artist", "Third Artist"},
+			album:    "Sun & You",
+			duration: 207884,
+			known:    true,
+		},
+		{
+			name: "nested track metadata",
+			entry: map[string]any{"track": map[string]any{
+				"uri": "spotify:track:two",
+				"metadata": map[string]any{
+					"title":       "Nested",
+					"artist_name": "Artist",
+					"album_title": "Album",
+					"is_explicit": "true",
+				},
+			}},
+			wantName: "Nested",
+			artists:  []string{"Artist"},
+			album:    "Album",
+			explicit: true,
+			known:    true,
+		},
+		{
+			name: "invalid metadata preserves existing values",
+			entry: map[string]any{
+				"uri":         "spotify:track:three",
+				"name":        "Existing",
+				"duration_ms": 123,
+				"metadata": map[string]any{
+					"artist_name:bad": "Ignored",
+					"duration":        "invalid",
+					"is_explicit":     "unknown",
+				},
+			},
+			wantName: "Existing",
+			duration: 123,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			item, ok := extractConnectTrack(test.entry)
+			if !ok {
+				t.Fatal("expected track")
+			}
+			artistsMatch := reflect.DeepEqual(item.Artists, test.artists) || len(item.Artists) == 0 && len(test.artists) == 0
+			if item.Name != test.wantName || !artistsMatch || item.Album != test.album || item.DurationMS != test.duration || item.Explicit != test.explicit || item.ExplicitKnown != test.known {
+				t.Fatalf("unexpected mapped metadata: %#v", item)
+			}
+		})
+	}
+}
+
+func TestMapQueueUsesConnectMetadataForCurrentAndUpcoming(t *testing.T) {
+	state := connectState{playerState: map[string]any{
+		"track": map[string]any{
+			"uri":      "spotify:track:current",
+			"metadata": map[string]any{"title": "Current", "artist_name": "Current Artist", "album_title": "Current Album"},
+		},
+		"next_tracks": []any{map[string]any{
+			"uri": "spotify:track:next",
+			"metadata": map[string]any{
+				"title": "Next", "artist_name": "Next Artist", "album_title": "Next Album", "duration": "1234", "is_explicit": "false",
+			},
+		}},
+	}}
+	queue := mapQueue(state)
+	if queue.CurrentlyPlaying == nil || queue.CurrentlyPlaying.Album != "Current Album" {
+		t.Fatalf("unexpected current track: %#v", queue.CurrentlyPlaying)
+	}
+	if len(queue.Queue) != 1 || queue.Queue[0].Name != "Next" || queue.Queue[0].DurationMS != 1234 {
+		t.Fatalf("unexpected upcoming track: %#v", queue.Queue)
+	}
+	data, err := json.Marshal(queue.Queue[0])
+	if err != nil {
+		t.Fatalf("marshal queue item: %v", err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(data, &fields); err != nil {
+		t.Fatalf("decode queue item: %v", err)
+	}
+	if fields["album"] != "Next Album" || fields["duration_ms"] != float64(1234) || fields["explicit"] != false {
+		t.Fatalf("missing metadata in JSON: %s", data)
 	}
 }

--- a/internal/spotify/connect_transport.go
+++ b/internal/spotify/connect_transport.go
@@ -261,7 +261,7 @@ func getConnectionID(ctx context.Context, accessToken string) (string, error) {
 		},
 	})
 	if err != nil {
-		return "", err
+		return "", redactedDealerError{err: err, accessToken: accessToken}
 	}
 	if resp != nil && resp.Body != nil {
 		defer func() { _ = resp.Body.Close() }()
@@ -290,4 +290,20 @@ func getConnectionID(ctx context.Context, accessToken string) (string, error) {
 		}
 	}
 	return "", errors.New("missing connection id")
+}
+
+type redactedDealerError struct {
+	err         error
+	accessToken string
+}
+
+func (e redactedDealerError) Error() string {
+	if e.accessToken == "" {
+		return e.err.Error()
+	}
+	return strings.ReplaceAll(e.err.Error(), e.accessToken, "[REDACTED]")
+}
+
+func (e redactedDealerError) Unwrap() error {
+	return e.err
 }


### PR DESCRIPTION
Testing spogo end to end against a live Spotify account surfaced three defects in the Connect engine, plus one token-disclosure bug found while fixing them.

### GraphQL operation hashes were resolved once per process

`hashResolver` cached hashes in memory only, so every single CLI invocation re-fetched `open.spotify.com`, the main web-player bundle, and then walked webpack chunks looking for the hash it needed. `getAlbum` never finished inside the request timeout, so `album info` always fell through to `infoWithWebFallback` and hit the public Web API, which is rate-limited for cookie-derived tokens. That fallback is exactly what the Connect engine exists to avoid, and it answered 429.

Hashes now persist in the existing connect cache, keyed by web-player `client_version` so a new Spotify build invalidates them, and the chunk scan runs with bounded concurrency and stops as soon as every needed operation is found. The first resolve also stores the other common operations, so one cold run warms the whole catalog surface.

### Info lookups returned the wrong entity

`extractItemFromPayload` walked the whole payload and latched onto the first name-ish node, which routinely belonged to discography or related content rather than the requested entity. `spogo artist info 3jOstUTkEu2JkjvRdBA5Gu` returned the correct URI with `"name": "Weezer, The Shins, Silversun Pickups"` — a related-content playlist title. Entities are now resolved by matching the requested URI, with artist followers and genres populated from the payload.

### Queue entries had no metadata

The Connect player state carries title, artist, and album inside a per-entry `metadata` block, with multi-artist entries as `artist_name`, `artist_name:1`, and so on. `mapQueue` never read it, and unlike `playback()` the queue path did no hydration for entries Spotify sends as a bare URI, so nearly every row rendered as ` —  · `. The metadata block is now mapped, and remaining entries hydrate concurrently through the Connect `getTrack` path (never the public Web API).

### Access token disclosure

The dealer WebSocket URL carries the access token as a query parameter, so a failed handshake surfaced the token verbatim in the error shown to the user. It is redacted now.

## Verification

Live against a real account, after the fixes:

| command | before | after |
| --- | --- | --- |
| `artist info 3jOstUTkEu2JkjvRdBA5Gu` | `Weezer, The Shins, Silversun Pickups` | `Weezer · 5567807 followers`, 2.5s |
| `album info 6ZG5lRT77aJ3btmArcykra` | never succeeded, 429 via Web API fallback | `Parachutes — Coldplay`, 1.6s |
| `queue show` | ` —  · ` for nearly every row | 78/78 entries with title, artists, album, duration |
| `search track` | 17.2s | 3.5s |
| `track info` | 23.7s, then 42.3s | 2.4s |

The before-timings were measured while this machine's connection was degraded, so treat them as directional; the structural win is that a warm run performs no bundle download at all.

`./scripts/lint.sh` reports 0 issues, `./scripts/check-coverage.sh 90` passes at 90.7% total, and `go test ./...` plus `go test -race ./internal/spotify ./internal/cli` are green.
