### PR TITLE
fix: populate and render complete metadata across every command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Fixed
+
+- Populate artists, release dates, owners, publishers, show names, durations, track/episode counts, and follower counts across Spotify catalog results
+- Render readable follower counts and listening timestamps while omitting unknown metadata, empty separators, false zero counts, and trailing device whitespace
+- List real library playlists immediately and fetch followed artists through Spotify's internal web-player API instead of rate-limited public endpoints
+- Preserve Spotify retry-after cooldown hints across failed engine fallbacks and document commands that still require the public Web API
+- Share the configured default HTTP timeout across Spotify Connect clients
+
+### Added
+
+- Fall back to the local Spotify.app for playback status and controls on macOS after both remote auto engines fail
+
 ## 0.10.5 - 2026-08-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -19,18 +19,20 @@ Product direction and compatibility policy: [VISION.md](VISION.md).
 - Browser cookie import via `sweetcookie`
 - `--json` and `--plain` for scripting
 - Colorized human output (respects `NO_COLOR`, `TERM=dumb`, `--no-color`)
-- Engine switch: `auto` (connect → web), `connect` (internal endpoints), `web` (Web API endpoints; search/info/playback fall back to connect on rate limit)
+- Engine switch: `auto` (connect → web → local Spotify.app for playback on macOS), `connect` (internal endpoints), `web` (Web API endpoints; search/info/playback fall back to connect on rate limit)
 
 ## Why Cookies?
 
-Spotify's official API has strict rate limits that make it impractical for agents and automation. By using browser cookies to authenticate with Spotify's internal web API (the same one their web player uses), spogo bypasses these limitations:
+Spotify's official Web API has strict rate limits that can make it impractical for agents and automation. Browser cookies let spogo use the same internal endpoints as the Spotify web player for catalog search, item lookup, library listing, listening history, and most playback and playlist operations:
 
-- **No rate limits** - Use the same endpoints as open.spotify.com
+- **Fewer public-API rate limits** - Most reads and playback use the same internal endpoints as open.spotify.com
 - **No app registration** - No need to create a Spotify Developer app
 - **Full functionality** - Access to everything the web player can do
 - **Agent-friendly** - Perfect for AI assistants and automation scripts
 
 Import your cookies once with `sweetcookie` and you're good to go (defaults to Chrome).
+
+Some operations still require Spotify's public Web API: saving/removing library tracks or albums, following/unfollowing artists, creating playlists, artist-top-track lookups used by artist playback, and certain device transfers or playback fallbacks. Explicit `--engine web` also uses the public API. These paths can return `429`; when Spotify supplies a cooldown, spogo reports its `retry-after hint`, which can be several hours.
 
 ## Install
 
@@ -127,12 +129,13 @@ printf '%s\n%s\n' "sp_dc=..." "sp_t=..." | spogo auth paste --no-input
 ## Auto engine notes
 
 - `auto` tries connect first, then falls back to web on unsupported features or rate limits.
+- On macOS, playback status and playback controls try the local Spotify.app through AppleScript only after both remote engines fail, including when cookies are unavailable. Search, library, playlists, queues, and devices never use this local fallback.
 
 ## Connect engine notes
 
 - `connect` uses Spotify's internal connect-state endpoints for playback control.
 - Auth/session data and the last active playback route are cached per profile so repeated playback commands avoid a full Connect state refresh when the route is still valid.
-- Search/info prefer the internal GraphQL API and fall back to web search if hashes can’t be resolved.
+- Search/info, followed artists, saved albums/tracks, playlists, top tracks, and recent listening history prefer internal endpoints; catalog lookups fall back to the Web API if their internal operation cannot be resolved.
 
 ## Web engine notes
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -15,7 +15,7 @@ A script-friendly CLI must guarantee:
 - **Stable exit codes.** `0` success, `1` generic, `2` usage, `3` auth, `4` network. Branch on these.
 - **stdout is data.** stderr carries everything else. Pipes always work.
 - **No interactive surprises.** When stdin is not a TTY, spogo refuses to prompt. Pass `--no-input` to be explicit.
-- **No tight rate limits.** Cookie auth via Connect avoids the public Web API throttle.
+- **Fewer public-API requests.** Connect uses internal endpoints for supported reads and playback; library mutations, playlist creation, and other Web-API-only paths can still return `429` with a retry hint.
 
 See [Output](output.md) for the full contract.
 

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -27,16 +27,18 @@ Talks to Spotify's internal Connect endpoints — the same ones the official des
 - Playback control (play, pause, next, prev, seek, volume, shuffle, repeat).
 - Device discovery and transfer.
 - Playlist mutations under heavy use (Connect doesn't hit the Web API rate limits).
-- Search and item info via the internal GraphQL surface.
+- Search and item info via the internal GraphQL surface, including episode lookup.
+- Listing followed artists, saved albums/tracks, and playlists; user top tracks and recently played history also use internal endpoints.
 
 **Tradeoffs**
 
-- A handful of features fall back to the Web API automatically (e.g. transfers when Connect has no origin device, volume on certain hardware that needs `PUT`).
-- Search/info uses GraphQL hashes; if a hash can't be resolved, falls back to web search.
+- Saving/removing library tracks or albums, following/unfollowing artists, creating playlists, and artist-top-track lookups used by artist playback still require the public Web API.
+- Transfers without a Connect origin device, some hardware volume/playback requests, and failed internal catalog/library lookups may also fall back to the public Web API.
+- These public-API paths can be rate-limited even with `--engine connect`; a `429` includes Spotify's `retry-after hint` whenever one is supplied.
 
 ## web
 
-The public Spotify Web API. Slower, lower throughput, and rate-limited (~180 req/min/account before backoff), but it works on accounts where Connect is unavailable.
+The public Spotify Web API. Slower, lower throughput, and rate-limited according to Spotify's account- and application-specific policies; cookie-derived tokens can encounter aggressive cooldowns, including retry hints measured in hours.
 
 **Best for**
 
@@ -46,18 +48,20 @@ The public Spotify Web API. Slower, lower throughput, and rate-limited (~180 req
 
 **Tradeoffs**
 
-- Rate limits will bite under bulk operations. If you see `429`, switch to `connect` or `auto`.
+- Rate limits can apply even without bulk operations. If you see `429`, prefer `connect` for supported reads and honor the reported `retry-after hint`; Web-API-only operations cannot bypass that cooldown by switching engines.
 - Search/info/playback auto-fall-back to Connect when rate limited, so practical behavior is closer to `auto`.
 
 ## auto
 
-Try `connect` first; fall back to `web` for unsupported features or when Connect signals the call won't work. The friendliest default if you're not sure.
+Try `connect` first, then fall back to `web` for unsupported features or rate limits. On macOS, playback status and controls get one final fallback to the already-local Spotify.app through AppleScript after both remote engines fail, including when cookies are missing.
 
 ```bash
 spogo --engine auto play spotify:playlist:...
 ```
 
 Most users don't need this — `connect` already falls back to web for the specific paths where it has to. `auto` is useful when you want **explicit** fallback behavior across all calls.
+
+The AppleScript last resort is limited to `status`, `play`, `pause`, `next`, `prev`, `seek`, `volume`, `shuffle`, and `repeat`. Search, catalog lookup, library operations, playlists, queue commands, and devices remain remote-only; explicit `--engine connect` and `--engine web` never use AppleScript.
 
 ## applescript (macOS only)
 
@@ -80,8 +84,7 @@ spogo --engine applescript status
 
 - macOS only.
 - No Connect device list (`device list` shows just the Mac), no transfers.
-- Search uses the Mac app's local search; results may differ from web search.
-- Library/playlist mutations are not supported via AppleScript — fall back to `connect` or `web` for those.
+- Search, catalog lookups, library, and playlists are not AppleScript operations; explicit `applescript` may delegate them to its configured remote fallback.
 
 ## Setting an engine
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,9 +11,9 @@ A single Go binary for Spotify on the command line. Search the catalog, drive pl
 ## Why spogo
 
 - **No app registration.** spogo authenticates with the cookies your browser already has — `spogo auth import --browser chrome` and you're authenticated. No client ID, no redirect URI, no developer dashboard.
-- **No tight rate limits.** Talks to Spotify's internal web endpoints (the same ones `open.spotify.com` uses), so search, info, and playback are usable for automation that the public Web API would throttle.
+- **Internal endpoints where available.** Search, catalog info, library listing, listening history, and most playback use the same internal endpoints as `open.spotify.com`; library mutations, playlist creation, and other Web-API-only operations can still be rate-limited.
 - **Predictable output.** `--json` for tools, `--plain` for `awk`/`cut`, color human output by default. `NO_COLOR`, `TERM=dumb`, and `--no-color` all respected.
-- **Multiple engines.** `connect` (internal), `web` (public Web API), `auto` (connect first, fall back to web), and `applescript` (drive Spotify.app on macOS) — pick what works.
+- **Multiple engines.** `connect` (internal), `web` (public Web API), `auto` (connect → web → local Spotify.app for playback on macOS), and `applescript` (drive Spotify.app on macOS) — pick what works.
 - **Built for agents.** Stable exit codes, structured errors, machine output — drop spogo into a shell script or hand it to a coding agent and it'll behave.
 
 ## Pick your path

--- a/docs/library.md
+++ b/docs/library.md
@@ -41,6 +41,8 @@ spogo library artists unfollow <id|url...>
 
 `--after` paginates by artist ID — pass the last ID from the previous page to fetch the next.
 
+Listing followed artists uses Spotify's internal web-player library operation. Following or unfollowing an artist still uses the public Web API and may return a rate-limit cooldown.
+
 ## library playlists
 
 ```bash
@@ -48,6 +50,8 @@ spogo library playlists list [--limit N]
 ```
 
 Lists every playlist you own or follow. To list **tracks** in a playlist, use `playlist tracks` below.
+
+Playlist and library collection listings use the internal web-player API. Saving/removing tracks or albums and creating playlists still require the public Web API, so those mutations may be rate-limited.
 
 ## playlist create
 

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -110,7 +110,7 @@ When Connect state has no origin device, `spogo` falls back to the Web API trans
 
 - **`connect`** (default) — playback control via Spotify's internal Connect endpoints. Best fidelity for transitions, queueing, and device transfer; auto-falls-back to Web API for transfers when no origin device exists.
 - **`web`** — the public Web API. Slower, rate-limited, but the only option for accounts with restrictive Connect availability.
-- **`auto`** — Connect first, fall back to Web on Connect-unsupported features.
+- **`auto`** — Connect first, then Web; on macOS, playback status/control finally fall back to Spotify.app through AppleScript if both remote engines fail.
 - **`applescript`** (macOS only) — drive Spotify.app directly via AppleScript. No network, but only sees the local Mac app.
 
 See [Engines](engines.md) for the full breakdown.
@@ -119,4 +119,4 @@ See [Engines](engines.md) for the full breakdown.
 
 - `no active device` — open Spotify on a phone/desktop/Connect speaker first, or pass `--device`.
 - `403 PREMIUM_REQUIRED` — playback requires a Spotify Premium account.
-- `429 too many requests` — Connect engine handles rate limits internally; if you see this on `web`, switch to `auto` or `connect`.
+- `429 too many requests` — prefer `connect` for supported playback; Web-API-only fallback paths can still be limited, so honor the reported `retry-after hint`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -142,7 +142,7 @@ spogo [global flags] <command> [args]
 
 ## Engines
 
-- `auto`: connect first; fall back to web for unsupported features or rate limits.
+- `auto`: connect first; fall back to web for unsupported features or rate limits; on macOS, playback status/control can finally fall back to Spotify.app through AppleScript after both remote engines fail.
 - `connect`: internal connect-state endpoints for playback; GraphQL for search/info. Auth/session data and the last active playback route are cached per profile.
 - `web`: Web API endpoints; search/info/playback auto-fallback to connect when rate limited.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -94,9 +94,11 @@ Older spogo versions had Connect responses missing artist/album for some track s
 
 ### `429 too many requests`
 
-Should not happen on the `connect` engine for normal usage. If you see it:
+Spotify's public Web API can rate-limit cookie-derived tokens aggressively, even when a command starts on the `connect` engine. If you see it:
 
-- You're on `--engine web` — switch to `connect` or `auto`.
+- You're on `--engine web` — switch to `connect` or `auto` when the command has an internal equivalent.
+- Saving/removing library tracks or albums, following/unfollowing artists, playlist creation, artist-top-track lookups, and some device/playback fallbacks still require the public API; changing engines cannot bypass their cooldown.
+- Respect the `retry-after hint` printed with the error. Spotify can advertise cooldowns lasting hours or longer.
 - You're hammering the API in a tight loop — add `sleep 0.2` between calls, or batch via `--limit`.
 - Multiple spogo profiles are sharing the same Spotify account at the same time — the throttle is per-account, not per-process.
 

--- a/internal/app/context_factory.go
+++ b/internal/app/context_factory.go
@@ -72,7 +72,11 @@ func (c *Context) newAutoClient(source cookies.Source) (spotify.API, error) {
 	}
 	client := spotify.API(webClient)
 	if connectClient, connectErr := c.newConnectClient(source); connectErr == nil {
-		client = spotify.NewAutoClient(connectClient, webClient)
+		if localClient, localErr := spotify.NewAppleScriptClient(spotify.AppleScriptOptions{}); localErr == nil {
+			client = spotify.NewAutoClient(connectClient, webClient, localClient)
+		} else {
+			client = spotify.NewAutoClient(connectClient, webClient)
+		}
 	}
 	return client, nil
 }

--- a/internal/cli/device.go
+++ b/internal/cli/device.go
@@ -35,7 +35,11 @@ func (cmd *DeviceListCmd) Run(ctx *app.Context) error {
 		if device.Active {
 			label = ctx.Output.Theme.Accent(label)
 		}
-		human = append(human, fmt.Sprintf("%s (%s) %s", label, device.Type, strings.TrimSpace(activeMarker(device.Active))))
+		line := fmt.Sprintf("%s (%s)", label, device.Type)
+		if marker := activeMarker(device.Active); marker != "" {
+			line += " " + marker
+		}
+		human = append(human, line)
 	}
 	return ctx.Output.Emit(devices, plain, human)
 }

--- a/internal/cli/device_test.go
+++ b/internal/cli/device_test.go
@@ -69,6 +69,24 @@ func TestDeviceListCmd(t *testing.T) {
 	}
 }
 
+func TestDeviceListHumanOmitsTrailingSpace(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatHuman)
+	ctx.SetSpotify(&testutil.SpotifyMock{
+		DevicesFn: func(context.Context) ([]spotify.Device, error) {
+			return []spotify.Device{
+				{ID: "d1", Name: "Schlafzimmer", Type: "SPEAKER"},
+				{ID: "d2", Name: "Desk", Type: "COMPUTER", Active: true},
+			}, nil
+		},
+	})
+	if err := (&DeviceListCmd{}).Run(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := out.String(), "Schlafzimmer (SPEAKER)\nDesk (COMPUTER) (active)\n"; got != want {
+		t.Fatalf("output=%q want=%q", got, want)
+	}
+}
+
 func TestDeviceListCmdError(t *testing.T) {
 	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
 	mock := &testutil.SpotifyMock{

--- a/internal/cli/history.go
+++ b/internal/cli/history.go
@@ -168,7 +168,7 @@ func (cmd *UserHistoryCmd) Run(ctx *app.Context) error {
 		"effective_lower_bound": after,
 	}
 	if ctx.Output.Format == output.FormatHuman {
-		header := fmt.Sprintf("Recently played (%s): %d", cmd.Period, len(allItems))
+		header := fmt.Sprintf("Recently played: %d", len(allItems))
 		human = append([]string{header}, human...)
 	}
 	return ctx.Output.Emit(payload, plain, human)
@@ -193,26 +193,26 @@ func parseRFC3339Milli(s string) (int64, error) {
 }
 
 func renderTopTracks(w *output.Writer, items []spotify.Item) (plain []string, human []string) {
-	accent := w.Theme.Accent
-	muted := w.Theme.Muted
 	plain = make([]string, 0, len(items))
 	human = make([]string, 0, len(items))
 	for i, item := range items {
 		rank := i + 1
 		plain = append(plain, fmt.Sprintf("%d\ttrack\t%s\t%s\t%s\t%s\t%s", rank, item.ID, item.Name, strings.Join(item.Artists, ", "), item.Album, item.URI))
-		human = append(human, fmt.Sprintf("%d. %s — %s %s", rank, accent(item.Name), strings.Join(item.Artists, ", "), muted("· "+item.Album)))
+		human = append(human, fmt.Sprintf("%d. %s", rank, humanItemLine(w, item.Name, strings.Join(item.Artists, ", "), item.Album)))
 	}
 	return plain, human
 }
 
 func renderRecentlyPlayed(w *output.Writer, items []spotify.RecentlyPlayedItem) (plain []string, human []string) {
-	accent := w.Theme.Accent
-	muted := w.Theme.Muted
 	plain = make([]string, 0, len(items))
 	human = make([]string, 0, len(items))
 	for _, item := range items {
 		plain = append(plain, fmt.Sprintf("%s\ttrack\t%s\t%s\t%s\t%s\t%s", item.PlayedAt, item.Track.ID, item.Track.Name, strings.Join(item.Track.Artists, ", "), item.Track.Album, item.Track.URI))
-		human = append(human, fmt.Sprintf("%s — %s %s", accent(item.Track.Name), strings.Join(item.Track.Artists, ", "), muted("· "+item.PlayedAt)))
+		playedAt := item.PlayedAt
+		if parsed, err := time.Parse(time.RFC3339Nano, playedAt); err == nil {
+			playedAt = parsed.Local().Format("Jan 2, 2006 at 3:04 PM MST")
+		}
+		human = append(human, humanItemLine(w, item.Track.Name, strings.Join(item.Track.Artists, ", "), playedAt))
 	}
 	return plain, human
 }

--- a/internal/cli/history_test.go
+++ b/internal/cli/history_test.go
@@ -167,6 +167,27 @@ func TestUserHistoryCmd(t *testing.T) {
 	}
 }
 
+func TestUserHistoryHumanOutputUsesReadableTimestampWithoutAffinityRange(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatHuman)
+	ctx.SetSpotify(&testutil.SpotifyMock{
+		GetRecentlyPlayedFn: func(context.Context, int, int64, int64) (spotify.RecentlyPlayedResult, error) {
+			return spotify.RecentlyPlayedResult{Items: []spotify.RecentlyPlayedItem{{
+				Track: spotify.Item{Name: "Long Way Home", Type: "track", Artists: []string{"Gareth Emery"}}, PlayedAt: "2026-08-23T22:20:10.967Z",
+			}}}, nil
+		},
+	})
+	if err := (&UserHistoryCmd{Period: "long_term", Limit: 1}).Run(ctx); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.HasPrefix(got, "Recently played: 1\nLong Way Home — Gareth Emery · ") {
+		t.Fatalf("unexpected history output %q", got)
+	}
+	if strings.Contains(got, "long_term") || strings.Contains(got, "2026-08-23T22:20:10.967Z") || !strings.Contains(got, "Aug 23, 2026") {
+		t.Fatalf("history output was not formatted for humans: %q", got)
+	}
+}
+
 func TestUserHistoryCmdWithPeriod(t *testing.T) {
 	ctx, _, _ := testutil.NewTestContext(t, output.FormatPlain)
 	mock := &testutil.SpotifyMock{

--- a/internal/cli/library_test.go
+++ b/internal/cli/library_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/steipete/spogo/internal/output"
@@ -226,6 +227,21 @@ func TestLibraryPlaylistsListCmd(t *testing.T) {
 	}
 	if out.String() == "" {
 		t.Fatalf("expected output")
+	}
+}
+
+func TestLibraryPlaylistsListCmdHumanOutput(t *testing.T) {
+	ctx, out, _ := testutil.NewTestContext(t, output.FormatHuman)
+	ctx.SetSpotify(&testutil.SpotifyMock{
+		PlaylistsFn: func(context.Context, int, int) ([]spotify.Item, int, error) {
+			return []spotify.Item{{ID: "p1", Name: "Discover Weekly", Type: "playlist", Owner: "Spotify"}}, 1, nil
+		},
+	})
+	if err := (&LibraryPlaylistsListCmd{Limit: 1}).Run(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); !strings.Contains(got, "Discover Weekly — Spotify") {
+		t.Fatalf("expected non-empty human playlist output, got %q", got)
 	}
 }
 

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -39,27 +40,78 @@ func itemPlain(item spotify.Item) string {
 }
 
 func itemHuman(w *output.Writer, item spotify.Item) string {
-	accent := w.Theme.Accent
-	muted := w.Theme.Muted
 	switch item.Type {
 	case "track":
-		return fmt.Sprintf("%s — %s %s", accent(item.Name), strings.Join(item.Artists, ", "), muted("· "+item.Album))
+		return humanItemLine(w, item.Name, strings.Join(item.Artists, ", "), item.Album)
 	case "album":
-		return fmt.Sprintf("%s — %s %s", accent(item.Name), strings.Join(item.Artists, ", "), muted("· "+item.ReleaseDate))
+		return humanItemLine(w, item.Name, strings.Join(item.Artists, ", "), item.ReleaseDate)
 	case "artist":
-		return fmt.Sprintf("%s %s", accent(item.Name), muted(fmt.Sprintf("· %d followers", item.Followers)))
-	case "playlist":
-		if item.TotalTracks > 0 {
-			return fmt.Sprintf("%s — %s %s", accent(item.Name), item.Owner, muted(fmt.Sprintf("· %d tracks", item.TotalTracks)))
+		followers := ""
+		if item.Followers > 0 {
+			followers = formatThousands(item.Followers) + " " + pluralNoun(item.Followers, "follower")
 		}
-		return fmt.Sprintf("%s — %s", accent(item.Name), item.Owner)
+		return humanItemLine(w, item.Name, "", followers)
+	case "playlist":
+		tracks := ""
+		if item.TotalTracks > 0 {
+			tracks = fmt.Sprintf("%d %s", item.TotalTracks, pluralNoun(item.TotalTracks, "track"))
+		}
+		return humanItemLine(w, item.Name, item.Owner, tracks)
 	case "show":
-		return fmt.Sprintf("%s — %s %s", accent(item.Name), item.Publisher, muted(fmt.Sprintf("· %d episodes", item.TotalEpisodes)))
+		episodes := ""
+		if item.TotalEpisodes > 0 {
+			episodes = fmt.Sprintf("%d %s", item.TotalEpisodes, pluralNoun(item.TotalEpisodes, "episode"))
+		}
+		return humanItemLine(w, item.Name, item.Publisher, episodes)
 	case "episode":
-		return fmt.Sprintf("%s %s", accent(item.Name), muted(fmt.Sprintf("· %s", humanDuration(item.DurationMS))))
+		duration := ""
+		if item.DurationMS > 0 {
+			duration = humanDuration(item.DurationMS)
+		}
+		return humanItemLine(w, item.Name, item.Show, duration)
 	default:
-		return accent(item.Name)
+		return w.Theme.Accent(item.Name)
 	}
+}
+
+func pluralNoun(count int, singular string) string {
+	if count == 1 {
+		return singular
+	}
+	return singular + "s"
+}
+
+func humanItemLine(w *output.Writer, name, secondary string, details ...string) string {
+	var line strings.Builder
+	line.WriteString(w.Theme.Accent(name))
+	if secondary != "" {
+		line.WriteString(" — ")
+		line.WriteString(secondary)
+	}
+	for _, detail := range details {
+		if detail == "" {
+			continue
+		}
+		line.WriteByte(' ')
+		line.WriteString(w.Theme.Muted("· " + detail))
+	}
+	return line.String()
+}
+
+func formatThousands(number int) string {
+	digits := strconv.Itoa(number)
+	if len(digits) <= 3 {
+		return digits
+	}
+	var formatted strings.Builder
+	formatted.Grow(len(digits) + (len(digits)-1)/3)
+	for index, digit := range digits {
+		if index > 0 && (len(digits)-index)%3 == 0 {
+			formatted.WriteByte(',')
+		}
+		formatted.WriteRune(digit)
+	}
+	return formatted.String()
 }
 
 func humanDuration(ms int) string {
@@ -88,15 +140,16 @@ func playbackPlain(status spotify.PlaybackStatus) string {
 }
 
 func playbackHuman(w *output.Writer, status spotify.PlaybackStatus) string {
-	accent := w.Theme.Accent
-	muted := w.Theme.Muted
 	state := "paused"
 	if status.IsPlaying {
 		state = "playing"
 	}
-	track := ""
-	if status.Item != nil {
-		track = fmt.Sprintf("%s — %s", accent(status.Item.Name), strings.Join(status.Item.Artists, ", "))
+	line := w.Theme.Accent(strings.ToUpper(state))
+	if status.Item != nil && status.Item.Name != "" {
+		line += " " + humanItemLine(w, status.Item.Name, strings.Join(status.Item.Artists, ", "))
 	}
-	return fmt.Sprintf("%s %s %s", accent(strings.ToUpper(state)), track, muted("· "+status.Device.Name))
+	if status.Device.Name != "" {
+		line += " " + w.Theme.Muted("· "+status.Device.Name)
+	}
+	return line
 }

--- a/internal/cli/render_test.go
+++ b/internal/cli/render_test.go
@@ -40,3 +40,84 @@ func TestPlaylistRenderOmitsZeroTracks(t *testing.T) {
 		t.Fatalf("unexpected track count: %s", line)
 	}
 }
+
+func TestItemHumanOmitsUnknownMetadata(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatHuman)
+	tests := []struct {
+		name string
+		item spotify.Item
+		want string
+	}{
+		{"track", spotify.Item{Type: "track", Name: "Song"}, "Song"},
+		{"album", spotify.Item{Type: "album", Name: "Parachutes", Artists: []string{"Coldplay"}}, "Parachutes — Coldplay"},
+		{"artist", spotify.Item{Type: "artist", Name: "Weezer"}, "Weezer"},
+		{"playlist", spotify.Item{Type: "playlist", Name: "Discover Weekly"}, "Discover Weekly"},
+		{"show", spotify.Item{Type: "show", Name: "Darknet Diaries"}, "Darknet Diaries"},
+		{"episode", spotify.Item{Type: "episode", Name: "178: Ubiquiti"}, "178: Ubiquiti"},
+		{"unknown", spotify.Item{Type: "other", Name: "Other"}, "Other"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := itemHuman(ctx.Output, test.item); got != test.want {
+				t.Fatalf("line=%q want=%q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestItemHumanFormatsCompleteMetadata(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatHuman)
+	tests := []struct {
+		item spotify.Item
+		want string
+	}{
+		{spotify.Item{Type: "artist", Name: "Weezer", Followers: 5567807}, "Weezer · 5,567,807 followers"},
+		{spotify.Item{Type: "playlist", Name: "TRANCE", Owner: "YOU LOVE DANCE", TotalTracks: 197}, "TRANCE — YOU LOVE DANCE · 197 tracks"},
+		{spotify.Item{Type: "show", Name: "Darknet Diaries", Publisher: "Jack Rhysider", TotalEpisodes: 227}, "Darknet Diaries — Jack Rhysider · 227 episodes"},
+		{spotify.Item{Type: "show", Name: "One-Off", TotalEpisodes: 1}, "One-Off · 1 episode"},
+		{spotify.Item{Type: "playlist", Name: "Single", TotalTracks: 1}, "Single · 1 track"},
+		{spotify.Item{Type: "artist", Name: "Newcomer", Followers: 1}, "Newcomer · 1 follower"},
+		{spotify.Item{Type: "episode", Name: "178: Ubiquiti", Show: "Darknet Diaries", DurationMS: 2429088}, "178: Ubiquiti — Darknet Diaries · 40m29s"},
+	}
+	for _, test := range tests {
+		if got := itemHuman(ctx.Output, test.item); got != test.want {
+			t.Fatalf("item=%#v line=%q want=%q", test.item, got, test.want)
+		}
+	}
+}
+
+func TestPlaybackHumanOmitsUnknownFields(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatHuman)
+	if got := playbackHuman(ctx.Output, spotify.PlaybackStatus{}); got != "PAUSED" {
+		t.Fatalf("playback=%q", got)
+	}
+	if got := playbackHuman(ctx.Output, spotify.PlaybackStatus{IsPlaying: true, Item: &spotify.Item{Name: "Song"}}); got != "PLAYING Song" {
+		t.Fatalf("playback=%q", got)
+	}
+}
+
+func TestItemPlainPreservesUnknownFieldPositions(t *testing.T) {
+	tests := []struct {
+		item spotify.Item
+		want string
+	}{
+		{spotify.Item{ID: "a1", Type: "album", Name: "Album"}, "album\ta1\tAlbum\t\t\t0"},
+		{spotify.Item{ID: "ar1", Type: "artist", Name: "Artist"}, "artist\tar1\tArtist\t0"},
+		{spotify.Item{ID: "p1", Type: "playlist", Name: "Playlist"}, "playlist\tp1\tPlaylist\t\t0"},
+		{spotify.Item{ID: "s1", Type: "show", Name: "Show"}, "show\ts1\tShow\t\t0"},
+		{spotify.Item{ID: "e1", Type: "episode", Name: "Episode"}, "episode\te1\tEpisode\t0"},
+	}
+	for _, test := range tests {
+		if got := itemPlain(test.item); got != test.want {
+			t.Fatalf("item=%#v line=%q want=%q", test.item, got, test.want)
+		}
+	}
+}
+
+func TestFormatThousands(t *testing.T) {
+	for value, want := range map[int]string{0: "0", 999: "999", 1000: "1,000", 5567807: "5,567,807"} {
+		if got := formatThousands(value); got != want {
+			t.Fatalf("formatThousands(%d)=%q want=%q", value, got, want)
+		}
+	}
+}

--- a/internal/spotify/auto.go
+++ b/internal/spotify/auto.go
@@ -9,10 +9,15 @@ import (
 type autoClient struct {
 	primary   API
 	secondary API
+	local     API
 }
 
-func NewAutoClient(connect API, web API) API {
-	return &autoClient{primary: connect, secondary: web}
+func NewAutoClient(connect API, web API, local ...API) API {
+	client := &autoClient{primary: connect, secondary: web}
+	if len(local) > 0 {
+		client.local = local[0]
+	}
+	return client
 }
 
 func (c *autoClient) shouldFallback(err error) bool {
@@ -28,7 +33,8 @@ func autoCall[T any](c *autoClient, fn func(API) (T, error)) (T, error) {
 	if err == nil || c.secondary == nil || !c.shouldFallback(err) {
 		return res, err
 	}
-	return fn(c.secondary)
+	fallback, fallbackErr := fn(c.secondary)
+	return fallback, preserveRateLimitHint(err, fallbackErr)
 }
 
 func autoVoid(c *autoClient, fn func(API) error) error {
@@ -36,7 +42,7 @@ func autoVoid(c *autoClient, fn func(API) error) error {
 	if err == nil || c.secondary == nil || !c.shouldFallback(err) {
 		return err
 	}
-	return fn(c.secondary)
+	return preserveRateLimitHint(err, fn(c.secondary))
 }
 
 func autoCall2[A, B any](c *autoClient, fn func(API) (A, B, error)) (A, B, error) {
@@ -44,7 +50,8 @@ func autoCall2[A, B any](c *autoClient, fn func(API) (A, B, error)) (A, B, error
 	if err == nil || c.secondary == nil || !c.shouldFallback(err) {
 		return a, b, err
 	}
-	return fn(c.secondary)
+	a, b, fallbackErr := fn(c.secondary)
+	return a, b, preserveRateLimitHint(err, fallbackErr)
 }
 
 func autoCall3[A, B, C any](c *autoClient, fn func(API) (A, B, C, error)) (A, B, C, error) {
@@ -52,7 +59,46 @@ func autoCall3[A, B, C any](c *autoClient, fn func(API) (A, B, C, error)) (A, B,
 	if err == nil || c.secondary == nil || !c.shouldFallback(err) {
 		return a, b, cval, err
 	}
-	return fn(c.secondary)
+	a, b, cval, fallbackErr := fn(c.secondary)
+	return a, b, cval, preserveRateLimitHint(err, fallbackErr)
+}
+
+func autoPlaybackCall[T any](c *autoClient, fn func(API) (T, error)) (T, error) {
+	result, err := fn(c.primary)
+	if err == nil {
+		return result, nil
+	}
+	if c.secondary != nil && (c.local != nil || c.shouldFallback(err)) {
+		fallback, fallbackErr := fn(c.secondary)
+		if fallbackErr == nil {
+			return fallback, nil
+		}
+		result = fallback
+		err = preserveRateLimitHint(err, fallbackErr)
+	}
+	if c.local == nil {
+		return result, err
+	}
+	local, localErr := fn(c.local)
+	return local, preserveRateLimitHint(err, localErr)
+}
+
+func autoPlaybackVoid(c *autoClient, fn func(API) error) error {
+	err := fn(c.primary)
+	if err == nil {
+		return nil
+	}
+	if c.secondary != nil && (c.local != nil || c.shouldFallback(err)) {
+		fallbackErr := fn(c.secondary)
+		if fallbackErr == nil {
+			return nil
+		}
+		err = preserveRateLimitHint(err, fallbackErr)
+	}
+	if c.local == nil {
+		return err
+	}
+	return preserveRateLimitHint(err, fn(c.local))
 }
 
 func (c *autoClient) Search(ctx context.Context, kind, query string, limit, offset int) (SearchResult, error) {
@@ -111,55 +157,55 @@ func (c *autoClient) GetEpisode(ctx context.Context, id string) (Item, error) {
 }
 
 func (c *autoClient) Playback(ctx context.Context) (PlaybackStatus, error) {
-	return autoCall(c, func(api API) (PlaybackStatus, error) {
+	return autoPlaybackCall(c, func(api API) (PlaybackStatus, error) {
 		return api.Playback(ctx)
 	})
 }
 
 func (c *autoClient) Play(ctx context.Context, uri string) error {
-	return autoVoid(c, func(api API) error {
+	return autoPlaybackVoid(c, func(api API) error {
 		return api.Play(ctx, uri)
 	})
 }
 
 func (c *autoClient) Pause(ctx context.Context) error {
-	return autoVoid(c, func(api API) error {
+	return autoPlaybackVoid(c, func(api API) error {
 		return api.Pause(ctx)
 	})
 }
 
 func (c *autoClient) Next(ctx context.Context) error {
-	return autoVoid(c, func(api API) error {
+	return autoPlaybackVoid(c, func(api API) error {
 		return api.Next(ctx)
 	})
 }
 
 func (c *autoClient) Previous(ctx context.Context) error {
-	return autoVoid(c, func(api API) error {
+	return autoPlaybackVoid(c, func(api API) error {
 		return api.Previous(ctx)
 	})
 }
 
 func (c *autoClient) Seek(ctx context.Context, positionMS int) error {
-	return autoVoid(c, func(api API) error {
+	return autoPlaybackVoid(c, func(api API) error {
 		return api.Seek(ctx, positionMS)
 	})
 }
 
 func (c *autoClient) Volume(ctx context.Context, volume int) error {
-	return autoVoid(c, func(api API) error {
+	return autoPlaybackVoid(c, func(api API) error {
 		return api.Volume(ctx, volume)
 	})
 }
 
 func (c *autoClient) Shuffle(ctx context.Context, enabled bool) error {
-	return autoVoid(c, func(api API) error {
+	return autoPlaybackVoid(c, func(api API) error {
 		return api.Shuffle(ctx, enabled)
 	})
 }
 
 func (c *autoClient) Repeat(ctx context.Context, mode string) error {
-	return autoVoid(c, func(api API) error {
+	return autoPlaybackVoid(c, func(api API) error {
 		return api.Repeat(ctx, mode)
 	})
 }

--- a/internal/spotify/auto_test.go
+++ b/internal/spotify/auto_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
+
+	"github.com/steipete/spogo/internal/cookies"
 )
 
 func TestAutoFallbackOnUnsupported(t *testing.T) {
@@ -127,6 +130,104 @@ func TestAutoNoFallbackOnGenericError(t *testing.T) {
 	}
 	if calls["Playback"] != 1 {
 		t.Fatalf("expected no fallback, got %d", calls["Playback"])
+	}
+}
+
+func TestAutoPlaybackFallsBackToLocalAfterBothRemoteEnginesFail(t *testing.T) {
+	connectCalls := map[string]int{}
+	webCalls := map[string]int{}
+	localCalls := map[string]int{}
+	connect := apiStub{calls: connectCalls, playbackFn: func(context.Context) (PlaybackStatus, error) {
+		return PlaybackStatus{}, cookies.ErrNoCookies
+	}}
+	web := apiStub{calls: webCalls, playbackFn: func(context.Context) (PlaybackStatus, error) {
+		return PlaybackStatus{}, cookies.ErrNoCookies
+	}}
+	local := apiStub{calls: localCalls, playbackFn: func(context.Context) (PlaybackStatus, error) {
+		return PlaybackStatus{IsPlaying: true, Device: Device{Name: "Local Spotify"}}, nil
+	}}
+	client := NewAutoClient(connect, web, local)
+	playback, err := client.Playback(context.Background())
+	if err != nil || !playback.IsPlaying || playback.Device.Name != "Local Spotify" {
+		t.Fatalf("playback=%#v err=%v", playback, err)
+	}
+	if connectCalls["Playback"] != 1 || webCalls["Playback"] != 1 || localCalls["Playback"] != 1 {
+		t.Fatalf("fallback order connect=%#v web=%#v local=%#v", connectCalls, webCalls, localCalls)
+	}
+}
+
+func TestAutoPlaybackControlFallsBackToLocalAfterRateLimits(t *testing.T) {
+	connectCalls := map[string]int{}
+	webCalls := map[string]int{}
+	localCalls := map[string]int{}
+	remoteError := APIError{Status: 429, RetryAfter: 24 * time.Hour}
+	connect := apiStub{calls: connectCalls, pauseFn: func(context.Context) error { return remoteError }}
+	web := apiStub{calls: webCalls, pauseFn: func(context.Context) error { return remoteError }}
+	local := apiStub{calls: localCalls, pauseFn: func(context.Context) error { return nil }}
+	if err := NewAutoClient(connect, web, local).Pause(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if connectCalls["Pause"] != 1 || webCalls["Pause"] != 1 || localCalls["Pause"] != 1 {
+		t.Fatalf("fallback order connect=%#v web=%#v local=%#v", connectCalls, webCalls, localCalls)
+	}
+}
+
+func TestAutoUsesLocalOnlyForPlaybackCommands(t *testing.T) {
+	localCalls := map[string]int{}
+	connect := apiStub{
+		searchFn: func(context.Context, string, string, int, int) (SearchResult, error) {
+			return SearchResult{}, ErrUnsupported
+		},
+		libraryTracksFn: func(context.Context, int, int) ([]Item, int, error) {
+			return nil, 0, ErrUnsupported
+		},
+	}
+	web := apiStub{
+		searchFn: func(context.Context, string, string, int, int) (SearchResult, error) {
+			return SearchResult{}, errors.New("web unavailable")
+		},
+		libraryTracksFn: func(context.Context, int, int) ([]Item, int, error) {
+			return nil, 0, errors.New("web unavailable")
+		},
+	}
+	local := apiStub{calls: localCalls}
+	client := NewAutoClient(connect, web, local)
+	if _, err := client.Search(context.Background(), "track", "weezer", 1, 0); err == nil {
+		t.Fatal("expected remote search failure")
+	}
+	if _, _, err := client.LibraryTracks(context.Background(), 1, 0); err == nil {
+		t.Fatal("expected remote library failure")
+	}
+	if len(localCalls) != 0 {
+		t.Fatalf("unsupported commands reached local Spotify: %#v", localCalls)
+	}
+}
+
+func TestAutoSkipsLocalWhenRemotePlaybackSucceeds(t *testing.T) {
+	localCalls := map[string]int{}
+	client := NewAutoClient(apiStub{playbackFn: func(context.Context) (PlaybackStatus, error) {
+		return PlaybackStatus{IsPlaying: true}, nil
+	}}, apiStub{}, apiStub{calls: localCalls})
+	if _, err := client.Playback(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(localCalls) != 0 {
+		t.Fatalf("local Spotify used before remote failure: %#v", localCalls)
+	}
+}
+
+func TestAutoPreservesRateLimitHintWhenFallbackFails(t *testing.T) {
+	primary := APIError{Status: 429, Message: "rate limit", RetryAfter: 24 * time.Hour}
+	connect := apiStub{searchFn: func(context.Context, string, string, int, int) (SearchResult, error) {
+		return SearchResult{}, primary
+	}}
+	web := apiStub{searchFn: func(context.Context, string, string, int, int) (SearchResult, error) {
+		return SearchResult{}, errors.New("secondary unavailable")
+	}}
+	_, err := NewAutoClient(connect, web).Search(context.Background(), "track", "weezer", 1, 0)
+	var apiErr APIError
+	if !errors.As(err, &apiErr) || apiErr.RetryAfter != 24*time.Hour {
+		t.Fatalf("expected actionable retry hint, got %v", err)
 	}
 }
 

--- a/internal/spotify/connect.go
+++ b/internal/spotify/connect.go
@@ -46,7 +46,7 @@ func NewConnectClient(opts ConnectOptions) (*ConnectClient, error) {
 	}
 	timeout := opts.Timeout
 	if timeout == 0 {
-		timeout = 10 * time.Second
+		timeout = defaultHTTPClientTimeout
 	}
 	httpClient := &http.Client{Timeout: timeout}
 	cache := newConnectCacheStore(opts.CachePath)
@@ -176,6 +176,10 @@ func (c *ConnectClient) FollowArtists(ctx context.Context, ids []string, method 
 }
 
 func (c *ConnectClient) FollowedArtists(ctx context.Context, limit int, after string) ([]Item, int, string, error) {
+	items, total, next, err := c.followedArtists(ctx, limit, after)
+	if err == nil {
+		return items, total, next, nil
+	}
 	return withWebCursorFallback(c, func(web *Client) ([]Item, int, string, error) {
 		return web.FollowedArtists(ctx, limit, after)
 	})
@@ -242,7 +246,8 @@ func withWebCollectionFallback(c *ConnectClient, primary func() ([]Item, int, er
 	if werr != nil {
 		return nil, 0, err
 	}
-	return fallback(web)
+	fallbackItems, fallbackTotal, fallbackErr := fallback(web)
+	return fallbackItems, fallbackTotal, preserveRateLimitHint(err, fallbackErr)
 }
 
 func withWebCursorFallback(c *ConnectClient, fallback func(*Client) ([]Item, int, string, error)) ([]Item, int, string, error) {

--- a/internal/spotify/connect_extract_items.go
+++ b/internal/spotify/connect_extract_items.go
@@ -2,6 +2,7 @@ package spotify
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -32,6 +33,15 @@ func extractItem(value any, kind string) (Item, bool) {
 	if !ok {
 		return Item{}, false
 	}
+	if data, ok := m["data"].(map[string]any); ok {
+		if uri := getString(m, "_uri"); uri != "" && getString(data, "uri") == "" {
+			data = copyEntityWithURI(data, uri)
+		}
+		m = data
+	}
+	if wrapped, ok := getMap(m, "item", "data"); ok {
+		m = wrapped
+	}
 	if kind == "track" {
 		if inner, ok := m["track"].(map[string]any); ok {
 			m = inner
@@ -59,6 +69,11 @@ func extractItem(value any, kind string) (Item, bool) {
 		name = getString(m, "title")
 	}
 	if name == "" {
+		if profile, ok := getMap(m, "profile"); ok {
+			name = getString(profile, "name")
+		}
+	}
+	if name == "" {
 		name = findFirstName(m)
 	}
 	item := Item{
@@ -76,6 +91,9 @@ func extractItem(value any, kind string) (Item, bool) {
 		if album := extractAlbumName(m); album != "" {
 			item.Album = album
 		}
+	}
+	if item.Type == "episode" {
+		item.Show = extractShowName(m)
 	}
 	if _, ok := m["explicit"]; ok {
 		item.Explicit = getBool(m, "explicit")
@@ -99,19 +117,80 @@ func extractItem(value any, kind string) (Item, bool) {
 		item.DurationMS = getNestedInt(m, "trackDuration", "totalMilliseconds")
 	}
 	item.Owner = extractOwnerName(m)
-	item.TotalTracks = getInt(m, "totalTracks")
-	if item.TotalTracks == 0 {
-		item.TotalTracks = getInt(m, "total")
-	}
-	item.ReleaseDate = getString(m, "releaseDate")
+	item.TotalTracks = firstPositiveInt(
+		getInt(m, "totalTracks"),
+		getInt(m, "total_tracks"),
+		getNestedInt(m, "tracks", "totalCount"),
+		getNestedInt(m, "tracks", "total"),
+		getNestedInt(m, "tracksV2", "totalCount"),
+		getNestedInt(m, "content", "totalCount"),
+		getInt(m, "total"),
+	)
+	item.ReleaseDate = extractReleaseDate(m)
 	item.Description = getString(m, "description")
 	item.IsPlayable = getBool(m, "isPlayable")
 	if !item.IsPlayable {
 		item.IsPlayable = getNestedBool(m, "playability", "playable")
 	}
 	item.Publisher = getString(m, "publisher")
-	item.TotalEpisodes = getInt(m, "totalEpisodes")
+	if item.Publisher == "" {
+		if publisher, ok := getMap(m, "publisher"); ok {
+			item.Publisher = getString(publisher, "name")
+		}
+	}
+	item.TotalEpisodes = firstPositiveInt(
+		getInt(m, "totalEpisodes"),
+		getInt(m, "total_episodes"),
+		getNestedInt(m, "episodes", "totalCount"),
+		getNestedInt(m, "episodesV2", "totalCount"),
+	)
+	item.Followers = firstPositiveInt(
+		getInt(m, "followers"),
+		getNestedInt(m, "stats", "followers"),
+		getNestedInt(m, "followers", "total"),
+	)
 	return item, true
+}
+
+func copyEntityWithURI(entity map[string]any, uri string) map[string]any {
+	copy := make(map[string]any, len(entity)+1)
+	for key, value := range entity {
+		copy[key] = value
+	}
+	copy["uri"] = uri
+	return copy
+}
+
+func firstPositiveInt(values ...int) int {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
+}
+
+func extractReleaseDate(entity map[string]any) string {
+	if date := getString(entity, "release_date"); date != "" {
+		return date
+	}
+	if date := getString(entity, "releaseDate"); date != "" {
+		return date
+	}
+	for _, key := range []string{"releaseDate", "date"} {
+		date, ok := getMap(entity, key)
+		if !ok {
+			continue
+		}
+		if value := getString(date, "isoString"); value != "" {
+			value, _, _ = strings.Cut(value, "T")
+			return value
+		}
+		if year := getInt(date, "year"); year > 0 {
+			return strconv.Itoa(year)
+		}
+	}
+	return ""
 }
 
 func idFromURI(uri string) string {

--- a/internal/spotify/connect_extract_metadata.go
+++ b/internal/spotify/connect_extract_metadata.go
@@ -137,6 +137,18 @@ func extractAlbumName(value any) string {
 }
 
 func extractOwnerName(value any) string {
+	if entity, ok := value.(map[string]any); ok {
+		for _, path := range [][]string{{"ownerV2", "data"}, {"owner"}, {"user", "data"}, {"user"}} {
+			if owner, ok := getMap(entity, path...); ok {
+				if name := getString(owner, "name"); name != "" {
+					return name
+				}
+				if name := getString(owner, "display_name"); name != "" {
+					return name
+				}
+			}
+		}
+	}
 	var owner string
 	walkMap(value, func(m map[string]any) {
 		if owner != "" {
@@ -154,6 +166,17 @@ func extractOwnerName(value any) string {
 		}
 	})
 	return owner
+}
+
+func extractShowName(entity map[string]any) string {
+	for _, path := range [][]string{{"podcastV2", "data"}, {"podcast", "data"}, {"podcast"}, {"show"}} {
+		if show, ok := getMap(entity, path...); ok {
+			if name := getString(show, "name"); name != "" {
+				return name
+			}
+		}
+	}
+	return ""
 }
 
 func walkMap(value any, fn func(map[string]any)) {

--- a/internal/spotify/connect_extract_search.go
+++ b/internal/spotify/connect_extract_search.go
@@ -91,10 +91,6 @@ func extractRequestedEntity(entity map[string]any, kind, requestedURI string) (I
 		return Item{}, false
 	}
 	if kind == "artist" {
-		item.Followers = getNestedInt(entity, "stats", "followers")
-		if item.Followers == 0 {
-			item.Followers = getNestedInt(entity, "followers", "total")
-		}
 		item.Genres = extractEntityGenres(entity)
 	}
 	return item, true

--- a/internal/spotify/connect_info.go
+++ b/internal/spotify/connect_info.go
@@ -52,12 +52,25 @@ func (c *ConnectClient) playlistInfo(ctx context.Context, id string) (Item, erro
 
 func (c *ConnectClient) showInfo(ctx context.Context, id string) (Item, error) {
 	return c.infoWithWebFallback(ctx, id, "show", func() (Item, error) {
-		return c.infoByOperation(ctx, "queryPodcastEpisodes", map[string]any{
+		item, err := c.infoByOperation(ctx, "queryPodcastEpisodes", map[string]any{
 			"uri":                            "spotify:show:" + id,
 			"offset":                         0,
 			"limit":                          25,
 			"includeEpisodeContentRatingsV2": false,
 		}, "show")
+		if err != nil || item.Publisher != "" || item.Name == "" {
+			return item, err
+		}
+		if payload, searchErr := c.graphQL(ctx, "searchDesktop", searchVariables(item.Name, 10, 0)); searchErr == nil {
+			matches, _ := extractSearchItems(payload, "show")
+			for _, match := range matches {
+				if match.URI == item.URI {
+					item.Publisher = match.Publisher
+					break
+				}
+			}
+		}
+		return item, nil
 	}, func(web *Client) (Item, error) {
 		return web.GetShow(ctx, id)
 	})
@@ -103,5 +116,6 @@ func (c *ConnectClient) infoWithWebFallback(ctx context.Context, id, kind string
 	if werr != nil {
 		return Item{}, err
 	}
-	return webLookup(web)
+	fallback, fallbackErr := webLookup(web)
+	return fallback, preserveRateLimitHint(err, fallbackErr)
 }

--- a/internal/spotify/connect_library.go
+++ b/internal/spotify/connect_library.go
@@ -1,6 +1,9 @@
 package spotify
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 func (c *ConnectClient) playlists(ctx context.Context, limit, offset int) ([]Item, int, error) {
 	payload, err := c.graphQL(ctx, "libraryV3", libraryV3Variables("Playlists", normalizeLibraryLimit(limit), offset))
@@ -42,6 +45,47 @@ func (c *ConnectClient) libraryAlbums(ctx context.Context, limit, offset int) ([
 	return items, total, nil
 }
 
+func (c *ConnectClient) followedArtists(ctx context.Context, limit int, after string) ([]Item, int, string, error) {
+	limit = normalizeLibraryLimit(limit)
+	offset := 0
+	if after != "" {
+		var err error
+		offset, err = c.followedArtistOffset(ctx, after)
+		if err != nil {
+			return nil, 0, "", err
+		}
+	}
+	payload, err := c.graphQL(ctx, "libraryV3", libraryV3Variables("Artists", limit, offset))
+	if err != nil {
+		return nil, 0, "", err
+	}
+	items, total := extractLibraryV3Items(payload, "artist")
+	next := ""
+	if len(items) > 0 && offset+len(items) < total {
+		next = items[len(items)-1].ID
+	}
+	return items, total, next, nil
+}
+
+func (c *ConnectClient) followedArtistOffset(ctx context.Context, after string) (int, error) {
+	const pageSize = 50
+	for offset := 0; ; offset += pageSize {
+		payload, err := c.graphQL(ctx, "libraryV3", libraryV3Variables("Artists", pageSize, offset))
+		if err != nil {
+			return 0, err
+		}
+		items, total := extractLibraryV3Items(payload, "artist")
+		for index, item := range items {
+			if item.ID == after || item.URI == after {
+				return offset + index + 1, nil
+			}
+		}
+		if len(items) == 0 || offset+len(items) >= total {
+			return 0, fmt.Errorf("followed artist cursor %q not found", after)
+		}
+	}
+}
+
 func normalizeLibraryLimit(limit int) int {
 	if limit <= 0 {
 		return 50
@@ -61,7 +105,7 @@ func libraryV3Variables(filter string, limit, offset int) map[string]any {
 		"filters":                      []any{filter},
 		"order":                        nil,
 		"textFilter":                   "",
-		"features":                     []any{"LIKED_SONGS", "YOUR_EPISODES"},
+		"features":                     []any{},
 		"limit":                        limit,
 		"offset":                       offset,
 		"flatten":                      false,

--- a/internal/spotify/connect_output_fixtures_test.go
+++ b/internal/spotify/connect_output_fixtures_test.go
@@ -1,0 +1,206 @@
+package spotify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestExtractSearchItemsRealPathfinderShapes(t *testing.T) {
+	const fixture = `{
+		"data":{"searchV2":{
+			"albumsV2":{"totalCount":899,"items":[{"__typename":"AlbumResponseWrapper","data":{
+				"uri":"spotify:album:65sHj9PvsbyD0uugGHjueN","name":"Weezer (Teal Album)",
+				"artists":{"items":[{"uri":"spotify:artist:3jOstUTkEu2JkjvRdBA5Gu","profile":{"name":"Weezer"}}]},
+				"date":{"year":2019}
+			}}]},
+			"artists":{"totalCount":829,"items":[{"__typename":"ArtistResponseWrapper","data":{
+				"uri":"spotify:artist:3jOstUTkEu2JkjvRdBA5Gu","profile":{"name":"Weezer"}
+			}}]},
+			"playlists":{"totalCount":911,"items":[{"__typename":"PlaylistResponseWrapper","data":{
+				"uri":"spotify:playlist:0Q3ugz23LAXFg2PvXJ8hMx","name":"TRANCE 2026",
+				"ownerV2":{"data":{"name":"YOU LOVE DANCE","uri":"spotify:user:1190272463"}}
+			}}]},
+			"podcasts":{"totalCount":857,"items":[{"__typename":"PodcastResponseWrapper","data":{
+				"uri":"spotify:show:4XPl3uEEL9hvqMkoZrzbx5","name":"Darknet Diaries",
+				"publisher":{"name":"Jack Rhysider"}
+			}}]},
+			"episodes":{"totalCount":1000,"items":[{"__typename":"EpisodeResponseWrapper","data":{
+				"uri":"spotify:episode:6CQAC1k7sUVk8FQsXABlRU","name":"178: Ubiquiti",
+				"duration":{"totalMilliseconds":2429088},"releaseDate":{"isoString":"2026-08-04T07:00:00Z"},
+				"podcastV2":{"data":{"name":"Darknet Diaries","uri":"spotify:show:4XPl3uEEL9hvqMkoZrzbx5"}}
+			}}]}
+		}}
+	}`
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(fixture), &payload); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		kind  string
+		total int
+		check func(*testing.T, Item)
+	}{
+		{"album", 899, func(t *testing.T, item Item) {
+			if item.Name != "Weezer (Teal Album)" || !reflect.DeepEqual(item.Artists, []string{"Weezer"}) || item.ReleaseDate != "2019" {
+				t.Fatalf("album metadata: %#v", item)
+			}
+		}},
+		{"artist", 829, func(t *testing.T, item Item) {
+			if item.Name != "Weezer" || item.ID != "3jOstUTkEu2JkjvRdBA5Gu" {
+				t.Fatalf("artist metadata: %#v", item)
+			}
+		}},
+		{"playlist", 911, func(t *testing.T, item Item) {
+			if item.Name != "TRANCE 2026" || item.Owner != "YOU LOVE DANCE" {
+				t.Fatalf("playlist metadata: %#v", item)
+			}
+		}},
+		{"show", 857, func(t *testing.T, item Item) {
+			if item.Name != "Darknet Diaries" || item.Publisher != "Jack Rhysider" {
+				t.Fatalf("show metadata: %#v", item)
+			}
+		}},
+		{"episode", 1000, func(t *testing.T, item Item) {
+			if item.Name != "178: Ubiquiti" || item.Show != "Darknet Diaries" || item.DurationMS != 2429088 || item.ReleaseDate != "2026-08-04" {
+				t.Fatalf("episode metadata: %#v", item)
+			}
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.kind, func(t *testing.T) {
+			items, total := extractSearchItems(payload, test.kind)
+			if total != test.total || len(items) != 1 {
+				t.Fatalf("items=%#v total=%d", items, total)
+			}
+			test.check(t, items[0])
+		})
+	}
+}
+
+func TestExtractItemRealInfoMetadata(t *testing.T) {
+	tests := []struct {
+		name  string
+		kind  string
+		raw   string
+		check func(*testing.T, Item)
+	}{
+		{"album", "album", `{"uri":"spotify:album:a1","name":"Parachutes","date":{"isoString":"2000-07-10T00:00:00Z"},"tracksV2":{"totalCount":10}}`, func(t *testing.T, item Item) {
+			if item.ReleaseDate != "2000-07-10" || item.TotalTracks != 10 {
+				t.Fatalf("album: %#v", item)
+			}
+		}},
+		{"artist", "artist", `{"uri":"spotify:artist:a1","profile":{"name":"Weezer"},"stats":{"followers":5567807}}`, func(t *testing.T, item Item) {
+			if item.Name != "Weezer" || item.Followers != 5567807 {
+				t.Fatalf("artist: %#v", item)
+			}
+		}},
+		{"playlist", "playlist", `{"uri":"spotify:playlist:p1","name":"TRANCE 2026","ownerV2":{"data":{"name":"YOU LOVE DANCE"}},"content":{"totalCount":197},"followers":352874}`, func(t *testing.T, item Item) {
+			if item.Owner != "YOU LOVE DANCE" || item.TotalTracks != 197 || item.Followers != 352874 {
+				t.Fatalf("playlist: %#v", item)
+			}
+		}},
+		{"show", "show", `{"uri":"spotify:show:s1","name":"Darknet Diaries","episodesV2":{"totalCount":227}}`, func(t *testing.T, item Item) {
+			if item.TotalEpisodes != 227 {
+				t.Fatalf("show: %#v", item)
+			}
+		}},
+		{"wrapped URI", "artist", `{"_uri":"spotify:artist:a1","data":{"profile":{"name":"Artist"}}}`, func(t *testing.T, item Item) {
+			if item.URI != "spotify:artist:a1" || item.Name != "Artist" {
+				t.Fatalf("wrapped artist: %#v", item)
+			}
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var raw map[string]any
+			if err := json.Unmarshal([]byte(test.raw), &raw); err != nil {
+				t.Fatal(err)
+			}
+			item, ok := extractItem(raw, test.kind)
+			if !ok {
+				t.Fatalf("item not extracted: %#v", raw)
+			}
+			test.check(t, item)
+		})
+	}
+}
+
+func TestConnectSearchHydratesArtistFollowersWithoutWebAPI(t *testing.T) {
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Query().Get("operationName") {
+		case "searchDesktop":
+			return jsonResponse(http.StatusOK, map[string]any{"data": map[string]any{"searchV2": map[string]any{"artists": map[string]any{
+				"totalCount": 1, "items": []any{map[string]any{"data": map[string]any{"uri": "spotify:artist:a1", "profile": map[string]any{"name": "Weezer"}}}},
+			}}}}), nil
+		case "queryArtistOverview":
+			return jsonResponse(http.StatusOK, map[string]any{"data": map[string]any{"artistUnion": map[string]any{
+				"uri": "spotify:artist:a1", "profile": map[string]any{"name": "Weezer"}, "stats": map[string]any{"followers": 5567807},
+			}}}), nil
+		default:
+			return nil, fmt.Errorf("unexpected operation or public API request: %s", req.URL)
+		}
+	})
+	client := newConnectClientForTests(transport)
+	client.hashes.hashes["searchDesktop"] = "hash"
+	client.hashes.hashes["queryArtistOverview"] = "hash"
+	result, err := client.Search(context.Background(), "artist", "weezer", 1, 0)
+	if err != nil || len(result.Items) != 1 || result.Items[0].Followers != 5567807 {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+}
+
+func TestConnectSearchHydratesPlaylistAndShowCounts(t *testing.T) {
+	tests := []struct {
+		kind      string
+		container string
+		operation string
+		key       string
+		entity    map[string]any
+		check     func(Item) bool
+	}{
+		{"playlist", "playlists", "fetchPlaylist", "playlistV2", map[string]any{"uri": "spotify:playlist:p1", "name": "List", "ownerV2": map[string]any{"data": map[string]any{"name": "Owner"}}, "content": map[string]any{"totalCount": 197}}, func(item Item) bool { return item.TotalTracks == 197 && item.Owner == "Owner" }},
+		{"show", "podcasts", "queryPodcastEpisodes", "podcastUnionV2", map[string]any{"uri": "spotify:show:s1", "name": "Show", "episodesV2": map[string]any{"totalCount": 227}}, func(item Item) bool { return item.TotalEpisodes == 227 && item.Publisher == "Publisher" }},
+		{"album", "albumsV2", "getAlbum", "albumUnion", map[string]any{"uri": "spotify:album:a1", "name": "Album", "tracksV2": map[string]any{"totalCount": 10}, "date": map[string]any{"isoString": "2000-07-10T00:00:00Z"}}, func(item Item) bool { return item.TotalTracks == 10 && item.ReleaseDate == "2000-07-10" }},
+	}
+	for _, test := range tests {
+		t.Run(test.kind, func(t *testing.T) {
+			transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				switch req.URL.Query().Get("operationName") {
+				case "searchDesktop":
+					entity := map[string]any{"uri": test.entity["uri"], "name": test.entity["name"]}
+					if test.kind == "show" {
+						entity["publisher"] = map[string]any{"name": "Publisher"}
+					}
+					return jsonResponse(http.StatusOK, map[string]any{"data": map[string]any{"searchV2": map[string]any{test.container: map[string]any{
+						"totalCount": 1, "items": []any{map[string]any{"data": entity}},
+					}}}}), nil
+				case test.operation:
+					return jsonResponse(http.StatusOK, map[string]any{"data": map[string]any{test.key: test.entity}}), nil
+				default:
+					return nil, fmt.Errorf("unexpected operation %q", req.URL.Query().Get("operationName"))
+				}
+			})
+			client := newConnectClientForTests(transport)
+			client.hashes.hashes["searchDesktop"] = "hash"
+			client.hashes.hashes[test.operation] = "hash"
+			result, err := client.Search(context.Background(), test.kind, "query", 1, 0)
+			if err != nil || len(result.Items) != 1 || !test.check(result.Items[0]) {
+				t.Fatalf("result=%#v err=%v", result, err)
+			}
+		})
+	}
+}
+
+func TestConnectClientUsesSharedDefaultTimeout(t *testing.T) {
+	client, err := NewConnectClient(ConnectOptions{Source: cookieSourceStub{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.client.Timeout != defaultHTTPClientTimeout {
+		t.Fatalf("timeout=%s want=%s", client.client.Timeout, defaultHTTPClientTimeout)
+	}
+}

--- a/internal/spotify/connect_pathfinder_info_test.go
+++ b/internal/spotify/connect_pathfinder_info_test.go
@@ -15,6 +15,13 @@ func TestConnectLibraryV3Helpers(t *testing.T) {
 		case "libraryV3":
 			query := req.URL.Query()
 			variables := query.Get("variables")
+			var decoded map[string]any
+			if err := json.Unmarshal([]byte(variables), &decoded); err != nil {
+				t.Fatalf("unmarshal libraryV3 variables: %v", err)
+			}
+			if features, ok := decoded["features"].([]any); !ok || len(features) != 0 {
+				t.Fatalf("libraryV3 must not request pseudo-playlists: %#v", decoded["features"])
+			}
 			switch {
 			case strings.Contains(variables, `"Playlists"`):
 				return jsonResponse(http.StatusOK, map[string]any{
@@ -35,6 +42,15 @@ func TestConnectLibraryV3Helpers(t *testing.T) {
 						"items": []any{map[string]any{"item": map[string]any{"data": map[string]any{
 							"uri":  "spotify:album:a1",
 							"name": "Album",
+						}}}},
+					}}},
+				}), nil
+			case strings.Contains(variables, `"Artists"`):
+				return jsonResponse(http.StatusOK, map[string]any{
+					"data": map[string]any{"me": map[string]any{"libraryV3": map[string]any{
+						"totalCount": 2,
+						"items": []any{map[string]any{"item": map[string]any{"data": map[string]any{
+							"uri": "spotify:artist:ar1", "profile": map[string]any{"name": "Artist"},
 						}}}},
 					}}},
 				}), nil
@@ -96,6 +112,53 @@ func TestConnectLibraryV3Helpers(t *testing.T) {
 	albums, total, err := client.libraryAlbums(context.Background(), 10, 0)
 	if err != nil || total != 1 || len(albums) != 1 || albums[0].ID != "a1" {
 		t.Fatalf("library albums: items=%#v total=%d err=%v", albums, total, err)
+	}
+	artists, total, next, err := client.FollowedArtists(context.Background(), 1, "")
+	if err != nil || total != 2 || len(artists) != 1 || artists[0].Name != "Artist" || next != "ar1" {
+		t.Fatalf("followed artists: items=%#v total=%d next=%q err=%v", artists, total, next, err)
+	}
+}
+
+func TestConnectFollowedArtistsCursorUsesLibraryV3(t *testing.T) {
+	requests := 0
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.URL.Query().Get("operationName") != "libraryV3" {
+			t.Fatalf("unexpected request %s", req.URL)
+		}
+		var vars map[string]any
+		if err := json.Unmarshal([]byte(req.URL.Query().Get("variables")), &vars); err != nil {
+			t.Fatal(err)
+		}
+		artists := []any{
+			map[string]any{"item": map[string]any{"data": map[string]any{"uri": "spotify:artist:a1", "profile": map[string]any{"name": "First"}}}},
+			map[string]any{"item": map[string]any{"data": map[string]any{"uri": "spotify:artist:a2", "profile": map[string]any{"name": "Second"}}}},
+			map[string]any{"item": map[string]any{"data": map[string]any{"uri": "spotify:artist:a3", "profile": map[string]any{"name": "Third"}}}},
+		}
+		offset := getInt(vars, "offset")
+		end := min(offset+getInt(vars, "limit"), len(artists))
+		return jsonResponse(http.StatusOK, map[string]any{"data": map[string]any{"me": map[string]any{"libraryV3": map[string]any{
+			"totalCount": len(artists), "items": artists[offset:end],
+		}}}}), nil
+	})
+	client := newConnectClientForTests(transport)
+	client.hashes.hashes["libraryV3"] = "hash"
+	items, total, next, err := client.FollowedArtists(context.Background(), 1, "a1")
+	if err != nil || total != 3 || len(items) != 1 || items[0].ID != "a2" || next != "a2" || requests != 2 {
+		t.Fatalf("items=%#v total=%d next=%q requests=%d err=%v", items, total, next, requests, err)
+	}
+}
+
+func TestConnectFollowedArtistCursorMissing(t *testing.T) {
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusOK, map[string]any{"data": map[string]any{"me": map[string]any{"libraryV3": map[string]any{
+			"totalCount": 1, "items": []any{map[string]any{"item": map[string]any{"data": map[string]any{"uri": "spotify:artist:a1", "profile": map[string]any{"name": "First"}}}}},
+		}}}}), nil
+	})
+	client := newConnectClientForTests(transport)
+	client.hashes.hashes["libraryV3"] = "hash"
+	if _, err := client.followedArtistOffset(context.Background(), "missing"); err == nil {
+		t.Fatal("expected missing cursor error")
 	}
 }
 

--- a/internal/spotify/connect_search.go
+++ b/internal/spotify/connect_search.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 )
+
+const searchMetadataConcurrency = 6
 
 func (c *ConnectClient) search(ctx context.Context, kind, query string, limit, offset int) (SearchResult, error) {
 	if strings.TrimSpace(query) == "" {
@@ -18,10 +21,88 @@ func (c *ConnectClient) search(ctx context.Context, kind, query string, limit, o
 		if ferr == nil {
 			return fallback, nil
 		}
-		return SearchResult{}, ferr
+		return SearchResult{}, preserveRateLimitHint(err, ferr)
 	}
 	items, total := extractSearchItems(payload, kind)
+	c.hydrateSearchItems(ctx, kind, items)
 	return SearchResult{Type: kind, Limit: limit, Offset: offset, Total: total, Items: items}, nil
+}
+
+func (c *ConnectClient) hydrateSearchItems(ctx context.Context, kind string, items []Item) {
+	if kind != "album" && kind != "artist" && kind != "playlist" && kind != "show" {
+		return
+	}
+	jobs := make(chan int)
+	var workers sync.WaitGroup
+	for range min(searchMetadataConcurrency, len(items)) {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for index := range jobs {
+				if detailed, err := c.searchItemDetails(ctx, kind, items[index].ID); err == nil {
+					items[index] = mergeSearchItem(items[index], detailed)
+				}
+			}
+		}()
+	}
+	for index := range items {
+		select {
+		case jobs <- index:
+		case <-ctx.Done():
+			close(jobs)
+			workers.Wait()
+			return
+		}
+	}
+	close(jobs)
+	workers.Wait()
+}
+
+func (c *ConnectClient) searchItemDetails(ctx context.Context, kind, id string) (Item, error) {
+	uri := "spotify:" + kind + ":" + id
+	switch kind {
+	case "album":
+		return c.infoByOperation(ctx, "getAlbum", map[string]any{"uri": uri, "locale": c.language, "offset": 0, "limit": 1}, kind)
+	case "artist":
+		return c.infoByOperation(ctx, "queryArtistOverview", map[string]any{"uri": uri, "locale": c.language}, kind)
+	case "playlist":
+		return c.infoByOperation(ctx, "fetchPlaylist", map[string]any{"uri": uri, "offset": 0, "limit": 1, "enableWatchFeedEntrypoint": false}, kind)
+	case "show":
+		return c.infoByOperation(ctx, "queryPodcastEpisodes", map[string]any{"uri": uri, "offset": 0, "limit": 1, "includeEpisodeContentRatingsV2": false}, kind)
+	default:
+		return Item{}, ErrUnsupported
+	}
+}
+
+func mergeSearchItem(item, detailed Item) Item {
+	if detailed.Name != "" {
+		item.Name = detailed.Name
+	}
+	if len(detailed.Artists) > 0 {
+		item.Artists = detailed.Artists
+	}
+	if detailed.Owner != "" {
+		item.Owner = detailed.Owner
+	}
+	if detailed.ReleaseDate != "" {
+		item.ReleaseDate = detailed.ReleaseDate
+	}
+	if detailed.TotalTracks > 0 {
+		item.TotalTracks = detailed.TotalTracks
+	}
+	if detailed.TotalEpisodes > 0 {
+		item.TotalEpisodes = detailed.TotalEpisodes
+	}
+	if detailed.Followers > 0 {
+		item.Followers = detailed.Followers
+	}
+	if detailed.Publisher != "" {
+		item.Publisher = detailed.Publisher
+	}
+	if len(detailed.Genres) > 0 {
+		item.Genres = detailed.Genres
+	}
+	return item
 }
 
 func (c *ConnectClient) searchViaWeb(ctx context.Context, kind, query string, limit, offset int) (SearchResult, error) {

--- a/internal/spotify/errors.go
+++ b/internal/spotify/errors.go
@@ -88,3 +88,18 @@ func retryAfterFromResponse(resp *http.Response) time.Duration {
 	}
 	return delay
 }
+
+func preserveRateLimitHint(previous, current error) error {
+	if current == nil {
+		return nil
+	}
+	var currentAPIError APIError
+	if errors.As(current, &currentAPIError) && currentAPIError.Status == http.StatusTooManyRequests && currentAPIError.RetryAfter > 0 {
+		return current
+	}
+	var previousAPIError APIError
+	if errors.As(previous, &previousAPIError) && previousAPIError.Status == http.StatusTooManyRequests && previousAPIError.RetryAfter > 0 {
+		return previous
+	}
+	return current
+}

--- a/internal/spotify/fallback.go
+++ b/internal/spotify/fallback.go
@@ -29,7 +29,8 @@ func fallbackCall[T any](c *fallbackClient, allow bool, fn func(API) (T, error))
 	if err == nil || !allow || c.connect == nil || !c.shouldFallback(err) {
 		return res, err
 	}
-	return fn(c.connect)
+	fallback, fallbackErr := fn(c.connect)
+	return fallback, preserveRateLimitHint(err, fallbackErr)
 }
 
 func fallbackVoid(c *fallbackClient, allow bool, fn func(API) error) error {
@@ -37,7 +38,7 @@ func fallbackVoid(c *fallbackClient, allow bool, fn func(API) error) error {
 	if err == nil || !allow || c.connect == nil || !c.shouldFallback(err) {
 		return err
 	}
-	return fn(c.connect)
+	return preserveRateLimitHint(err, fn(c.connect))
 }
 
 func (c *fallbackClient) Search(ctx context.Context, kind, query string, limit, offset int) (SearchResult, error) {
@@ -56,7 +57,8 @@ func (c *fallbackClient) ArtistTopTracks(ctx context.Context, id string, limit i
 		return items, err
 	}
 	if connect, ok := c.connect.(artistTopTracksAPI); ok {
-		return connect.ArtistTopTracks(ctx, id, limit)
+		fallback, fallbackErr := connect.ArtistTopTracks(ctx, id, limit)
+		return fallback, preserveRateLimitHint(err, fallbackErr)
 	}
 	return items, err
 }

--- a/internal/spotify/fallback_test.go
+++ b/internal/spotify/fallback_test.go
@@ -2,7 +2,9 @@ package spotify
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 )
 
 type apiStub struct {
@@ -255,6 +257,20 @@ func TestFallbackPlaybackOnRateLimit(t *testing.T) {
 	}
 	if webCalls != 1 || connectCalls != 1 {
 		t.Fatalf("unexpected call counts web=%d connect=%d", webCalls, connectCalls)
+	}
+}
+
+func TestFallbackPreservesRateLimitHintWhenConnectFails(t *testing.T) {
+	web := apiStub{playbackFn: func(context.Context) (PlaybackStatus, error) {
+		return PlaybackStatus{}, APIError{Status: 429, Message: "rate limit", RetryAfter: 24 * time.Hour}
+	}}
+	connect := apiStub{playbackFn: func(context.Context) (PlaybackStatus, error) {
+		return PlaybackStatus{}, errors.New("connect unavailable")
+	}}
+	_, err := NewPlaybackFallbackClient(web, connect).Playback(context.Background())
+	var apiErr APIError
+	if !errors.As(err, &apiErr) || apiErr.RetryAfter != 24*time.Hour {
+		t.Fatalf("expected actionable retry hint, got %v", err)
 	}
 }
 

--- a/internal/spotify/types.go
+++ b/internal/spotify/types.go
@@ -10,6 +10,7 @@ type Item struct {
 	URL           string   `json:"url"`
 	Artists       []string `json:"artists,omitempty"`
 	Album         string   `json:"album,omitempty"`
+	Show          string   `json:"show,omitempty"`
 	Owner         string   `json:"owner,omitempty"`
 	DurationMS    int      `json:"duration_ms,omitempty"`
 	Explicit      bool     `json:"-"`


### PR DESCRIPTION
A full sweep of every read command against a live account found that the output layer was incomplete or wrong almost everywhere outside `search track`. This fixes all of it.

## Search returned almost no metadata for non-track kinds

`extractItem` only understood the track shape, and Spotify wraps non-track search results in a nested `data` object. Album, artist, playlist, show, and episode results all came back stripped:

| Command | Before | After |
|---|---|---|
| `search album weezer` | `Weezer —  · ` | `Weezer — Weezer · 2026-08-21` |
| `search artist weezer` | `Weezer · 0 followers` | `Weezer · 5,567,807 followers` |
| `search playlist trance` | `rave — ` | `rave — Spotify · 100 tracks` |
| `search show darknet` | `Darknet Diaries —  · 0 episodes` | `Darknet Diaries — Jack Rhysider · 227 episodes` |
| `search episode darknet` | `178: Ubiquiti · 0s` | `178: Ubiquiti — Darknet Diaries · 40m29s` |

Follower counts, playlist sizes, and episode counts are absent from search responses entirely, so those results are enriched through the internal Pathfinder operations with bounded concurrency.

## `library playlists list` printed nothing

`--json` and `--plain` returned the playlists correctly while human output was empty. Spotify was being asked to prepend "Liked Songs" and "Your Episodes", which consumed the requested limit before both were discarded as non-playlists.

## Renderer printed empty separators and fake zeros

`album info` ended in a bare `· `, `device list` left a trailing space, and unknown values rendered as `0 episodes` / `0s`, which claims a show has no episodes rather than that the count is unknown. Fields and their separators are now omitted when the value is unknown, counts are pluralized, and follower counts are formatted with thousands separators. `--plain` column positions and `--json` raw values are unchanged, since plain output is a scripting contract.

## `user history` mislabelled its range

Printed `Recently played (long_term): 3`, leaking the affinity range from the top-tracks path. Timestamps now render as `Aug 23, 2026 at 3:52 PM PDT`, with the raw value kept in `--json`.

## Rate limits: implementation and honesty

Followed artists, library playlists, top tracks, history, and episode lookup now use internal endpoints and no longer depend on the public Web API — `library artists list` previously failed outright. README claimed "**No rate limits**" while several commands reliably returned 429, once with a 24h retry hint; the docs now state exactly which operations still require the public API, and cooldown hints survive failed fallbacks.

## `auto` gains a local last resort

With Spotify.app running and cookies missing, `auto` failed even though AppleScript could answer instantly. Playback status and controls now fall back to the local app after both remote engines fail. Search, library, playlists, queues, and devices never use it, and explicit `--engine connect` / `--engine web` are unchanged.

Also fixes the `connect.go` hardcoded 10s default flagged in #51 review.

## Verification

Every command above was live-verified against a real account. `./scripts/lint.sh` 0 issues, `./scripts/check-coverage.sh 90` passes at 90.6%, `go vet ./...`, `go test ./...`, `go test -race ./internal/spotify` all clean.
