### PR TITLE
feat: show the album in spogo status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Show the album in `spogo status` human output, omitting it when it only repeats the track name
+
 ## 0.10.6 - 2026-08-23
 
 ### Fixed

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -116,7 +116,7 @@ Drive what's playing. See [Playback](playback.md).
 | `spogo volume <0-100>` | Set device volume. |
 | `spogo shuffle <on|off>` | Toggle shuffle. |
 | `spogo repeat <off|track|context>` | Set repeat mode. |
-| `spogo status` | Print currently playing item + device. |
+| `spogo status` | Print currently playing item, album, and device. |
 
 ## queue
 

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -146,7 +146,12 @@ func playbackHuman(w *output.Writer, status spotify.PlaybackStatus) string {
 	}
 	line := w.Theme.Accent(strings.ToUpper(state))
 	if status.Item != nil && status.Item.Name != "" {
-		line += " " + humanItemLine(w, status.Item.Name, strings.Join(status.Item.Artists, ", "))
+		// Singles repeat the track name as the album title, so skip the duplicate.
+		album := status.Item.Album
+		if strings.EqualFold(album, status.Item.Name) {
+			album = ""
+		}
+		line += " " + humanItemLine(w, status.Item.Name, strings.Join(status.Item.Artists, ", "), album)
 	}
 	if status.Device.Name != "" {
 		line += " " + w.Theme.Muted("· "+status.Device.Name)

--- a/internal/cli/render_test.go
+++ b/internal/cli/render_test.go
@@ -96,6 +96,50 @@ func TestPlaybackHumanOmitsUnknownFields(t *testing.T) {
 	}
 }
 
+func TestPlaybackHumanShowsAlbum(t *testing.T) {
+	ctx, _, _ := testutil.NewTestContext(t, output.FormatHuman)
+	tests := []struct {
+		name   string
+		status spotify.PlaybackStatus
+		want   string
+	}{
+		{
+			name: "album and device",
+			status: spotify.PlaybackStatus{
+				IsPlaying: true,
+				Item:      &spotify.Item{Name: "Yesterday", Artists: []string{"Gareth Emery", "NASH"}, Album: "Lasers"},
+				Device:    spotify.Device{Name: "steipete-studio-sf"},
+			},
+			want: "PLAYING Yesterday — Gareth Emery, NASH · Lasers · steipete-studio-sf",
+		},
+		{
+			name: "single repeats its own name as the album",
+			status: spotify.PlaybackStatus{
+				IsPlaying: true,
+				Item:      &spotify.Item{Name: "Yesterday", Artists: []string{"Gareth Emery"}, Album: "yesterday"},
+				Device:    spotify.Device{Name: "steipete-studio-sf"},
+			},
+			want: "PLAYING Yesterday — Gareth Emery · steipete-studio-sf",
+		},
+		{
+			name: "unknown album",
+			status: spotify.PlaybackStatus{
+				IsPlaying: true,
+				Item:      &spotify.Item{Name: "Yesterday", Artists: []string{"Gareth Emery"}},
+				Device:    spotify.Device{Name: "steipete-studio-sf"},
+			},
+			want: "PLAYING Yesterday — Gareth Emery · steipete-studio-sf",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := playbackHuman(ctx.Output, tt.status); got != tt.want {
+				t.Fatalf("playback=%q want=%q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestItemPlainPreservesUnknownFieldPositions(t *testing.T) {
 	tests := []struct {
 		item spotify.Item


### PR DESCRIPTION
`spogo status` carried the album in `--json` but never showed it in human output, so the one command people run most was the only place the album stayed hidden.

Before:

```
PLAYING Yesterday — Gareth Emery, NASH, Linney · steipete-studio-sf
```

After:

```
PLAYING Hold Me Through The Silence - Extended Mix — Steve Allen · Hold Me Through The Silence · steipete-studio-sf
```

Singles frequently repeat the track name as the album title, which would render `Yesterday · Yesterday`, so an album that matches the track name case-insensitively is omitted. The match is deliberately exact rather than prefix-based: a remix whose album drops the `- Extended Mix` suffix still shows both, which is correct, and fuzzy matching would risk hiding genuinely different albums.

`--json` and `--plain` are untouched.

## Verification

Table-driven tests cover the album, the self-titled-single duplicate, and the unknown-album case. `./scripts/lint.sh` 0 issues, `./scripts/check-coverage.sh 90` passes at 90.4%, `go vet ./...`, `go test ./...` clean, and the line above is real output from the built binary.
