### PR TITLE
fix: honor configured dealer timeout and close both CodeQL alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Honor the configured request timeout when opening Spotify Connect dealer WebSocket connections
+
 ## 0.10.4 - 2026-08-23
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Honor the configured request timeout when opening Spotify Connect dealer WebSocket connections
+- Strip every heading anchor safely when generating documentation tables of contents
 
 ## 0.10.4 - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Honor the configured request timeout when opening Spotify Connect dealer WebSocket connections
 - Strip every heading anchor safely when generating documentation tables of contents
+- Restrict CI workflow permissions to read-only repository contents
 
 ## 0.10.4 - 2026-08-23
 

--- a/internal/spotify/connect_dealer_test.go
+++ b/internal/spotify/connect_dealer_test.go
@@ -32,12 +32,42 @@ func TestGetConnectionID(t *testing.T) {
 	dealerURL = "ws" + strings.TrimPrefix(srv.URL, "http")
 	t.Cleanup(func() { dealerURL = prev })
 
-	id, err := getConnectionID(context.Background(), "token")
+	id, err := getConnectionID(context.Background(), "token", 0)
 	if err != nil {
 		t.Fatalf("getConnectionID: %v", err)
 	}
 	if id != "conn-id" {
 		t.Fatalf("unexpected id: %s", id)
+	}
+}
+
+func TestDealerConnectionContextTimeout(t *testing.T) {
+	tests := []struct {
+		name         string
+		timeout      time.Duration
+		wantTimeout  time.Duration
+		wantDeadline bool
+	}{
+		{name: "zero uses default", timeout: 0, wantTimeout: defaultHTTPClientTimeout, wantDeadline: true},
+		{name: "positive uses configured timeout", timeout: 1500 * time.Millisecond, wantTimeout: 1500 * time.Millisecond, wantDeadline: true},
+		{name: "negative is unlimited", timeout: -time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := time.Now()
+			ctx, cancel := dealerConnectionContext(context.Background(), tt.timeout)
+			t.Cleanup(cancel)
+			after := time.Now()
+
+			deadline, ok := ctx.Deadline()
+			if ok != tt.wantDeadline {
+				t.Fatalf("deadline present = %t, want %t", ok, tt.wantDeadline)
+			}
+			if ok && (deadline.Before(before.Add(tt.wantTimeout)) || deadline.After(after.Add(tt.wantTimeout))) {
+				t.Fatalf("deadline = %s, want timeout %s", deadline, tt.wantTimeout)
+			}
+		})
 	}
 }
 
@@ -93,7 +123,7 @@ func TestGetConnectionIDMissingHeader(t *testing.T) {
 	dealerURL = "ws" + strings.TrimPrefix(srv.URL, "http")
 	t.Cleanup(func() { dealerURL = prev })
 
-	if _, err := getConnectionID(context.Background(), "token"); err == nil {
+	if _, err := getConnectionID(context.Background(), "token", 0); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -116,7 +146,7 @@ func TestGetConnectionIDBadHeadersType(t *testing.T) {
 	dealerURL = "ws" + strings.TrimPrefix(srv.URL, "http")
 	t.Cleanup(func() { dealerURL = prev })
 
-	if _, err := getConnectionID(context.Background(), "token"); err == nil {
+	if _, err := getConnectionID(context.Background(), "token", 0); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -127,7 +157,7 @@ func TestGetConnectionIDDialError(t *testing.T) {
 	t.Cleanup(func() { dealerURL = prev })
 
 	const accessToken = "sensitive-test-token"
-	_, err := getConnectionID(context.Background(), accessToken)
+	_, err := getConnectionID(context.Background(), accessToken, 0)
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -160,7 +190,7 @@ func TestGetConnectionIDBadJSON(t *testing.T) {
 	dealerURL = "ws" + strings.TrimPrefix(srv.URL, "http")
 	t.Cleanup(func() { dealerURL = prev })
 
-	if _, err := getConnectionID(context.Background(), "token"); err == nil {
+	if _, err := getConnectionID(context.Background(), "token", 0); err == nil {
 		t.Fatalf("expected error")
 	}
 }

--- a/internal/spotify/connect_transport.go
+++ b/internal/spotify/connect_transport.go
@@ -109,7 +109,7 @@ func (c *ConnectClient) ensureConnectDevice(ctx context.Context, auth connectAut
 	if !needs {
 		return nil
 	}
-	connectionID, err := getConnectionID(ctx, auth.AccessToken)
+	connectionID, err := getConnectionID(ctx, auth.AccessToken, c.client.Timeout)
 	if err != nil {
 		return err
 	}
@@ -243,8 +243,8 @@ func (c *ConnectClient) sendConnectRequest(ctx context.Context, method, url stri
 	return nil
 }
 
-func getConnectionID(ctx context.Context, accessToken string) (string, error) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+func getConnectionID(ctx context.Context, accessToken string, timeout time.Duration) (string, error) {
+	ctx, cancel := dealerConnectionContext(ctx, timeout)
 	defer cancel()
 	url := dealerURL
 	sep := "?"
@@ -290,6 +290,16 @@ func getConnectionID(ctx context.Context, accessToken string) (string, error) {
 		}
 	}
 	return "", errors.New("missing connection id")
+}
+
+func dealerConnectionContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout == 0 {
+		timeout = defaultHTTPClientTimeout
+	}
+	if timeout < 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, timeout)
 }
 
 type redactedDealerError struct {

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -404,10 +404,20 @@ function tocFromHtml(html) {
   const re = /<h([23]) id="([^"]+)">([\s\S]*?)<\/h[23]>/g;
   let m;
   while ((m = re.exec(html))) {
-    const text = m[3]
-      .replace(/<a class="anchor"[^>]*>.*?<\/a>/, "")
-      .replace(/<[^>]+>/g, "")
-      .trim();
+    let text = "";
+    let anchorDepth = 0;
+    for (const part of m[3].split(/(<[^>]+>)/g)) {
+      if (part.startsWith('<a class="anchor"')) {
+        anchorDepth += 1;
+      } else if (anchorDepth > 0 && /^<a(?:\s|>)/.test(part)) {
+        anchorDepth += 1;
+      } else if (anchorDepth > 0 && part === "</a>") {
+        anchorDepth -= 1;
+      } else if (anchorDepth === 0 && !part.startsWith("<")) {
+        text += part;
+      }
+    }
+    text = text.trim();
     items.push({ level: Number(m[1]), id: m[2], text });
   }
   if (items.length < 2) return "";


### PR DESCRIPTION
Three small fixes: the last unreachable timeout in the Connect path, and both open CodeQL alerts.

### Dealer WebSocket ignored the configured timeout

`getConnectionID` hardcoded `context.WithTimeout(ctx, 10*time.Second)`, so `--timeout` / `SPOGO_TIMEOUT` never reached the dealer handshake. It was the remaining way `spogo status` could fail on a slow link regardless of what the user configured. The client's timeout is now threaded through from `ensureConnectDevice`, following the same semantics #48 established for the cookie-token client: zero falls back to the shared 10s default, a positive value becomes the deadline, and a negative value stays unlimited.

### CodeQL #2 (high): incomplete multi-character sanitization

`tocFromHtml` in `scripts/build-docs-site.mjs` stripped heading anchors with a non-global `replace`, so only the first anchor per heading was removed. `escapeHtml` downstream meant this was not a live injection, but the sanitizer is now a straightforward tokenizing pass that drops every anchor, including repeated and nested ones, rather than a regex that reconstructs markup.

All 14 existing tables of contents render byte-for-byte identically after the change, and the new path was checked against repeated anchors, nested anchors, multi-heading pages, ordinary links, and literal `#` characters.

### CodeQL #1 (medium): workflow without permissions

`ci.yml` had no `permissions:` block, so its jobs ran with the repository default. The build job only checks out and runs Go tooling, so the workflow now declares `contents: read`.

## Verification

`./scripts/lint.sh` reports 0 issues, `./scripts/check-coverage.sh 90` passes at 90.7%, `go vet ./...`, `go test ./...`, and `go test -race ./internal/spotify` are green, and `make docs-site` builds cleanly.
